### PR TITLE
enrollment summary section

### DIFF
--- a/src/components/PendingTasks.tsx
+++ b/src/components/PendingTasks.tsx
@@ -57,17 +57,17 @@ const PendingTasks = ({ isPolling = false }: PendingTasksProps) => {
         className="collapsible-trigger d-flex border-0 align-items-center text-decoration-none"
       >
         <div className="d-flex">
-          <h3>{intl.formatMessage(messages.pendingTasksTitle)}</h3>
+          <h3 className="text-primary-700">{intl.formatMessage(messages.pendingTasksTitle)}</h3>
         </div>
 
         <Collapsible.Visible whenClosed>
           <div className="pl-2 d-flex">
-            <Icon src={ExpandMore} />
+            <Icon className="text-primary-500" src={ExpandMore} />
           </div>
         </Collapsible.Visible>
         <Collapsible.Visible whenOpen>
           <div className="pl-2 d-flex">
-            <Icon src={ExpandLess} />
+            <Icon className="text-primary-500" src={ExpandLess} />
           </div>
         </Collapsible.Visible>
       </Collapsible.Trigger>

--- a/src/courseInfo/CourseInfoPage.tsx
+++ b/src/courseInfo/CourseInfoPage.tsx
@@ -2,22 +2,12 @@ import { PendingTasks } from '@src/components/PendingTasks';
 import { GeneralCourseInfo } from '@src/courseInfo/components/generalCourseInfo';
 import { EnrollmentSummary } from './components/EnrollmentSummary';
 
-const CourseInfoPage = () => {
-  // TODO: replace this mock data with real data from API
-  const mockEnrollmentCounts = {
-    total: 3640,
-    staffAndAdmins: 10,
-    learners: 3630,
-    verified: 2400,
-    audit: 1230,
-  };
-  return (
-    <div className="mt-4.5 mb-4">
-      <GeneralCourseInfo />
-      <EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />
-      <PendingTasks />
-    </div>
-  );
-};
+const CourseInfoPage = () => (
+  <>
+    <GeneralCourseInfo />
+    <EnrollmentSummary />
+    <PendingTasks />
+  </>
+);
 
 export default CourseInfoPage;

--- a/src/courseInfo/CourseInfoPage.tsx
+++ b/src/courseInfo/CourseInfoPage.tsx
@@ -1,13 +1,22 @@
-import { Container } from '@openedx/paragon';
 import { PendingTasks } from '@src/components/PendingTasks';
 import { GeneralCourseInfo } from '@src/courseInfo/components/generalCourseInfo';
+import { EnrollmentSummary } from './components/EnrollmentSummary';
 
 const CourseInfoPage = () => {
+  // TODO: replace this mock data with real data from API
+  const mockEnrollmentCounts = {
+    total: 3640,
+    staffAndAdmins: 10,
+    learners: 3630,
+    verified: 2400,
+    audit: 1230,
+  };
   return (
-    <Container className="mt-4.5 mb-4" fluid>
+    <div className="mt-4.5 mb-4">
       <GeneralCourseInfo />
+      <EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />
       <PendingTasks />
-    </Container>
+    </div>
   );
 };
 

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.test.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.test.tsx
@@ -1,0 +1,295 @@
+import { render, screen } from '@testing-library/react';
+import { Verified, Person, Group } from '@openedx/paragon/icons';
+import { EnrollmentCounter } from './';
+
+describe('EnrollmentCounter', () => {
+  it('displays the enrollment label and count', () => {
+    render(
+      <EnrollmentCounter
+        label="Total Students"
+        count="1500"
+      />
+    );
+
+    expect(screen.getByText('Total Students')).toBeInTheDocument();
+    expect(screen.getByText('1,500')).toBeInTheDocument();
+  });
+
+  it('formats numbers with thousands separators', () => {
+    render(
+      <EnrollmentCounter
+        label="All Enrollments"
+        count="3640"
+      />
+    );
+
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('3,640')).toBeInTheDocument();
+  });
+
+  it('displays and checks an SVG icon when provided', () => {
+    render(
+      <EnrollmentCounter
+        label="Verified Students"
+        count="410"
+        icon={<Verified />}
+      />
+    );
+
+    expect(screen.getByText('Verified Students')).toBeInTheDocument();
+    expect(screen.getByText('410')).toBeInTheDocument();
+
+    const svgElement = document.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+  });
+
+  it('renders without an icon when not provided', () => {
+    render(
+      <EnrollmentCounter
+        label="Audit Students"
+        count="3230"
+      />
+    );
+
+    expect(screen.getByText('Audit Students')).toBeInTheDocument();
+    expect(screen.getByText('3,230')).toBeInTheDocument();
+
+    // Should not have any icon elements
+    const svgElement = document.querySelector('svg');
+    expect(svgElement).not.toBeInTheDocument();
+  });
+
+  it('displays different types of enrollment data correctly', () => {
+    const { rerender } = render(
+      <EnrollmentCounter
+        label="Staff and Admins"
+        count="10"
+      />
+    );
+
+    expect(screen.getByText('Staff and Admins')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+
+    rerender(
+      <EnrollmentCounter
+        label="Learners"
+        count="3630"
+        icon={<Person />}
+      />
+    );
+
+    expect(screen.getByText('Learners')).toBeInTheDocument();
+    expect(screen.getByText('3,630')).toBeInTheDocument();
+  });
+
+  it('handles large numbers correctly with comma formatting', () => {
+    render(
+      <EnrollmentCounter
+        label="Total Enrollments"
+        count="1234567"
+      />
+    );
+
+    expect(screen.getByText('Total Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('1,234,567')).toBeInTheDocument();
+  });
+
+  it('handles small numbers without unnecessary formatting', () => {
+    render(
+      <EnrollmentCounter
+        label="Admin Users"
+        count="1"
+      />
+    );
+
+    expect(screen.getByText('Admin Users')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('displays numbers in the hundreds correctly', () => {
+    render(
+      <EnrollmentCounter
+        label="Premium Users"
+        count="150"
+      />
+    );
+
+    expect(screen.getByText('Premium Users')).toBeInTheDocument();
+    expect(screen.getByText('150')).toBeInTheDocument();
+  });
+
+  it('maintains proper visual hierarchy with label above count', () => {
+    render(
+      <EnrollmentCounter
+        label="Total Active"
+        count="999"
+      />
+    );
+
+    const label = screen.getByText('Total Active');
+    const count = screen.getByText('999');
+
+    // Label should appear before count in the DOM
+    expect(label.compareDocumentPosition(count) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('handles zero count correctly', () => {
+    render(
+      <EnrollmentCounter
+        label="Pending Approvals"
+        count="0"
+      />
+    );
+
+    expect(screen.getByText('Pending Approvals')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('works with different paragon icon types', () => {
+    const { rerender } = render(
+      <EnrollmentCounter
+        label="Verified Users"
+        count="100"
+        icon={<Verified />}
+      />
+    );
+
+    expect(screen.getByText('Verified Users')).toBeInTheDocument();
+    let svgElement = document.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+
+    rerender(
+      <EnrollmentCounter
+        label="Regular Users"
+        count="200"
+        icon={<Group />}
+      />
+    );
+
+    expect(screen.getByText('Regular Users')).toBeInTheDocument();
+    svgElement = document.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+  });
+
+  it('is accessible to screen readers', () => {
+    render(
+      <EnrollmentCounter
+        label="Verified Certificates"
+        count="125"
+        icon={<Verified />}
+      />
+    );
+
+    // Text should be accessible and visible
+    expect(screen.getByText('Verified Certificates')).toBeVisible();
+    expect(screen.getByText('125')).toBeVisible();
+
+    // Content should be readable by screen readers
+    const labelElement = screen.getByText('Verified Certificates');
+    const countElement = screen.getByText('125');
+
+    expect(labelElement).not.toHaveAttribute('aria-hidden');
+    expect(countElement).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('displays complete enrollment information as a cohesive unit', () => {
+    render(
+      <EnrollmentCounter
+        label="Premium Members"
+        count="1250"
+        icon={<Verified />}
+      />
+    );
+
+    // All elements should be present and visible together
+    expect(screen.getByText('Premium Members')).toBeVisible();
+    expect(screen.getByText('1,250')).toBeVisible();
+
+    // The container should hold all related information
+    const container = screen.getByText('Premium Members').closest('div');
+    expect(container).toContainElement(screen.getByText('1,250'));
+  });
+
+  it('handles various enrollment scenarios users might see', () => {
+    const scenarios = [
+      { label: 'All Enrollments', count: '3640' },
+      { label: 'Staff and Admins', count: '10' },
+      { label: 'Learners', count: '3630' },
+      { label: 'Verified', count: '410' },
+      { label: 'Audit', count: '3230' },
+    ];
+
+    scenarios.forEach(({ label, count }) => {
+      const { unmount } = render(
+        <EnrollmentCounter
+          label={label}
+          count={count}
+          icon={label === 'Verified' ? <Verified /> : undefined}
+        />
+      );
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(count === '3640' ? '3,640'
+        : count === '3630' ? '3,630'
+          : count === '3230' ? '3,230' : count)).toBeInTheDocument();
+
+      if (label === 'Verified') {
+        const svgElement = document.querySelector('svg');
+        expect(svgElement).toBeInTheDocument();
+      }
+
+      unmount();
+    });
+  });
+
+  it('provides clear visual distinction between label and count', () => {
+    render(
+      <EnrollmentCounter
+        label="Course Participants"
+        count="2500"
+      />
+    );
+
+    const label = screen.getByText('Course Participants');
+    const count = screen.getByText('2,500');
+
+    // Both should be visible but with different styling
+    expect(label).toBeVisible();
+    expect(count).toBeVisible();
+
+    // They should be in separate elements
+    expect(label.tagName).toBe('P');
+    expect(count.tagName).toBe('P');
+  });
+
+  it('handles edge case of very large numbers', () => {
+    render(
+      <EnrollmentCounter
+        label="Global Users"
+        count="10000000"
+      />
+    );
+
+    expect(screen.getByText('Global Users')).toBeInTheDocument();
+    expect(screen.getByText('10,000,000')).toBeInTheDocument();
+  });
+
+  it('displays icon and text content together when both are provided', () => {
+    render(
+      <EnrollmentCounter
+        label="Certified Learners"
+        count="850"
+        icon={<Verified />}
+      />
+    );
+
+    const container = screen.getByText('Certified Learners').closest('div');
+
+    // Should contain both text elements and icon
+    expect(container).toContainElement(screen.getByText('Certified Learners'));
+    expect(container).toContainElement(screen.getByText('850'));
+
+    const svgElement = document.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+  });
+});

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react';
+import { formatNumberWithCommas } from './utils';
+
+interface EnrollmentCounterProps {
+  label: string,
+  count: string,
+  icon?: React.ReactNode,
+}
+
+const EnrollmentCounter: FC<EnrollmentCounterProps> = (props) => {
+  const renderCounter = () => {
+    return (<p className="text-primary-500 lead mb-0">{formatNumberWithCommas(props.count)}</p>);
+  };
+
+  const renderCounterWithIcon = () => {
+    return (
+      <div className="d-flex align-items-center">
+        {props.icon}
+        {renderCounter()}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex-row">
+      <p className="text-gray x-small mb-1">{props.label}</p>
+      { props.icon ? renderCounterWithIcon() : renderCounter() }
+    </div>
+  );
+};
+
+export { EnrollmentCounter };

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
@@ -3,7 +3,7 @@ import { formatNumberWithCommas } from './utils';
 
 interface EnrollmentCounterProps {
   label: string,
-  count: string,
+  count: string | number,
   icon?: React.ReactNode,
 }
 

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentCounter.tsx
@@ -23,7 +23,7 @@ const EnrollmentCounter: FC<EnrollmentCounterProps> = (props) => {
 
   return (
     <div className="flex-row">
-      <p className="text-gray x-small mb-1">{props.label}</p>
+      <p className="text-gray-500 x-small mb-1">{props.label}</p>
       { props.icon ? renderCounterWithIcon() : renderCounter() }
     </div>
   );

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
@@ -1,0 +1,269 @@
+import { screen } from '@testing-library/react';
+import { EnrollmentSummary } from './EnrollmentSummary';
+import { renderWithIntl } from '../../../testUtils';
+
+describe('EnrollmentSummary', () => {
+  const mockEnrollmentCounts = {
+    total: 5000,
+    staffAndAdmins: 25,
+    learners: 4975,
+    verified: 3500,
+    audit: 1475,
+  };
+
+  it('displays the enrollment summary title', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByRole('heading', { name: /course enrollment/i })).toBeInTheDocument();
+  });
+
+  it('displays total enrollment count with proper formatting', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('5,000')).toBeInTheDocument();
+  });
+
+  it('displays Staff / Admin count when provided', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('displays learners count when provided', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByText('Learners')).toBeInTheDocument();
+    expect(screen.getByText('4,975')).toBeInTheDocument();
+  });
+
+  it('displays verified count with svg icon when provided', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.getByText('3,500')).toBeInTheDocument();
+
+    const svgElements = document.querySelectorAll('svg');
+    expect(svgElements.length).toBeGreaterThan(0);
+  });
+
+  it('displays audit count when provided', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    expect(screen.getByText('Audit')).toBeInTheDocument();
+    expect(screen.getByText('1,475')).toBeInTheDocument();
+  });
+
+  it('does not display Staff / Admin section when not provided', () => {
+    const countsWithoutStaff = {
+      total: 3000,
+      learners: 3000,
+      verified: 2000,
+      audit: 1000,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutStaff} />);
+
+    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Learners')).toBeInTheDocument();
+  });
+
+  it('does not display learners section when not provided', () => {
+    const countsWithoutLearners = {
+      total: 500,
+      staffAndAdmins: 50,
+      verified: 400,
+      audit: 50,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutLearners} />);
+
+    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
+  });
+
+  it('does not display verified section when not provided', () => {
+    const countsWithoutVerified = {
+      total: 2000,
+      staffAndAdmins: 20,
+      learners: 1980,
+      audit: 1980,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutVerified} />);
+
+    expect(screen.queryByText('Verified')).not.toBeInTheDocument();
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Learners')).toBeInTheDocument();
+  });
+
+  it('does not display audit section when not provided', () => {
+    const countsWithoutAudit = {
+      total: 1500,
+      staffAndAdmins: 15,
+      learners: 1485,
+      verified: 1485,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutAudit} />);
+
+    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+
+  it('displays only total when other counts are not provided', () => {
+    const minimalCounts = { total: 100 };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={minimalCounts} />);
+
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
+    expect(screen.queryByText('Verified')).not.toBeInTheDocument();
+    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
+  });
+
+  it('handles zero values correctly', () => {
+    const countsWithZeros = {
+      total: 0,
+      staffAndAdmins: 0,
+      learners: 0,
+      verified: 0,
+      audit: 0,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithZeros} />);
+
+    // Should still display sections with zero values when provided
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getAllByText('0')).toHaveLength(1); // Only total should appear with 0
+  });
+
+  it('displays enrollment data in proper visual order', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    const allEnrollments = screen.getByText('All Enrollments');
+    const staffAndAdmins = screen.getByText('Staff / Admin');
+    const learners = screen.getByText('Learners');
+    const verified = screen.getByText('Verified');
+    const audit = screen.getByText('Audit');
+
+    // Check DOM order
+    expect(allEnrollments.compareDocumentPosition(staffAndAdmins) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(staffAndAdmins.compareDocumentPosition(learners) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(learners.compareDocumentPosition(verified) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(verified.compareDocumentPosition(audit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('displays large numbers with proper comma formatting', () => {
+    const largeCounts = {
+      total: 1234567,
+      staffAndAdmins: 1234,
+      learners: 1233333,
+      verified: 987654,
+      audit: 245913,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={largeCounts} />);
+
+    expect(screen.getByText('1,234,567')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('1,233,333')).toBeInTheDocument();
+    expect(screen.getByText('987,654')).toBeInTheDocument();
+    expect(screen.getByText('245,913')).toBeInTheDocument();
+  });
+
+  it('is accessible to screen readers', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    // Main heading should be accessible
+    const heading = screen.getByRole('heading', { name: /course enrollment/i });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toBeVisible();
+
+    // All enrollment information should be visible and accessible
+    expect(screen.getByText('All Enrollments')).toBeVisible();
+    expect(screen.getByText('Staff / Admin')).toBeVisible();
+    expect(screen.getByText('Learners')).toBeVisible();
+    expect(screen.getByText('Verified')).toBeVisible();
+    expect(screen.getByText('Audit')).toBeVisible();
+
+    // All counts should be visible
+    expect(screen.getByText('5,000')).toBeVisible();
+    expect(screen.getByText('25')).toBeVisible();
+    expect(screen.getByText('4,975')).toBeVisible();
+    expect(screen.getByText('3,500')).toBeVisible();
+    expect(screen.getByText('1,475')).toBeVisible();
+  });
+
+  it('maintains proper heading hierarchy', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).toHaveTextContent('Course Enrollment');
+  });
+
+  it('displays enrollment counters in horizontal layout', () => {
+    const { container } = renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    // Check for horizontal stack layout
+    const stackElement = container.querySelector('.d-flex');
+    expect(stackElement).toBeInTheDocument();
+  });
+
+  it('shows verified enrollment with distinctive icon presentation', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    // Verified section should have both text and icon
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.getByText('3,500')).toBeInTheDocument();
+
+    // Should have an SVG icon for verified
+    const svgElements = document.querySelectorAll('svg');
+    expect(svgElements.length).toBeGreaterThan(0);
+  });
+
+  it('handles edge case with only verified enrollments', () => {
+    const verifiedOnlyCounts = {
+      total: 500,
+      verified: 500,
+    };
+
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={verifiedOnlyCounts} />);
+
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.getAllByText('500')).toHaveLength(2);
+
+    // Should not show other sections
+    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
+    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
+  });
+
+  it('provides complete enrollment overview for course administrators', () => {
+    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+
+    // Should show comprehensive enrollment data
+    expect(screen.getByText('Course Enrollment')).toBeInTheDocument();
+
+    // All major enrollment categories should be visible
+    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
+    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
+    expect(screen.getByText('Learners')).toBeInTheDocument();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.getByText('Audit')).toBeInTheDocument();
+
+    // All counts should be properly formatted and visible
+    expect(screen.getByText('5,000')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByText('4,975')).toBeInTheDocument();
+    expect(screen.getByText('3,500')).toBeInTheDocument();
+    expect(screen.getByText('1,475')).toBeInTheDocument();
+  });
+});

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
@@ -1,157 +1,186 @@
 import { screen } from '@testing-library/react';
 import { EnrollmentSummary } from './EnrollmentSummary';
 import { renderWithIntl } from '../../../testUtils';
+import { useCourseInfo } from '@src/data/apiHook';
+import messages from './messages';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({
+    courseId: 'course-v1:edX+DemoX+Demo_Course',
+  }),
+}));
+
+jest.mock('@src/data/apiHook', () => ({
+  useCourseInfo: jest.fn(),
+}));
+
+const mockCounter = {
+  enrollmentCounts: {
+    total: 5000,
+    verified: 3500,
+    audit: 1500,
+  },
+  staffCount: 25,
+  learnerCount: 4975,
+};
 
 describe('EnrollmentSummary', () => {
-  const mockEnrollmentCounts = {
-    total: 5000,
-    staffAndAdmins: 25,
-    learners: 4975,
-    verified: 3500,
-    audit: 1475,
-  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('displays the enrollment summary title', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByRole('heading', { name: /course enrollment/i })).toBeInTheDocument();
   });
 
   it('displays total enrollment count with proper formatting', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
+    screen.debug();
 
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('5,000')).toBeInTheDocument();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
   });
 
   it('displays Staff / Admin count when provided', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
-    expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByText(messages.staffAndAdminsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeInTheDocument();
   });
 
   it('displays learners count when provided', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('Learners')).toBeInTheDocument();
-    expect(screen.getByText('4,975')).toBeInTheDocument();
+    expect(screen.getByText(messages.learnersLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeInTheDocument();
   });
 
   it('displays verified count with svg icon when provided', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('Verified')).toBeInTheDocument();
-    expect(screen.getByText('3,500')).toBeInTheDocument();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
 
     const svgElements = document.querySelectorAll('svg');
     expect(svgElements.length).toBeGreaterThan(0);
   });
 
   it('displays audit count when provided', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('Audit')).toBeInTheDocument();
-    expect(screen.getByText('1,475')).toBeInTheDocument();
-  });
-
-  it('does not display Staff / Admin section when not provided', () => {
-    const countsWithoutStaff = {
-      total: 3000,
-      learners: 3000,
-      verified: 2000,
-      audit: 1000,
-    };
-
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutStaff} />);
-
-    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Learners')).toBeInTheDocument();
-  });
-
-  it('does not display learners section when not provided', () => {
-    const countsWithoutLearners = {
-      total: 500,
-      staffAndAdmins: 50,
-      verified: 400,
-      audit: 50,
-    };
-
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutLearners} />);
-
-    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
+    expect(screen.getByText(messages.audit.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
   });
 
   it('does not display verified section when not provided', () => {
     const countsWithoutVerified = {
       total: 2000,
-      staffAndAdmins: 20,
-      learners: 1980,
-      audit: 1980,
+      audit: 2000,
     };
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutVerified} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: { enrollmentCounts: countsWithoutVerified, staffCount: 20, learnerCount: 1980 },
+      isLoading: false,
+    });
 
-    expect(screen.queryByText('Verified')).not.toBeInTheDocument();
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Learners')).toBeInTheDocument();
+    renderWithIntl(<EnrollmentSummary />);
+
+    expect(screen.queryByText(messages.verified.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.learnersLabel.defaultMessage)).toBeInTheDocument();
   });
 
   it('does not display audit section when not provided', () => {
     const countsWithoutAudit = {
       total: 1500,
-      staffAndAdmins: 15,
-      learners: 1485,
-      verified: 1485,
+      verified: 1500,
     };
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithoutAudit} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: { enrollmentCounts: countsWithoutAudit, staffCount: 15, learnerCount: 1485 },
+      isLoading: false,
+    });
 
-    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Verified')).toBeInTheDocument();
+    renderWithIntl(<EnrollmentSummary />);
+
+    expect(screen.queryByText(messages.audit.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
   });
 
   it('displays only total when other counts are not provided', () => {
     const minimalCounts = { total: 100 };
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: { enrollmentCounts: minimalCounts, staffCount: 0, learnerCount: 0 },
+      isLoading: false,
+    });
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={minimalCounts} />);
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('100')).toBeInTheDocument();
-    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
-    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
-    expect(screen.queryByText('Verified')).not.toBeInTheDocument();
-    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(minimalCounts.total.toLocaleString())).toBeInTheDocument();
+    expect(screen.queryByText(messages.verified.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.audit.defaultMessage)).not.toBeInTheDocument();
   });
 
   it('handles zero values correctly', () => {
     const countsWithZeros = {
       total: 0,
-      staffAndAdmins: 0,
-      learners: 0,
       verified: 0,
       audit: 0,
     };
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={countsWithZeros} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: { enrollmentCounts: countsWithZeros, staffCount: 0, learnerCount: 0 },
+      isLoading: false,
+    });
+
+    renderWithIntl(<EnrollmentSummary />);
 
     // Should still display sections with zero values when provided
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getAllByText('0')).toHaveLength(1); // Only total should appear with 0
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getAllByText('0')).toHaveLength(5);
   });
 
   it('displays enrollment data in proper visual order', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
 
-    const allEnrollments = screen.getByText('All Enrollments');
-    const staffAndAdmins = screen.getByText('Staff / Admin');
-    const learners = screen.getByText('Learners');
-    const verified = screen.getByText('Verified');
-    const audit = screen.getByText('Audit');
+    renderWithIntl(<EnrollmentSummary />);
+
+    const allEnrollments = screen.getByText(messages.allEnrollmentsLabel.defaultMessage);
+    const staffAndAdmins = screen.getByText(messages.staffAndAdminsLabel.defaultMessage);
+    const learners = screen.getByText(messages.learnersLabel.defaultMessage);
+    const verified = screen.getByText(messages.verified.defaultMessage);
+    const audit = screen.getByText(messages.audit.defaultMessage);
 
     // Check DOM order
     expect(allEnrollments.compareDocumentPosition(staffAndAdmins) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -162,24 +191,35 @@ describe('EnrollmentSummary', () => {
 
   it('displays large numbers with proper comma formatting', () => {
     const largeCounts = {
-      total: 1234567,
-      staffAndAdmins: 1234,
-      learners: 1233333,
-      verified: 987654,
-      audit: 245913,
+      enrollmentCounts: {
+        total: 1234567,
+        verified: 987654,
+        audit: 245913,
+      },
+      staffCount: 1234,
+      learnerCount: 1233333,
     };
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: largeCounts,
+      isLoading: false,
+    });
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={largeCounts} />);
+    renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText('1,234,567')).toBeInTheDocument();
-    expect(screen.getByText('1,234')).toBeInTheDocument();
-    expect(screen.getByText('1,233,333')).toBeInTheDocument();
-    expect(screen.getByText('987,654')).toBeInTheDocument();
-    expect(screen.getByText('245,913')).toBeInTheDocument();
+    expect(screen.getByText(largeCounts.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(largeCounts.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(largeCounts.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(largeCounts.staffCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(largeCounts.learnerCount.toLocaleString())).toBeInTheDocument();
   });
 
   it('is accessible to screen readers', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+
+    renderWithIntl(<EnrollmentSummary />);
 
     // Main heading should be accessible
     const heading = screen.getByRole('heading', { name: /course enrollment/i });
@@ -187,29 +227,33 @@ describe('EnrollmentSummary', () => {
     expect(heading).toBeVisible();
 
     // All enrollment information should be visible and accessible
-    expect(screen.getByText('All Enrollments')).toBeVisible();
-    expect(screen.getByText('Staff / Admin')).toBeVisible();
-    expect(screen.getByText('Learners')).toBeVisible();
-    expect(screen.getByText('Verified')).toBeVisible();
-    expect(screen.getByText('Audit')).toBeVisible();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeVisible();
+    expect(screen.getByText(messages.staffAndAdminsLabel.defaultMessage)).toBeVisible();
+    expect(screen.getByText(messages.learnersLabel.defaultMessage)).toBeVisible();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeVisible();
+    expect(screen.getByText(messages.audit.defaultMessage)).toBeVisible();
 
     // All counts should be visible
-    expect(screen.getByText('5,000')).toBeVisible();
-    expect(screen.getByText('25')).toBeVisible();
-    expect(screen.getByText('4,975')).toBeVisible();
-    expect(screen.getByText('3,500')).toBeVisible();
-    expect(screen.getByText('1,475')).toBeVisible();
+    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeVisible();
+    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeVisible();
+    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeVisible();
+    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeVisible();
+    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeVisible();
   });
 
   it('maintains proper heading hierarchy', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
     const heading = screen.getByRole('heading', { level: 3 });
     expect(heading).toHaveTextContent('Course Enrollment');
   });
 
   it('displays enrollment counters in horizontal layout', () => {
-    const { container } = renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    const { container } = renderWithIntl(<EnrollmentSummary />);
 
     // Check for horizontal stack layout
     const stackElement = container.querySelector('.d-flex');
@@ -217,11 +261,15 @@ describe('EnrollmentSummary', () => {
   });
 
   it('shows verified enrollment with distinctive icon presentation', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
     // Verified section should have both text and icon
-    expect(screen.getByText('Verified')).toBeInTheDocument();
-    expect(screen.getByText('3,500')).toBeInTheDocument();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
 
     // Should have an SVG icon for verified
     const svgElements = document.querySelectorAll('svg');
@@ -230,40 +278,51 @@ describe('EnrollmentSummary', () => {
 
   it('handles edge case with only verified enrollments', () => {
     const verifiedOnlyCounts = {
-      total: 500,
-      verified: 500,
+      enrollmentCounts: {
+        total: 500,
+        verified: 500,
+      },
+      staffCount: 0,
+      learnerCount: 0,
     };
 
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={verifiedOnlyCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: verifiedOnlyCounts,
+      isLoading: false,
+    });
 
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Verified')).toBeInTheDocument();
-    expect(screen.getAllByText('500')).toHaveLength(2);
+    renderWithIntl(<EnrollmentSummary />);
+
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
+    expect(screen.getAllByText(verifiedOnlyCounts.enrollmentCounts.verified.toLocaleString())).toHaveLength(2);
 
     // Should not show other sections
-    expect(screen.queryByText('Staff / Admin')).not.toBeInTheDocument();
-    expect(screen.queryByText('Learners')).not.toBeInTheDocument();
-    expect(screen.queryByText('Audit')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.audit.defaultMessage)).not.toBeInTheDocument();
   });
 
   it('provides complete enrollment overview for course administrators', () => {
-    renderWithIntl(<EnrollmentSummary enrollmentCounts={mockEnrollmentCounts} />);
+    (useCourseInfo as jest.Mock).mockReturnValue({
+      data: mockCounter,
+      isLoading: false,
+    });
+    renderWithIntl(<EnrollmentSummary />);
 
     // Should show comprehensive enrollment data
-    expect(screen.getByText('Course Enrollment')).toBeInTheDocument();
+    expect(screen.getByText(messages.enrollmentSummaryTitle.defaultMessage)).toBeInTheDocument();
 
     // All major enrollment categories should be visible
-    expect(screen.getByText('All Enrollments')).toBeInTheDocument();
-    expect(screen.getByText('Staff / Admin')).toBeInTheDocument();
-    expect(screen.getByText('Learners')).toBeInTheDocument();
-    expect(screen.getByText('Verified')).toBeInTheDocument();
-    expect(screen.getByText('Audit')).toBeInTheDocument();
+    expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.staffAndAdminsLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.learnersLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.audit.defaultMessage)).toBeInTheDocument();
 
     // All counts should be properly formatted and visible
-    expect(screen.getByText('5,000')).toBeInTheDocument();
-    expect(screen.getByText('25')).toBeInTheDocument();
-    expect(screen.getByText('4,975')).toBeInTheDocument();
-    expect(screen.getByText('3,500')).toBeInTheDocument();
-    expect(screen.getByText('1,475')).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
   });
 });

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.test.tsx
@@ -3,6 +3,7 @@ import { EnrollmentSummary } from './EnrollmentSummary';
 import { renderWithIntl } from '../../../testUtils';
 import { useCourseInfo } from '@src/data/apiHook';
 import messages from './messages';
+import { formatNumberWithCommas } from './utils';
 
 jest.mock('react-router-dom', () => ({
   useParams: () => ({
@@ -48,7 +49,7 @@ describe('EnrollmentSummary', () => {
     screen.debug();
 
     expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.total))).toBeInTheDocument();
   });
 
   it('displays Staff / Admin count when provided', () => {
@@ -59,7 +60,7 @@ describe('EnrollmentSummary', () => {
     renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByText(messages.staffAndAdminsLabel.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(mockCounter.staffCount)).toBeInTheDocument();
   });
 
   it('displays learners count when provided', () => {
@@ -70,7 +71,7 @@ describe('EnrollmentSummary', () => {
     renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByText(messages.learnersLabel.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.learnerCount))).toBeInTheDocument();
   });
 
   it('displays verified count with svg icon when provided', () => {
@@ -81,7 +82,7 @@ describe('EnrollmentSummary', () => {
     renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.verified))).toBeInTheDocument();
 
     const svgElements = document.querySelectorAll('svg');
     expect(svgElements.length).toBeGreaterThan(0);
@@ -95,7 +96,7 @@ describe('EnrollmentSummary', () => {
     renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByText(messages.audit.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.audit))).toBeInTheDocument();
   });
 
   it('does not display verified section when not provided', () => {
@@ -144,7 +145,7 @@ describe('EnrollmentSummary', () => {
     renderWithIntl(<EnrollmentSummary />);
 
     expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(minimalCounts.total.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(minimalCounts.total)).toBeInTheDocument();
     expect(screen.queryByText(messages.verified.defaultMessage)).not.toBeInTheDocument();
     expect(screen.queryByText(messages.audit.defaultMessage)).not.toBeInTheDocument();
   });
@@ -206,11 +207,11 @@ describe('EnrollmentSummary', () => {
 
     renderWithIntl(<EnrollmentSummary />);
 
-    expect(screen.getByText(largeCounts.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(largeCounts.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(largeCounts.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(largeCounts.staffCount.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(largeCounts.learnerCount.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(largeCounts.enrollmentCounts.total))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(largeCounts.enrollmentCounts.verified))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(largeCounts.enrollmentCounts.audit))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(largeCounts.staffCount))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(largeCounts.learnerCount))).toBeInTheDocument();
   });
 
   it('is accessible to screen readers', () => {
@@ -234,11 +235,11 @@ describe('EnrollmentSummary', () => {
     expect(screen.getByText(messages.audit.defaultMessage)).toBeVisible();
 
     // All counts should be visible
-    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeVisible();
-    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeVisible();
-    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeVisible();
-    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeVisible();
-    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeVisible();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.total))).toBeVisible();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.verified))).toBeVisible();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.audit))).toBeVisible();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.staffCount))).toBeVisible();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.learnerCount))).toBeVisible();
   });
 
   it('maintains proper heading hierarchy', () => {
@@ -269,7 +270,7 @@ describe('EnrollmentSummary', () => {
 
     // Verified section should have both text and icon
     expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.verified))).toBeInTheDocument();
 
     // Should have an SVG icon for verified
     const svgElements = document.querySelectorAll('svg');
@@ -295,7 +296,7 @@ describe('EnrollmentSummary', () => {
 
     expect(screen.getByText(messages.allEnrollmentsLabel.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.verified.defaultMessage)).toBeInTheDocument();
-    expect(screen.getAllByText(verifiedOnlyCounts.enrollmentCounts.verified.toLocaleString())).toHaveLength(2);
+    expect(screen.getAllByText(verifiedOnlyCounts.enrollmentCounts.verified)).toHaveLength(2);
 
     // Should not show other sections
     expect(screen.queryByText(messages.audit.defaultMessage)).not.toBeInTheDocument();
@@ -319,10 +320,10 @@ describe('EnrollmentSummary', () => {
     expect(screen.getByText(messages.audit.defaultMessage)).toBeInTheDocument();
 
     // All counts should be properly formatted and visible
-    expect(screen.getByText(mockCounter.enrollmentCounts.total.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.staffCount.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.learnerCount.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.verified.toLocaleString())).toBeInTheDocument();
-    expect(screen.getByText(mockCounter.enrollmentCounts.audit.toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.total))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.staffCount))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.learnerCount))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.verified))).toBeInTheDocument();
+    expect(screen.getByText(formatNumberWithCommas(mockCounter.enrollmentCounts.audit))).toBeInTheDocument();
   });
 });

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
@@ -1,0 +1,69 @@
+import { useIntl } from '@openedx/frontend-base';
+import { FC } from 'react';
+import messages from './messages';
+import { Col, Container, Row, Stack } from '@openedx/paragon';
+import { Verified } from '@openedx/paragon/icons';
+import { EnrollmentCounter } from './';
+
+import './index.scss';
+
+interface EnrollmentSummaryProps {
+  enrollmentCounts: {
+    total: number,
+    staffAndAdmins?: number,
+    learners?: number,
+    verified?: number,
+    audit?: number,
+  },
+};
+
+const EnrollmentSummary: FC<EnrollmentSummaryProps> = ({ enrollmentCounts }) => {
+  const intl = useIntl();
+
+  return (
+    <Container>
+      <Row className="my-3">
+        <Col xs={12}>
+          <h3 className="h3 text-primary-700">{intl.formatMessage(messages.enrollmentSummaryTitle)}</h3>
+        </Col>
+      </Row>
+      <Stack direction="horizontal" gap={5}>
+        <EnrollmentCounter
+          label={intl.formatMessage(messages.allEnrollmentsLabel)}
+          count={enrollmentCounts.total.toString()}
+        />
+        <div className="vertical-separator" />
+        {enrollmentCounts?.staffAndAdmins && (
+          <EnrollmentCounter
+            label={intl.formatMessage(messages.staffAndAdminsLabel)}
+            count={enrollmentCounts.staffAndAdmins?.toString() ?? '0'}
+          />
+        )}
+        {enrollmentCounts?.learners && (
+          <EnrollmentCounter
+            label={intl.formatMessage(messages.learnersLabel)}
+            count={enrollmentCounts.learners?.toString() ?? '0'}
+          />
+        )}
+        {(enrollmentCounts?.learners ?? enrollmentCounts?.verified) && (
+          <div className="vertical-separator" />
+        )}
+        {enrollmentCounts?.verified && (
+          <EnrollmentCounter
+            label={intl.formatMessage(messages.verifiedLabel)}
+            count={enrollmentCounts.verified?.toString() ?? '0'}
+            icon={<Verified className="text-primary-400 mr-2" size="1.5rem" />}
+          />
+        )}
+        {enrollmentCounts?.audit && (
+          <EnrollmentCounter
+            label={intl.formatMessage(messages.auditLabel)}
+            count={enrollmentCounts.audit?.toString() ?? '0'}
+          />
+        )}
+      </Stack>
+    </Container>
+  );
+};
+
+export { EnrollmentSummary };

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
@@ -5,8 +5,6 @@ import { Col, Container, Row, Stack } from '@openedx/paragon';
 import { Verified } from '@openedx/paragon/icons';
 import { EnrollmentCounter } from './';
 
-import './index.scss';
-
 interface EnrollmentSummaryProps {
   enrollmentCounts: {
     total: number,
@@ -32,7 +30,7 @@ const EnrollmentSummary: FC<EnrollmentSummaryProps> = ({ enrollmentCounts }) => 
           label={intl.formatMessage(messages.allEnrollmentsLabel)}
           count={enrollmentCounts.total.toString()}
         />
-        <div className="vertical-separator" />
+        <div className="h-auto border-light-400 border-left align-self-stretch" />
         {enrollmentCounts?.staffAndAdmins && (
           <EnrollmentCounter
             label={intl.formatMessage(messages.staffAndAdminsLabel)}
@@ -46,7 +44,7 @@ const EnrollmentSummary: FC<EnrollmentSummaryProps> = ({ enrollmentCounts }) => 
           />
         )}
         {(enrollmentCounts?.learners ?? enrollmentCounts?.verified) && (
-          <div className="vertical-separator" />
+          <div className="h-auto border-light-400 border-left align-self-stretch" />
         )}
         {enrollmentCounts?.verified && (
           <EnrollmentCounter

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
@@ -1,66 +1,65 @@
 import { useIntl } from '@openedx/frontend-base';
-import { FC } from 'react';
 import messages from './messages';
-import { Col, Container, Row, Stack } from '@openedx/paragon';
+import { Col, Row, Skeleton, Stack } from '@openedx/paragon';
 import { Verified } from '@openedx/paragon/icons';
 import { EnrollmentCounter } from './';
+import { useParams } from 'react-router-dom';
+import { useCourseInfo } from '@src/data/apiHook';
 
-interface EnrollmentSummaryProps {
-  enrollmentCounts: {
-    total: number,
-    staffAndAdmins?: number,
-    learners?: number,
-    verified?: number,
-    audit?: number,
-  },
-};
-
-const EnrollmentSummary: FC<EnrollmentSummaryProps> = ({ enrollmentCounts }) => {
+const EnrollmentSummary = () => {
   const intl = useIntl();
+  const { courseId = '' } = useParams();
+  const { data: courseInfo, isLoading } = useCourseInfo(courseId);
+  const { enrollmentCounts, staffCount = 0, learnerCount = 0 } = courseInfo ?? {};
 
   return (
-    <Container>
+    <>
       <Row className="my-3">
         <Col xs={12}>
           <h3 className="h3 text-primary-700">{intl.formatMessage(messages.enrollmentSummaryTitle)}</h3>
         </Col>
       </Row>
-      <Stack direction="horizontal" gap={5}>
-        <EnrollmentCounter
-          label={intl.formatMessage(messages.allEnrollmentsLabel)}
-          count={enrollmentCounts.total.toString()}
-        />
-        <div className="h-auto border-light-400 border-left align-self-stretch" />
-        {enrollmentCounts?.staffAndAdmins && (
-          <EnrollmentCounter
-            label={intl.formatMessage(messages.staffAndAdminsLabel)}
-            count={enrollmentCounts.staffAndAdmins?.toString() ?? '0'}
-          />
-        )}
-        {enrollmentCounts?.learners && (
-          <EnrollmentCounter
-            label={intl.formatMessage(messages.learnersLabel)}
-            count={enrollmentCounts.learners?.toString() ?? '0'}
-          />
-        )}
-        {(enrollmentCounts?.learners ?? enrollmentCounts?.verified) && (
-          <div className="h-auto border-light-400 border-left align-self-stretch" />
-        )}
-        {enrollmentCounts?.verified && (
-          <EnrollmentCounter
-            label={intl.formatMessage(messages.verifiedLabel)}
-            count={enrollmentCounts.verified?.toString() ?? '0'}
-            icon={<Verified className="text-primary-400 mr-2" size="1.5rem" />}
-          />
-        )}
-        {enrollmentCounts?.audit && (
-          <EnrollmentCounter
-            label={intl.formatMessage(messages.auditLabel)}
-            count={enrollmentCounts.audit?.toString() ?? '0'}
-          />
-        )}
-      </Stack>
-    </Container>
+      {
+        isLoading ? (
+          <>
+            <Skeleton count={1} width="50%" className="mb-2" />
+            <Skeleton count={1} width="50%" className="mb-2 lead" />
+          </>
+        ) : (
+          <Stack direction="horizontal" gap={5}>
+            <EnrollmentCounter
+              label={intl.formatMessage(messages.allEnrollmentsLabel)}
+              count={enrollmentCounts.total.toLocaleString()}
+            />
+            <div className="h-auto border-light-400 border-left align-self-stretch" />
+            <EnrollmentCounter
+              label={intl.formatMessage(messages.staffAndAdminsLabel)}
+              count={staffCount.toLocaleString() ?? '0'}
+            />
+            <EnrollmentCounter
+              label={intl.formatMessage(messages.learnersLabel)}
+              count={learnerCount?.toLocaleString() ?? '0'}
+            />
+            <div className="h-auto border-light-400 border-left align-self-stretch" />
+            {
+              Object.entries(enrollmentCounts).map(([type, count]) => {
+                if (type === 'total' || count === undefined) {
+                  return null;
+                }
+                return (
+                  <EnrollmentCounter
+                    key={type}
+                    label={intl.formatMessage(messages[`${type}` as keyof typeof messages] ?? { id: 'fallback', defaultMessage: type, description: `${type} label` })}
+                    count={count?.toLocaleString() ?? '0'}
+                    icon={type === 'verified' ? <Verified className="text-primary-400 mr-2" size="1.5rem" /> : undefined}
+                  />
+                );
+              })
+            }
+          </Stack>
+        )
+      }
+    </>
   );
 };
 

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
@@ -51,7 +51,7 @@ const EnrollmentSummary = () => {
                     key={type}
                     label={intl.formatMessage(messages[`${type}` as keyof typeof messages] ?? { id: 'fallback', defaultMessage: type, description: `${type} label` })}
                     count={count?.toLocaleString() ?? '0'}
-                    icon={type === 'verified' ? <Verified className="text-primary-400 mr-2" size="1.5rem" /> : undefined}
+                    icon={type === 'verified' ? <Verified className="text-primary-300 mr-2" size="1.5rem" /> : undefined}
                   />
                 );
               })

--- a/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
+++ b/src/courseInfo/components/EnrollmentSummary/EnrollmentSummary.tsx
@@ -29,20 +29,20 @@ const EnrollmentSummary = () => {
           <Stack direction="horizontal" gap={5}>
             <EnrollmentCounter
               label={intl.formatMessage(messages.allEnrollmentsLabel)}
-              count={enrollmentCounts.total.toLocaleString()}
+              count={enrollmentCounts?.total ?? 0}
             />
             <div className="h-auto border-light-400 border-left align-self-stretch" />
             <EnrollmentCounter
               label={intl.formatMessage(messages.staffAndAdminsLabel)}
-              count={staffCount.toLocaleString() ?? '0'}
+              count={staffCount ?? 0}
             />
             <EnrollmentCounter
               label={intl.formatMessage(messages.learnersLabel)}
-              count={learnerCount?.toLocaleString() ?? '0'}
+              count={learnerCount ?? 0}
             />
             <div className="h-auto border-light-400 border-left align-self-stretch" />
             {
-              Object.entries(enrollmentCounts).map(([type, count]) => {
+              Object.entries(enrollmentCounts ?? {}).map(([type, count]) => {
                 if (type === 'total' || count === undefined) {
                   return null;
                 }
@@ -50,7 +50,7 @@ const EnrollmentSummary = () => {
                   <EnrollmentCounter
                     key={type}
                     label={intl.formatMessage(messages[`${type}` as keyof typeof messages] ?? { id: 'fallback', defaultMessage: type, description: `${type} label` })}
-                    count={count?.toLocaleString() ?? '0'}
+                    count={(count ?? 0).toLocaleString()}
                     icon={type === 'verified' ? <Verified className="text-primary-300 mr-2" size="1.5rem" /> : undefined}
                   />
                 );

--- a/src/courseInfo/components/EnrollmentSummary/index.scss
+++ b/src/courseInfo/components/EnrollmentSummary/index.scss
@@ -1,0 +1,7 @@
+@use "@openedx/paragon/scss/core/core" as paragon;
+
+.vertical-separator {
+  border-left: 1px solid paragon.$light-400;
+  height: auto;
+  align-self: stretch;
+}

--- a/src/courseInfo/components/EnrollmentSummary/index.scss
+++ b/src/courseInfo/components/EnrollmentSummary/index.scss
@@ -1,7 +1,0 @@
-@use "@openedx/paragon/scss/core/core" as paragon;
-
-.vertical-separator {
-  border-left: 1px solid paragon.$light-400;
-  height: auto;
-  align-self: stretch;
-}

--- a/src/courseInfo/components/EnrollmentSummary/index.ts
+++ b/src/courseInfo/components/EnrollmentSummary/index.ts
@@ -1,0 +1,2 @@
+export { EnrollmentSummary } from './EnrollmentSummary';
+export { EnrollmentCounter } from './EnrollmentCounter';

--- a/src/courseInfo/components/EnrollmentSummary/messages.ts
+++ b/src/courseInfo/components/EnrollmentSummary/messages.ts
@@ -1,0 +1,37 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+
+  enrollmentSummaryTitle: {
+    id: 'instruct.courseInfo.enrollmentSummary.title',
+    defaultMessage: 'Course Enrollment',
+    description: 'Title for the enrollment summary section',
+  },
+  allEnrollmentsLabel: {
+    id: 'instruct.courseInfo.enrollmentSummary.allEnrollments',
+    defaultMessage: 'All Enrollments',
+    description: 'Label for all enrollments count',
+  },
+  staffAndAdminsLabel: {
+    id: 'instruct.courseInfo.enrollmentSummary.staffAndAdmins',
+    defaultMessage: 'Staff / Admin',
+    description: 'Label for staff and admins count',
+  },
+  learnersLabel: {
+    id: 'instruct.courseInfo.enrollmentSummary.learners',
+    defaultMessage: 'Learners',
+    description: 'Label for learners count',
+  },
+  verifiedLabel: {
+    id: 'instruct.courseInfo.enrollmentSummary.verified',
+    defaultMessage: 'Verified',
+    description: 'Label for verified enrollments count',
+  },
+  auditLabel: {
+    id: 'instruct.courseInfo.enrollmentSummary.audit',
+    defaultMessage: 'Audit',
+    description: 'Label for audit enrollments count',
+  },
+});
+
+export default messages;

--- a/src/courseInfo/components/EnrollmentSummary/messages.ts
+++ b/src/courseInfo/components/EnrollmentSummary/messages.ts
@@ -22,15 +22,65 @@ const messages = defineMessages({
     defaultMessage: 'Learners',
     description: 'Label for learners count',
   },
-  verifiedLabel: {
+  verified: {
     id: 'instruct.courseInfo.enrollmentSummary.verified',
     defaultMessage: 'Verified',
     description: 'Label for verified enrollments count',
   },
-  auditLabel: {
+  audit: {
     id: 'instruct.courseInfo.enrollmentSummary.audit',
     defaultMessage: 'Audit',
     description: 'Label for audit enrollments count',
+  },
+  masters: {
+    id: 'instruct.courseInfo.enrollmentSummary.masters',
+    defaultMessage: 'Master\'s',
+    description: 'Label for master\'s enrollments count',
+  },
+  honor: {
+    id: 'instruct.courseInfo.enrollmentSummary.honor',
+    defaultMessage: 'Honor',
+    description: 'Label for honor enrollments count',
+  },
+  professional: {
+    id: 'instruct.courseInfo.enrollmentSummary.professional',
+    defaultMessage: 'Professional',
+    description: 'Label for professional enrollments count',
+  },
+  noIdProfessional: {
+    id: 'instruct.courseInfo.enrollmentSummary.noIdProfessional',
+    defaultMessage: 'No ID Professional',
+    description: 'Label for no ID professional enrollments count',
+  },
+  credit: {
+    id: 'instruct.courseInfo.enrollmentSummary.credit',
+    defaultMessage: 'Credit',
+    description: 'Label for credit enrollments count',
+  },
+  paidBootcamp: {
+    id: 'instruct.courseInfo.enrollmentSummary.paidBootcamp',
+    defaultMessage: 'Paid Bootcamp',
+    description: 'Label for paid bootcamp enrollments count',
+  },
+  unpaidBootcamp: {
+    id: 'instruct.courseInfo.enrollmentSummary.unpaidBootcamp',
+    defaultMessage: 'Unpaid Bootcamp',
+    description: 'Label for unpaid bootcamp enrollments count',
+  },
+  executiveEducation: {
+    id: 'instruct.courseInfo.enrollmentSummary.executiveEducation',
+    defaultMessage: 'Executive Education',
+    description: 'Label for executive education enrollments count',
+  },
+  paidExecutiveEducation: {
+    id: 'instruct.courseInfo.enrollmentSummary.paidExecutiveEducation',
+    defaultMessage: 'Paid Executive Education',
+    description: 'Label for paid executive education enrollments count',
+  },
+  unpaidExecutiveEducation: {
+    id: 'instruct.courseInfo.enrollmentSummary.unpaidExecutiveEducation',
+    defaultMessage: 'Unpaid Executive Education',
+    description: 'Label for unpaid executive education enrollments count',
   },
 });
 

--- a/src/courseInfo/components/EnrollmentSummary/utils.test.ts
+++ b/src/courseInfo/components/EnrollmentSummary/utils.test.ts
@@ -1,0 +1,24 @@
+import { formatNumberWithCommas } from './utils';
+
+describe('formatNumberWithCommas', () => {
+  it('formats valid numbers with commas', () => {
+    expect(formatNumberWithCommas('1000')).toBe('1,000');
+    expect(formatNumberWithCommas('1234567')).toBe('1,234,567');
+  });
+
+  it('removes existing commas and spaces before formatting', () => {
+    expect(formatNumberWithCommas('1,000')).toBe('1,000');
+    expect(formatNumberWithCommas('1 000')).toBe('1,000');
+    expect(formatNumberWithCommas('1, 000')).toBe('1,000');
+  });
+
+  it('returns original string for invalid numbers', () => {
+    expect(formatNumberWithCommas('abc')).toBe('abc');
+    expect(formatNumberWithCommas('12abc')).toBe('12abc');
+  });
+
+  it('handles small numbers without commas', () => {
+    expect(formatNumberWithCommas('123')).toBe('123');
+    expect(formatNumberWithCommas('0')).toBe('0');
+  });
+});

--- a/src/courseInfo/components/EnrollmentSummary/utils.ts
+++ b/src/courseInfo/components/EnrollmentSummary/utils.ts
@@ -1,0 +1,7 @@
+export const formatNumberWithCommas = (numberString: string): string => {
+  const cleanNumber = numberString.replace(/[,\s]/g, '');
+  if (isNaN(Number(cleanNumber))) {
+    return numberString;
+  }
+  return Number(cleanNumber).toLocaleString('en-US');
+};

--- a/src/courseInfo/components/EnrollmentSummary/utils.ts
+++ b/src/courseInfo/components/EnrollmentSummary/utils.ts
@@ -1,7 +1,8 @@
-export const formatNumberWithCommas = (numberString: string): string => {
+export const formatNumberWithCommas = (digit: string | number): string => {
+  const numberString = typeof digit === 'number' ? digit.toString() : digit;
   const cleanNumber = numberString.replace(/[,\s]/g, '');
   if (isNaN(Number(cleanNumber))) {
     return numberString;
   }
-  return Number(cleanNumber).toLocaleString('en-US');
+  return Number(cleanNumber).toLocaleString();
 };

--- a/src/courseInfo/components/generalCourseInfo/GeneralCourseInfo.tsx
+++ b/src/courseInfo/components/generalCourseInfo/GeneralCourseInfo.tsx
@@ -42,6 +42,10 @@ const GeneralCourseInfo = () => {
     );
   }
 
+  if (!courseInfo) {
+    return null;
+  }
+
   return (
     <Card className="general-course-info">
       <Card.Section>

--- a/src/courseInfo/types.ts
+++ b/src/courseInfo/types.ts
@@ -1,0 +1,25 @@
+export interface CourseInfoResponse {
+  courseId: string,
+  displayName: string,
+  courseNumber: string,
+  courseRun: string,
+  enrollmentCounts: EnrollmentCounts,
+  start: string | null,
+  end: string | null,
+  totalEnrollment: number,
+  studioUrl: string,
+  pacing: string,
+  org?: string,
+  numSections: number,
+  hasStarted: boolean,
+  hasEnded: boolean,
+  enrollmentEnd: string | null,
+  enrollmentStart: string | null,
+  gradeCutoffs: string | null,
+  staffCount: number,
+  learnerCount: number,
+}
+
+interface EnrollmentCounts extends Record<string, number> {
+  total: number,
+}

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,5 +1,6 @@
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { appId } from '@src/constants';
+import { CourseInfoResponse } from '@src/courseInfo/types';
 
 export const getApiBaseUrl = () => getAppConfig(appId).LMS_BASE_URL;
 
@@ -8,7 +9,7 @@ export const getApiBaseUrl = () => getAppConfig(appId).LMS_BASE_URL;
  * @param {string} courseId
  * @returns {Promise<Object>}
  */
-export const getCourseInfo = async (courseId) => {
+export const getCourseInfo = async (courseId: string): Promise<CourseInfoResponse> => {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}`);
   return camelCaseObject(data);

--- a/src/data/apiHook.test.tsx
+++ b/src/data/apiHook.test.tsx
@@ -8,6 +8,29 @@ jest.mock('./api');
 const mockGetCourseInfo = getCourseInfo as jest.MockedFunction<typeof getCourseInfo>;
 const mockFetchPendingTasks = fetchPendingTasks as jest.MockedFunction<typeof fetchPendingTasks>;
 
+const mockCourseData = {
+  courseId: 'test-course-123',
+  displayName: 'Test Course',
+  courseNumber: '123',
+  courseRun: '2024',
+  enrollmentCounts: { total: 100, audit: 50 },
+  start: null,
+  end: null,
+  tabs: [],
+  totalEnrollment: 150,
+  studioUrl: 'http://studio.example.com',
+  pacing: 'self-paced',
+  org: 'Test Org',
+  numSections: 10,
+  hasStarted: true,
+  hasEnded: false,
+  enrollmentEnd: null,
+  enrollmentStart: null,
+  gradeCutoffs: null,
+  staffCount: 5,
+  learnerCount: 145,
+};
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -28,7 +51,6 @@ describe('api hooks', () => {
     });
 
     it('fetches course info successfully', async () => {
-      const mockCourseData = { courseName: 'Test Course' };
       mockGetCourseInfo.mockResolvedValue(mockCourseData);
 
       const { result } = renderHook(() => useCourseInfo('test-course-123'), {


### PR DESCRIPTION
## Description
Adding the course enrollment summary section.
Splitted the code in different components in order to enhance reusability, testability and readbility of the code.
I have used copilot to generate the unit tests, and I have supervised them to be correct and useful.
 
It closes https://github.com/openedx/frontend-app-instruct/issues/25
Figma design: https://www.figma.com/design/RnkfsNvyutLkSDXEhEOkEY/Instructor-Experience?node-id=18471-191211&t=ISjOGICChS4uRnek-11

## Screenshot
<img width="1234" height="457" alt="Captura de pantalla 2025-10-24 a la(s) 11 45 43 a m" src="https://github.com/user-attachments/assets/3c67cf87-35aa-460c-ab27-741dc68dab60" />

## How to test it

- `npm install && npm run dev `
- Go to [instructor/course_info](http://apps.local.openedx.io:8080/instructor/course_info)
