### PR TITLE
Date extensions list

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "*.scss"
   ],
   "scripts": {
-    "dev": "PORT=8080 PUBLIC_PATH=/instructor openedx dev",
+    "dev": "PORT=8081 PUBLIC_PATH=/instructor openedx dev",
     "i18n_extract": "openedx formatjs extract",
     "lint": "openedx lint .",
     "lint:fix": "openedx lint --fix .",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "*.scss"
   ],
   "scripts": {
-    "dev": "PORT=8081 PUBLIC_PATH=/instructor openedx dev",
+    "dev": "PORT=8080 PUBLIC_PATH=/instructor openedx dev",
     "i18n_extract": "openedx formatjs extract",
     "lint": "openedx lint .",
     "lint:fix": "openedx lint --fix .",

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,10 +1,8 @@
 import { CurrentAppProvider, getAppConfig } from '@openedx/frontend-base';
-
-import { appId } from './constants';
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { appId } from './constants';
 import './main.scss';
 
 const queryClient = new QueryClient();

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -55,10 +55,16 @@ describe('DateExtensionsPage', () => {
 
   it('shows loading state on table when fetching data', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({
-      data: null,
+      data: [],
       isLoading: true,
     });
     render(<RenderWithRouter />);
     expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders reset link for each row', () => {
+    render(<RenderWithRouter />);
+    const resetLinks = screen.getAllByRole('button', { name: 'Reset Extensions' });
+    expect(resetLinks).toHaveLength(mockDateExtensions.length);
   });
 });

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -22,7 +22,7 @@ const mockDateExtensions = [
 describe('DateExtensionsPage', () => {
   beforeEach(() => {
     (useDateExtensions as jest.Mock).mockReturnValue({
-      data: mockDateExtensions,
+      data: { count: mockDateExtensions.length, results: mockDateExtensions },
       isLoading: false,
     });
   });
@@ -55,7 +55,7 @@ describe('DateExtensionsPage', () => {
 
   it('shows loading state on table when fetching data', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({
-      data: [],
+      data: { count: 0, results: [] },
       isLoading: true,
     });
     render(<RenderWithRouter />);

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from '@openedx/frontend-base';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DateExtensionsPage from './DateExtensionsPage';
+import { useDateExtensions } from '../data/apiHook';
+
+jest.mock('../data/apiHook', () => ({
+  useDateExtensions: jest.fn(),
+}));
+
+const mockDateExtensions = [
+  {
+    id: 1,
+    username: 'edByun',
+    fullname: 'Ed Byun',
+    email: 'ed.byun@example.com',
+    graded_subsection: 'Three body diagrams',
+    extended_due_date: '2026-07-15'
+  },
+];
+
+describe('DateExtensionsPage', () => {
+  beforeEach(() => {
+    (useDateExtensions as jest.Mock).mockReturnValue({
+      data: mockDateExtensions,
+      isLoading: false,
+    });
+  });
+
+  const RenderWithRouter = () => (
+    <IntlProvider messages={{}}>
+      <MemoryRouter initialEntries={['/course-v1:edX+DemoX+Demo_Course']}>
+        <Routes>
+          <Route path="/:courseId" element={<DateExtensionsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </IntlProvider>
+  );
+
+  it('renders page title', () => {
+    render(<RenderWithRouter />);
+    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+  });
+
+  it('renders add extension button', () => {
+    render(<RenderWithRouter />);
+    expect(screen.getByRole('button', { name: /add individual extension/i })).toBeInTheDocument();
+  });
+
+  it('renders date extensions list', () => {
+    render(<RenderWithRouter />);
+    expect(screen.getByText('Ed Byun')).toBeInTheDocument();
+    expect(screen.getByText('Three body diagrams')).toBeInTheDocument();
+  });
+
+  it('shows loading state on table when fetching data', () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+    });
+    render(<RenderWithRouter />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -12,10 +12,10 @@ const mockDateExtensions = [
   {
     id: 1,
     username: 'edByun',
-    fullname: 'Ed Byun',
+    fullName: 'Ed Byun',
     email: 'ed.byun@example.com',
-    graded_subsection: 'Three body diagrams',
-    extended_due_date: '2026-07-15'
+    unitTitle: 'Three body diagrams',
+    extendedDueDate: '2026-07-15'
   },
 ];
 

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@openedx/frontend-base';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import DateExtensionsPage from './DateExtensionsPage';
-import { useDateExtensions } from '../data/apiHook';
+import { useDateExtensions } from './data/apiHook';
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('./data/apiHook', () => ({
   useDateExtensions: jest.fn(),
 }));
 

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -5,14 +5,34 @@ import { Button, Container } from '@openedx/paragon';
 import { useDateExtensions } from './data/apiHook';
 import { useParams } from 'react-router-dom';
 
-const mockDateExtensions = [
-  { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
-];
+// For testing purposes, will be deleted once backend is ready
+// const mockDateExtensions = [
+//   { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
+// ];
+
+export interface User {
+  id: number,
+  username: string,
+  fullname: string,
+  email: string,
+  graded_subsection: string,
+  extended_due_date: string,
+}
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
   const { courseId } = useParams();
-  const { data, isLoading } = useDateExtensions(courseId ?? '');
+  const { data = [], isLoading } = useDateExtensions(courseId ?? '');
+
+  const handleResetExtensions = (user: User) => {
+    // Implementation for resetting extensions will go here
+    console.log(user);
+  };
+
+  const tableData = data.map(item => ({
+    ...item,
+    reset: <Button variant="link" size="inline" onClick={() => handleResetExtensions(item)}>Reset Extensions</Button>,
+  }));
 
   return (
     <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
@@ -21,7 +41,7 @@ const DateExtensionsPage = () => {
         <p>filters</p>
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
-      <DateExtensionsList data={data ?? mockDateExtensions} isLoading={isLoading} />
+      <DateExtensionsList data={tableData} isLoading={isLoading} />
     </Container>
   );
 };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -2,37 +2,17 @@ import { useIntl } from '@openedx/frontend-base';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import { Button, Container } from '@openedx/paragon';
-import { useDateExtensions } from './data/apiHook';
-import { useParams } from 'react-router-dom';
+import { LearnerDateExtension } from './types';
 
-// For testing purposes, will be deleted once backend is ready
-// const mockDateExtensions = [
-//   { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
-// ];
-
-export interface User {
-  id: number,
-  username: string,
-  fullname: string,
-  email: string,
-  graded_subsection: string,
-  extended_due_date: string,
-}
+// const successMessage = 'Successfully reset due date for student Phu Nguyen for A subsection with two units (block-v1:SchemaAximWGU+WGU101+1+type@sequential+block@3984030755104708a86592cf23fb1ae4) to 2025-08-21 00:00';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
-  const { courseId } = useParams();
-  const { data = [], isLoading } = useDateExtensions(courseId ?? '');
 
-  const handleResetExtensions = (user: User) => {
+  const handleResetExtensions = (user: LearnerDateExtension) => {
     // Implementation for resetting extensions will go here
     console.log(user);
   };
-
-  const tableData = data.map(item => ({
-    ...item,
-    reset: <Button variant="link" size="inline" onClick={() => handleResetExtensions(item)}>Reset Extensions</Button>,
-  }));
 
   return (
     <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
@@ -41,7 +21,7 @@ const DateExtensionsPage = () => {
         <p>filters</p>
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
-      <DateExtensionsList data={tableData} isLoading={isLoading} />
+      <DateExtensionsList onResetExtensions={handleResetExtensions} />
     </Container>
   );
 };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,0 +1,20 @@
+import { useIntl } from '@openedx/frontend-base';
+import messages from './messages';
+import DateExtensionsList from './components/DateExtensionsList';
+import { Button } from '@openedx/paragon';
+
+const DateExtensionsPage = () => {
+  const intl = useIntl();
+  return (
+    <div>
+      <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
+      <div className="d-flex align-items-center justify-content-between">
+        <p>filters</p>
+        <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
+      </div>
+      <DateExtensionsList />
+    </div>
+  );
+};
+
+export default DateExtensionsPage;

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from '@openedx/frontend-base';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
-import { Button, Container } from '@openedx/paragon';
+import { Button } from '@openedx/paragon';
 import { LearnerDateExtension } from './types';
 
 // const successMessage = 'Successfully reset due date for student Phu Nguyen for A subsection with two units (block-v1:SchemaAximWGU+WGU101+1+type@sequential+block@3984030755104708a86592cf23fb1ae4) to 2025-08-21 00:00';
@@ -15,14 +15,14 @@ const DateExtensionsPage = () => {
   };
 
   return (
-    <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
+    <div className="mt-4.5 mb-4 mx-4">
       <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
       <div className="d-flex align-items-center justify-content-between mb-3.5">
         <p>filters</p>
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
       <DateExtensionsList onResetExtensions={handleResetExtensions} />
-    </Container>
+    </div>
   );
 };
 

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -2,9 +2,18 @@ import { useIntl } from '@openedx/frontend-base';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import { Button } from '@openedx/paragon';
+import { useDateExtensions } from './data/apiHook';
+import { useParams } from 'react-router-dom';
+
+const mockDateExtensions = [
+  { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
+];
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
+  const { courseId } = useParams();
+  const { data, isLoading } = useDateExtensions(courseId ?? '');
+
   return (
     <div>
       <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
@@ -12,7 +21,7 @@ const DateExtensionsPage = () => {
         <p>filters</p>
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
-      <DateExtensionsList />
+      <DateExtensionsList data={data ?? mockDateExtensions} isLoading={isLoading} />
     </div>
   );
 };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from '@openedx/frontend-base';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
-import { Button } from '@openedx/paragon';
+import { Button, Container } from '@openedx/paragon';
 import { useDateExtensions } from './data/apiHook';
 import { useParams } from 'react-router-dom';
 
@@ -15,14 +15,14 @@ const DateExtensionsPage = () => {
   const { data, isLoading } = useDateExtensions(courseId ?? '');
 
   return (
-    <div>
+    <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
       <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
-      <div className="d-flex align-items-center justify-content-between">
+      <div className="d-flex align-items-center justify-content-between mb-3.5">
         <p>filters</p>
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
       <DateExtensionsList data={data ?? mockDateExtensions} isLoading={isLoading} />
-    </div>
+    </Container>
   );
 };
 

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -32,12 +32,6 @@ describe('DateExtensionsList', () => {
     expect(screen.getByText('2024-01-01')).toBeInTheDocument();
   });
 
-  it('renders reset link for each row', () => {
-    renderComponent({ data: mockData });
-    const resetLinks = screen.getAllByRole('link', { name: 'Reset Extensions' });
-    expect(resetLinks).toHaveLength(mockData.length);
-  });
-
   it('renders empty table when no data provided', () => {
     renderComponent({ data: [] });
     expect(screen.queryByText('test_user')).not.toBeInTheDocument();

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import DateExtensionsList, { DateExtensionListProps } from './DateExtensionsList';
+import { renderWithIntl } from '../../testUtils';
+
+const mockData = [
+  {
+    id: 1,
+    username: 'test_user',
+    fullname: 'Test User',
+    email: 'test@example.com',
+    graded_subsection: 'Test Section',
+    extended_due_date: '2024-01-01'
+  }
+];
+
+describe('DateExtensionsList', () => {
+  const renderComponent = (props: DateExtensionListProps) => renderWithIntl(
+    <DateExtensionsList {...props} />
+  );
+
+  it('renders loading state on the table', () => {
+    renderComponent({ data: [], isLoading: true });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders table with data', () => {
+    renderComponent({ data: mockData });
+    expect(screen.getByText('test_user')).toBeInTheDocument();
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.getByText('2024-01-01')).toBeInTheDocument();
+  });
+
+  it('renders reset link for each row', () => {
+    renderComponent({ data: mockData });
+    const resetLinks = screen.getAllByRole('link', { name: 'Reset Extensions' });
+    expect(resetLinks).toHaveLength(mockData.length);
+  });
+
+  it('renders empty table when no data provided', () => {
+    renderComponent({ data: [] });
+    expect(screen.queryByText('test_user')).not.toBeInTheDocument();
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+});

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -8,10 +8,10 @@ const mockData = [
   {
     id: 1,
     username: 'test_user',
-    fullname: 'Test User',
+    fullName: 'Test User',
     email: 'test@example.com',
-    graded_subsection: 'Test Section',
-    extended_due_date: '2024-01-01'
+    unitTitle: 'Test Section',
+    extendedDueDate: '2024-01-01'
   }
 ];
 

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DateExtensionsList, { DateExtensionListProps } from './DateExtensionsList';
 import { renderWithIntl } from '../../testUtils';
-import { useDateExtensions } from '../../data/apiHook';
+import { useDateExtensions } from '../data/apiHook';
 
 const mockData = [
   {
@@ -15,7 +15,7 @@ const mockData = [
   }
 ];
 
-jest.mock('../../data/apiHook', () => ({
+jest.mock('../data/apiHook', () => ({
   useDateExtensions: jest.fn(),
 }));
 

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DateExtensionsList, { DateExtensionListProps } from './DateExtensionsList';
 import { renderWithIntl } from '../../testUtils';
+import { useDateExtensions } from '../../data/apiHook';
 
 const mockData = [
   {
@@ -13,27 +15,41 @@ const mockData = [
   }
 ];
 
+jest.mock('../../data/apiHook', () => ({
+  useDateExtensions: jest.fn(),
+}));
+
+const mockResetExtensions = jest.fn();
+
 describe('DateExtensionsList', () => {
   const renderComponent = (props: DateExtensionListProps) => renderWithIntl(
     <DateExtensionsList {...props} />
   );
 
   it('renders loading state on the table', () => {
-    renderComponent({ data: [], isLoading: true });
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: true, data: { count: 0, results: [] } });
+    renderComponent({});
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('renders table with data', () => {
-    renderComponent({ data: mockData });
+  it('renders table with data', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: mockData.length, results: mockData } });
+    renderComponent({ onResetExtensions: mockResetExtensions });
+    const user = userEvent.setup();
     expect(screen.getByText('test_user')).toBeInTheDocument();
     expect(screen.getByText('Test User')).toBeInTheDocument();
     expect(screen.getByText('test@example.com')).toBeInTheDocument();
     expect(screen.getByText('Test Section')).toBeInTheDocument();
     expect(screen.getByText('2024-01-01')).toBeInTheDocument();
+    const resetExtensions = screen.getByRole('button', { name: /reset extensions/i });
+    expect(resetExtensions).toBeInTheDocument();
+    await user.click(resetExtensions);
+    expect(mockResetExtensions).toHaveBeenCalledWith(mockData[0]);
   });
 
   it('renders empty table when no data provided', () => {
-    renderComponent({ data: [] });
+    (useDateExtensions as jest.Mock).mockReturnValue({ data: { count: 0, results: [] } });
+    renderComponent({});
     expect(screen.queryByText('test_user')).not.toBeInTheDocument();
     expect(screen.getByText('No results found')).toBeInTheDocument();
   });

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -2,7 +2,7 @@ import { useIntl } from '@openedx/frontend-base';
 import { Button, DataTable } from '@openedx/paragon';
 import messages from '../messages';
 import { LearnerDateExtension } from '../types';
-import { useDateExtensions } from '../../data/apiHook';
+import { useDateExtensions } from '../data/apiHook';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 
@@ -12,7 +12,7 @@ import { useState } from 'react';
 //   { id: 2, username: 'dianaSalas', fullname: 'Diana Villalvazo', email: 'diana.villalvazo@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
 // ];
 
-export const DATE_EXTENSIONS_PAGE_SIZE = 25;
+const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
 export interface DateExtensionListProps {
   onResetExtensions?: (user: LearnerDateExtension) => void,

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -1,18 +1,12 @@
 import { useIntl } from '@openedx/frontend-base';
 import { DataTable } from '@openedx/paragon';
 import messages from '../messages';
+import { User } from '../DateExtensionsPage';
 
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
 export interface DateExtensionListProps {
-  data: {
-    id: number,
-    username: string,
-    fullname: string,
-    email: string,
-    graded_subsection: string,
-    extended_due_date: string,
-  }[],
+  data: User[],
   isLoading?: boolean,
 }
 
@@ -33,14 +27,7 @@ const DateExtensionsList = ({
 
   const totalItemCount = 25;
 
-  const tableData = data.map(item => ({
-    ...item,
-    reset: <a href="/">Reset Extensions</a>,
-  }));
-
-  return (
-    <DataTable columns={tableColumns} data={tableData} isPaginated itemCount={totalItemCount} pageSize={DATE_EXTENSIONS_PAGE_SIZE} isLoading={isLoading} />
-  );
+  return <DataTable columns={tableColumns} data={data} isPaginated itemCount={totalItemCount} pageSize={DATE_EXTENSIONS_PAGE_SIZE} isLoading={isLoading} />;
 };
 
 export default DateExtensionsList;

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -4,7 +4,7 @@ import messages from '../messages';
 
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
-interface DateExtensionListProps {
+export interface DateExtensionListProps {
   data: {
     id: number,
     username: string,
@@ -13,7 +13,7 @@ interface DateExtensionListProps {
     graded_subsection: string,
     extended_due_date: string,
   }[],
-  isLoading: boolean,
+  isLoading?: boolean,
 }
 
 const DateExtensionsList = ({

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -1,0 +1,29 @@
+import { useIntl } from '@openedx/frontend-base';
+import { DataTable } from '@openedx/paragon';
+import messages from '../messages';
+
+const mockDateExtensions = [
+  { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15', reset: <a href="/">Reset Extensions</a> },
+];
+
+const DATE_EXTENSIONS_PAGE_SIZE = 25;
+
+const DateExtensionsList = () => {
+  const intl = useIntl();
+
+  const tableColumns = [
+    { accessor: 'username', Header: intl.formatMessage(messages.username) },
+    { accessor: 'fullname', Header: intl.formatMessage(messages.fullname) },
+    { accessor: 'email', Header: intl.formatMessage(messages.email) },
+    { accessor: 'graded_subsection', Header: intl.formatMessage(messages.graded_subsection) },
+    { accessor: 'extended_due_date', Header: intl.formatMessage(messages.extended_due_date) },
+    { accessor: 'reset', Header: intl.formatMessage(messages.reset) },
+  ];
+
+  const totalItemCount = 25;
+  return (
+    <DataTable columns={tableColumns} data={mockDateExtensions} isPaginated itemCount={totalItemCount} pageSize={DATE_EXTENSIONS_PAGE_SIZE} />
+  );
+};
+
+export default DateExtensionsList;

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -6,12 +6,6 @@ import { useDateExtensions } from '../data/apiHook';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 
-// For testing purposes, will be deleted once backend is ready
-// const mockDateExtensions = [
-//   { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
-//   { id: 2, username: 'dianaSalas', fullname: 'Diana Villalvazo', email: 'diana.villalvazo@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15' },
-// ];
-
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
 export interface DateExtensionListProps {
@@ -37,17 +31,25 @@ const DateExtensionsList = ({
 
   const tableColumns = [
     { accessor: 'username', Header: intl.formatMessage(messages.username) },
-    { accessor: 'fullname', Header: intl.formatMessage(messages.fullname) },
+    { accessor: 'fullName', Header: intl.formatMessage(messages.fullname) },
     { accessor: 'email', Header: intl.formatMessage(messages.email) },
-    { accessor: 'graded_subsection', Header: intl.formatMessage(messages.gradedSubsection) },
-    { accessor: 'extended_due_date', Header: intl.formatMessage(messages.extendedDueDate) },
-    { accessor: 'reset', Header: intl.formatMessage(messages.reset) },
+    { accessor: 'unitTitle', Header: intl.formatMessage(messages.gradedSubsection) },
+    { accessor: 'extendedDueDate', Header: intl.formatMessage(messages.extendedDueDate) },
   ];
 
-  const tableData = data.results.map(item => ({
-    ...item,
-    reset: <Button variant="link" size="inline" onClick={() => onResetExtensions(item)}>Reset Extensions</Button>,
-  }));
+  const additionalColumns = [{
+    id: 'reset',
+    Header: intl.formatMessage(messages.reset),
+    Cell: ({ row }: { row: { original: LearnerDateExtension } }) => (
+      <Button
+        variant="link"
+        size="inline"
+        onClick={() => onResetExtensions(row.original)}
+      >
+        {intl.formatMessage(messages.resetExtensions)}
+      </Button>
+    )
+  }];
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
     setPage(data.pageIndex);
@@ -56,7 +58,8 @@ const DateExtensionsList = ({
   return (
     <DataTable
       columns={tableColumns}
-      data={tableData}
+      additionalColumns={additionalColumns}
+      data={data.results}
       fetchData={handleFetchData}
       initialState={{
         pageIndex: page,

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -2,13 +2,24 @@ import { useIntl } from '@openedx/frontend-base';
 import { DataTable } from '@openedx/paragon';
 import messages from '../messages';
 
-const mockDateExtensions = [
-  { id: 1, username: 'edByun', fullname: 'Ed Byun', email: 'ed.byun@example.com', graded_subsection: 'Three body diagrams', extended_due_date: '2026-07-15', reset: <a href="/">Reset Extensions</a> },
-];
-
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
-const DateExtensionsList = () => {
+interface DateExtensionListProps {
+  data: {
+    id: number,
+    username: string,
+    fullname: string,
+    email: string,
+    graded_subsection: string,
+    extended_due_date: string,
+  }[],
+  isLoading: boolean,
+}
+
+const DateExtensionsList = ({
+  data = [],
+  isLoading = false,
+}: DateExtensionListProps) => {
   const intl = useIntl();
 
   const tableColumns = [
@@ -21,8 +32,14 @@ const DateExtensionsList = () => {
   ];
 
   const totalItemCount = 25;
+
+  const tableData = data.map(item => ({
+    ...item,
+    reset: <a href="/">Reset Extensions</a>,
+  }));
+
   return (
-    <DataTable columns={tableColumns} data={mockDateExtensions} isPaginated itemCount={totalItemCount} pageSize={DATE_EXTENSIONS_PAGE_SIZE} />
+    <DataTable columns={tableColumns} data={tableData} isPaginated itemCount={totalItemCount} pageSize={DATE_EXTENSIONS_PAGE_SIZE} isLoading={isLoading} />
   );
 };
 

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -39,8 +39,8 @@ const DateExtensionsList = ({
     { accessor: 'username', Header: intl.formatMessage(messages.username) },
     { accessor: 'fullname', Header: intl.formatMessage(messages.fullname) },
     { accessor: 'email', Header: intl.formatMessage(messages.email) },
-    { accessor: 'graded_subsection', Header: intl.formatMessage(messages.graded_subsection) },
-    { accessor: 'extended_due_date', Header: intl.formatMessage(messages.extended_due_date) },
+    { accessor: 'graded_subsection', Header: intl.formatMessage(messages.gradedSubsection) },
+    { accessor: 'extended_due_date', Header: intl.formatMessage(messages.extendedDueDate) },
     { accessor: 'reset', Header: intl.formatMessage(messages.reset) },
   ];
 

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -1,7 +1,18 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
+import { DateExtensionsResponse } from '../types';
 
-export const getDateExtensions = async (courseId) => {
-  const { data } = await getAuthenticatedHttpClient().get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions`);
+export interface PaginationQueryKeys {
+  page: number,
+  pageSize: number,
+}
+
+export const getDateExtensions = async (
+  courseId: string,
+  pagination: PaginationQueryKeys
+): Promise<DateExtensionsResponse> => {
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions/?page=${pagination.page}&page_size=${pagination.pageSize}`
+  );
   return camelCaseObject(data);
 };

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -2,6 +2,6 @@ import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-b
 import { getApiBaseUrl } from '../../data/api';
 
 export const getDateExtensions = async (courseId) => {
-  const { data } = await getAuthenticatedHttpClient().get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/date-extensions`);
+  const { data } = await getAuthenticatedHttpClient().get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions`);
   return camelCaseObject(data);
 };

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -12,7 +12,7 @@ export const getDateExtensions = async (
   pagination: PaginationQueryKeys
 ): Promise<DateExtensionsResponse> => {
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions/?page=${pagination.page}&page_size=${pagination.pageSize}`
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions?page=${pagination.page + 1}&page_size=${pagination.pageSize}`
   );
   return camelCaseObject(data);
 };

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -1,0 +1,7 @@
+import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { getApiBaseUrl } from '../../data/api';
+
+export const getDateExtensions = async (courseId) => {
+  const { data } = await getAuthenticatedHttpClient().get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/date-extensions`);
+  return camelCaseObject(data);
+};

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { getDateExtensions } from './api';
+import { getDateExtensions, PaginationQueryKeys } from './api';
 import { dateExtensionsQueryKeys } from './queryKeys';
 
-export const useDateExtensions = (courseId: string) => (
+export const useDateExtensions = (courseId: string, pagination: PaginationQueryKeys) => (
   useQuery({
     queryKey: dateExtensionsQueryKeys.byCourse(courseId),
-    queryFn: () => getDateExtensions(courseId),
+    queryFn: () => getDateExtensions(courseId, pagination),
   })
 );

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDateExtensions } from './api';
+import { dateExtensionsQueryKeys } from './queryKeys';
+
+export const useDateExtensions = (courseId: string) => (
+  useQuery({
+    queryKey: dateExtensionsQueryKeys.byCourse(courseId),
+    queryFn: () => getDateExtensions(courseId),
+  })
+);

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -4,7 +4,7 @@ import { dateExtensionsQueryKeys } from './queryKeys';
 
 export const useDateExtensions = (courseId: string, pagination: PaginationQueryKeys) => (
   useQuery({
-    queryKey: dateExtensionsQueryKeys.byCourse(courseId),
+    queryKey: dateExtensionsQueryKeys.byCoursePaginated(courseId, pagination),
     queryFn: () => getDateExtensions(courseId, pagination),
   })
 );

--- a/src/dateExtensions/data/queryKeys.ts
+++ b/src/dateExtensions/data/queryKeys.ts
@@ -1,0 +1,6 @@
+import { appId } from '../../constants';
+
+export const dateExtensionsQueryKeys = {
+  all: [appId, 'dateExtensions'] as const,
+  byCourse: (courseId: string) => [appId, 'dateExtensions', courseId] as const,
+};

--- a/src/dateExtensions/data/queryKeys.ts
+++ b/src/dateExtensions/data/queryKeys.ts
@@ -1,6 +1,8 @@
 import { appId } from '../../constants';
+import { PaginationQueryKeys } from './api';
 
 export const dateExtensionsQueryKeys = {
   all: [appId, 'dateExtensions'] as const,
-  byCourse: (courseId: string) => [appId, 'dateExtensions', courseId] as const,
+  byCourse: (courseId: string) => [...dateExtensionsQueryKeys.all, courseId] as const,
+  byCoursePaginated: (courseId: string, pagination: PaginationQueryKeys) => [...dateExtensionsQueryKeys.byCourse(courseId), pagination.page] as const,
 };

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -41,6 +41,11 @@ const messages = defineMessages({
     defaultMessage: 'Reset',
     description: 'Label for the reset column in the date extensions table',
   },
+  resetExtensions: {
+    id: 'instruct.dateExtensions.page.button.resetExtensions',
+    defaultMessage: 'Reset Extensions',
+    description: 'Button text for resetting date extensions for a user',
+  }
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -1,0 +1,46 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+  dateExtensionsTitle: {
+    id: 'instruct.dateExtensions.page.title',
+    defaultMessage: 'Viewing Granted Extensions',
+    description: 'Title for date extensions page',
+  },
+  addIndividualExtension: {
+    id: 'instruct.dateExtensions.page.addIndividualExtension',
+    defaultMessage: 'Add Individual Extension',
+    description: 'Button text for adding an individual date extension',
+  },
+  username: {
+    id: 'instruct.dateExtensions.page.tableHeader.username',
+    defaultMessage: 'User Name',
+    description: 'Label for the user name column in the date extensions table',
+  },
+  fullname: {
+    id: 'instruct.dateExtensions.page.tableHeader.fullname',
+    defaultMessage: 'Full Name',
+    description: 'Label for the full name column in the date extensions table',
+  },
+  email: {
+    id: 'instruct.dateExtensions.page.tableHeader.email',
+    defaultMessage: 'Email',
+    description: 'Label for the email column in the date extensions table',
+  },
+  graded_subsection: {
+    id: 'instruct.dateExtensions.page.tableHeader.graded_subsection',
+    defaultMessage: 'Graded Subsection',
+    description: 'Label for the graded subsection column in the date extensions table',
+  },
+  extended_due_date: {
+    id: 'instruct.dateExtensions.page.tableHeader.extended_due_date',
+    defaultMessage: 'Extended Due Date',
+    description: 'Label for the extended due date column in the date extensions table',
+  },
+  reset: {
+    id: 'instruct.dateExtensions.page.tableHeader.reset',
+    defaultMessage: 'Reset',
+    description: 'Label for the reset column in the date extensions table',
+  },
+});
+
+export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -26,13 +26,13 @@ const messages = defineMessages({
     defaultMessage: 'Email',
     description: 'Label for the email column in the date extensions table',
   },
-  graded_subsection: {
-    id: 'instruct.dateExtensions.page.tableHeader.graded_subsection',
+  gradedSubsection: {
+    id: 'instruct.dateExtensions.page.tableHeader.gradedSubsection',
     defaultMessage: 'Graded Subsection',
     description: 'Label for the graded subsection column in the date extensions table',
   },
-  extended_due_date: {
-    id: 'instruct.dateExtensions.page.tableHeader.extended_due_date',
+  extendedDueDate: {
+    id: 'instruct.dateExtensions.page.tableHeader.extendedDueDate',
     defaultMessage: 'Extended Due Date',
     description: 'Label for the extended due date column in the date extensions table',
   },

--- a/src/dateExtensions/types.ts
+++ b/src/dateExtensions/types.ts
@@ -1,0 +1,15 @@
+export interface LearnerDateExtension {
+  id: number,
+  username: string,
+  fullname: string,
+  email: string,
+  graded_subsection: string,
+  extended_due_date: string,
+}
+
+export interface DateExtensionsResponse {
+  count: number,
+  next: string | null,
+  previous: string | null,
+  results: LearnerDateExtension[],
+}

--- a/src/dateExtensions/types.ts
+++ b/src/dateExtensions/types.ts
@@ -1,10 +1,10 @@
 export interface LearnerDateExtension {
   id: number,
   username: string,
-  fullname: string,
+  fullName: string,
   email: string,
-  graded_subsection: string,
-  extended_due_date: string,
+  unitTitle: string,
+  extendedDueDate: string,
 }
 
 export interface DateExtensionsResponse {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,7 +26,7 @@ const routes = [
         element: <CohortsPage />
       },
       {
-        path: '/:courseId/date_extensions',
+        path: '/date_extensions',
         element: <DateExtensionsPage />
       },
       // {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,7 +26,7 @@ const routes = [
         element: <CohortsPage />
       },
       {
-        path: '/date_extensions',
+        path: 'date_extensions',
         element: <DateExtensionsPage />
       },
       // {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,7 +26,7 @@ const routes = [
         element: <CohortsPage />
       },
       {
-        path: 'date_extensions',
+        path: '/:courseId/date_extensions',
         element: <DateExtensionsPage />
       },
       // {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,6 @@
 import CohortsPage from '@src/cohorts/CohortsPage';
 import CourseInfoPage from '@src/courseInfo/CourseInfoPage';
+import DateExtensionsPage from '@src/dateExtensions/DateExtensionsPage';
 import OpenResponsesPage from '@src/openResponses/OpenResponsesPage';
 import Main from '@src/Main';
 
@@ -24,10 +25,10 @@ const routes = [
         path: 'cohorts',
         element: <CohortsPage />
       },
-      // {
-      //   path: 'extensions',
-      //   element: <ExtensionsPage />
-      // },
+      {
+        path: 'date_extensions',
+        element: <DateExtensionsPage />
+      },
       // {
       //   path: 'student_admin',
       //   element: <StudentAdminPage />


### PR DESCRIPTION
### Description
It covers the first and fourth point of the acceptance criteria for https://github.com/openedx/frontend-app-instruct/issues/30

A table lists all granted extensions with the following columns:
- User Name
- Full Name
- Email
- Graded Subsection
- Extended Due Date
- Reset Action
The list supports pagination with 25 per page.

### Screenshot
<img width="1548" height="898" alt="Screenshot 2025-11-05 at 5 11 28 p m" src="https://github.com/user-attachments/assets/118e8b44-aac2-4365-a6a3-d91d370859d5" />

Link to test when MFE is running: http://apps.local.openedx.io:8081/instructor/course-v1:OpenedX+DemoX+DemoCourse/date_extensions

#### Support Information
Closes #56 