### PR TITLE
Date extensions Action buttons

### DIFF
--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@openedx/frontend-base';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import DateExtensionsPage from './DateExtensionsPage';
-import { useDateExtensions } from './data/apiHook';
+import { useDateExtensions, useResetDateExtensionMutation } from './data/apiHook';
 
 jest.mock('./data/apiHook', () => ({
   useDateExtensions: jest.fn(),
+  useResetDateExtensionMutation: jest.fn(),
 }));
 
 const mockDateExtensions = [
@@ -19,11 +21,16 @@ const mockDateExtensions = [
   },
 ];
 
+const mutateMock = jest.fn();
+
 describe('DateExtensionsPage', () => {
   beforeEach(() => {
     (useDateExtensions as jest.Mock).mockReturnValue({
       data: { count: mockDateExtensions.length, results: mockDateExtensions },
       isLoading: false,
+    });
+    (useResetDateExtensionMutation as jest.Mock).mockReturnValue({
+      mutate: mutateMock,
     });
   });
 
@@ -66,5 +73,36 @@ describe('DateExtensionsPage', () => {
     render(<RenderWithRouter />);
     const resetLinks = screen.getAllByRole('button', { name: 'Reset Extensions' });
     expect(resetLinks).toHaveLength(mockDateExtensions.length);
+  });
+
+  it('opens reset modal when reset button is clicked', async () => {
+    render(<RenderWithRouter />);
+    const user = userEvent.setup();
+    const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
+    await user.click(resetButton);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/reset extensions for/i)).toBeInTheDocument();
+    const confirmButton = screen.getByRole('button', { name: /reset due date/i });
+    expect(confirmButton).toBeInTheDocument();
+  });
+
+  it('calls reset mutation when confirm reset is clicked', async () => {
+    render(<RenderWithRouter />);
+    const user = userEvent.setup();
+    const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
+    await user.click(resetButton);
+    const confirmButton = screen.getByRole('button', { name: /reset due date/i });
+    await user.click(confirmButton);
+    expect(mutateMock).toHaveBeenCalled();
+  });
+
+  it('closes reset modal when cancel is clicked', async () => {
+    render(<RenderWithRouter />);
+    const user = userEvent.setup();
+    const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
+    await user.click(resetButton);
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await user.click(cancelButton);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -1,9 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { IntlProvider } from '@openedx/frontend-base';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import DateExtensionsPage from './DateExtensionsPage';
 import { useDateExtensions, useResetDateExtensionMutation } from './data/apiHook';
+import { renderWithAlertAndIntl } from '@src/testUtils';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    courseId: 'course-v1:edX+DemoX+Demo_Course',
+  }),
+}));
 
 jest.mock('./data/apiHook', () => ({
   useDateExtensions: jest.fn(),
@@ -34,28 +40,18 @@ describe('DateExtensionsPage', () => {
     });
   });
 
-  const RenderWithRouter = () => (
-    <IntlProvider messages={{}}>
-      <MemoryRouter initialEntries={['/course-v1:edX+DemoX+Demo_Course']}>
-        <Routes>
-          <Route path="/:courseId" element={<DateExtensionsPage />} />
-        </Routes>
-      </MemoryRouter>
-    </IntlProvider>
-  );
-
   it('renders page title', () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
   });
 
   it('renders add extension button', () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     expect(screen.getByRole('button', { name: /add individual extension/i })).toBeInTheDocument();
   });
 
   it('renders date extensions list', () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     expect(screen.getByText('Ed Byun')).toBeInTheDocument();
     expect(screen.getByText('Three body diagrams')).toBeInTheDocument();
   });
@@ -65,18 +61,18 @@ describe('DateExtensionsPage', () => {
       data: { count: 0, results: [] },
       isLoading: true,
     });
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders reset link for each row', () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     const resetLinks = screen.getAllByRole('button', { name: 'Reset Extensions' });
     expect(resetLinks).toHaveLength(mockDateExtensions.length);
   });
 
   it('opens reset modal when reset button is clicked', async () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     const user = userEvent.setup();
     const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
     await user.click(resetButton);
@@ -87,7 +83,7 @@ describe('DateExtensionsPage', () => {
   });
 
   it('calls reset mutation when confirm reset is clicked', async () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     const user = userEvent.setup();
     const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
     await user.click(resetButton);
@@ -97,7 +93,7 @@ describe('DateExtensionsPage', () => {
   });
 
   it('closes reset modal when cancel is clicked', async () => {
-    render(<RenderWithRouter />);
+    renderWithAlertAndIntl(<DateExtensionsPage />);
     const user = userEvent.setup();
     const resetButton = screen.getByRole('button', { name: 'Reset Extensions' });
     await user.click(resetButton);

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -14,18 +14,18 @@ const DateExtensionsPage = () => {
   const intl = useIntl();
   const { courseId } = useParams<{ courseId: string }>();
   const { mutate: resetMutation } = useResetDateExtensionMutation();
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<LearnerDateExtension | null>(null);
   const [successMessage, setSuccessMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
-    setIsModalOpen(true);
+    setIsResetModalOpen(true);
     setSelectedUser(user);
   };
 
   const handleCloseModal = () => {
-    setIsModalOpen(false);
+    setIsResetModalOpen(false);
     setSelectedUser(null);
   };
 
@@ -60,7 +60,7 @@ const DateExtensionsPage = () => {
       </div>
       <DateExtensionsList onResetExtensions={handleResetExtensions} />
       <ResetExtensionsModal
-        isOpen={isModalOpen}
+        isOpen={isResetModalOpen}
         message={intl.formatMessage(messages.resetConfirmationMessage)}
         title={intl.formatMessage(messages.resetConfirmationHeader, { username: selectedUser?.username })}
         onCancelReset={handleCloseModal}
@@ -70,7 +70,7 @@ const DateExtensionsPage = () => {
       <Toast show={!!successMessage} onClose={() => {}} className="text-break">
         {successMessage}
       </Toast>
-      <AlertModal isOpen={!!errorMessage} footerNode={<Button onClick={() => setErrorMessage('')}>{intl.formatMessage(messages.close)}</Button>}>
+      <AlertModal title={errorMessage} isOpen={!!errorMessage} footerNode={<Button onClick={() => setErrorMessage('')}>{intl.formatMessage(messages.close)}</Button>}>
         {errorMessage}
       </AlertModal>
     </div>

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -13,22 +13,20 @@ const DateExtensionsPage = () => {
   const intl = useIntl();
   const { courseId } = useParams<{ courseId: string }>();
   const { mutate: resetMutation } = useResetDateExtensionMutation();
-  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<LearnerDateExtension | null>(null);
+  const isResetModalOpen = selectedUser !== null;
   const { showToast, showModal, removeAlert, clearAlerts } = useAlert();
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
     clearAlerts();
-    setIsResetModalOpen(true);
     setSelectedUser(user);
   };
 
   const handleCloseModal = () => {
-    setIsResetModalOpen(false);
     setSelectedUser(null);
   };
 
-  const handleErrorOnReset = (error: any) => {
+  const handleErrorOnReset = (error: Error) => {
     showModal({
       confirmText: intl.formatMessage(messages.close),
       message: error.message,
@@ -53,6 +51,13 @@ const DateExtensionsPage = () => {
       }, {
         onError: handleErrorOnReset,
         onSuccess: handleSuccessOnReset
+      });
+    } else {
+      showModal({
+        confirmText: intl.formatMessage(messages.close),
+        message: intl.formatMessage(messages.missingUserOrCourseIdError),
+        variant: 'danger',
+        onConfirm: (id) => removeAlert(id)
       });
     }
   };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,17 +1,35 @@
+import { useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
+import { Button } from '@openedx/paragon';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
-import { Button } from '@openedx/paragon';
+import ResetExtensionsModal from './components/ResetExtensionsModal';
 import { LearnerDateExtension } from './types';
 
 // const successMessage = 'Successfully reset due date for student Phu Nguyen for A subsection with two units (block-v1:SchemaAximWGU+WGU101+1+type@sequential+block@3984030755104708a86592cf23fb1ae4) to 2025-08-21 00:00';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<LearnerDateExtension | null>(null);
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
-    // Implementation for resetting extensions will go here
-    console.log(user);
+    setIsModalOpen(true);
+    setSelectedUser(user);
+  };
+
+  const handleConfirmReset = () => {
+    if (selectedUser) {
+      // Call the API to reset the extensions for the selected user
+      console.log(`Resetting extensions for user: ${selectedUser.username}`);
+    }
+    setIsModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleCancelReset = () => {
+    setIsModalOpen(false);
+    setSelectedUser(null);
   };
 
   return (
@@ -22,6 +40,14 @@ const DateExtensionsPage = () => {
         <Button>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
       <DateExtensionsList onResetExtensions={handleResetExtensions} />
+      <ResetExtensionsModal
+        isOpen={isModalOpen}
+        message={intl.formatMessage(messages.resetConfirmationMessage)}
+        title={intl.formatMessage(messages.resetConfirmationHeader, { username: selectedUser?.username })}
+        onCancelReset={handleCancelReset}
+        onClose={handleCancelReset}
+        onConfirmReset={handleConfirmReset}
+      />
     </div>
   );
 };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,35 +1,54 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { Button } from '@openedx/paragon';
+import { AlertModal, Button, Toast } from '@openedx/paragon';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import ResetExtensionsModal from './components/ResetExtensionsModal';
 import { LearnerDateExtension } from './types';
+import { useResetDateExtensionMutation } from './data/apiHook';
 
 // const successMessage = 'Successfully reset due date for student Phu Nguyen for A subsection with two units (block-v1:SchemaAximWGU+WGU101+1+type@sequential+block@3984030755104708a86592cf23fb1ae4) to 2025-08-21 00:00';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
+  const { courseId } = useParams<{ courseId: string }>();
+  const { mutate: resetMutation } = useResetDateExtensionMutation();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<LearnerDateExtension | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
     setIsModalOpen(true);
     setSelectedUser(user);
   };
 
-  const handleConfirmReset = () => {
-    if (selectedUser) {
-      // Call the API to reset the extensions for the selected user
-      console.log(`Resetting extensions for user: ${selectedUser.username}`);
-    }
+  const handleCloseModal = () => {
     setIsModalOpen(false);
     setSelectedUser(null);
   };
 
-  const handleCancelReset = () => {
-    setIsModalOpen(false);
-    setSelectedUser(null);
+  const handleErrorOnReset = (error: any) => {
+    setErrorMessage(error.message);
+  };
+
+  const handleSuccessOnReset = (response: any) => {
+    const { message } = response;
+    setSuccessMessage(message);
+    handleCloseModal();
+  };
+
+  const handleConfirmReset = async () => {
+    if (selectedUser && courseId) {
+      resetMutation({
+        courseId,
+        userId: selectedUser.id
+      }, {
+        onError: handleErrorOnReset,
+        onSuccess: handleSuccessOnReset
+      });
+    }
   };
 
   return (
@@ -44,10 +63,16 @@ const DateExtensionsPage = () => {
         isOpen={isModalOpen}
         message={intl.formatMessage(messages.resetConfirmationMessage)}
         title={intl.formatMessage(messages.resetConfirmationHeader, { username: selectedUser?.username })}
-        onCancelReset={handleCancelReset}
-        onClose={handleCancelReset}
+        onCancelReset={handleCloseModal}
+        onClose={handleCloseModal}
         onConfirmReset={handleConfirmReset}
       />
+      <Toast show={!!successMessage} onClose={() => {}} className="text-break">
+        {successMessage}
+      </Toast>
+      <AlertModal isOpen={!!errorMessage} footerNode={<Button onClick={() => setErrorMessage('')}>{intl.formatMessage(messages.close)}</Button>}>
+        {errorMessage}
+      </AlertModal>
     </div>
   );
 };

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -8,8 +8,6 @@ import ResetExtensionsModal from './components/ResetExtensionsModal';
 import { LearnerDateExtension } from './types';
 import { useResetDateExtensionMutation } from './data/apiHook';
 
-// const successMessage = 'Successfully reset due date for student Phu Nguyen for A subsection with two units (block-v1:SchemaAximWGU+WGU101+1+type@sequential+block@3984030755104708a86592cf23fb1ae4) to 2025-08-21 00:00';
-
 const DateExtensionsPage = () => {
   const intl = useIntl();
   const { courseId } = useParams<{ courseId: string }>();
@@ -33,9 +31,8 @@ const DateExtensionsPage = () => {
     setErrorMessage(error.message);
   };
 
-  const handleSuccessOnReset = (response: any) => {
-    const { message } = response;
-    setSuccessMessage(message);
+  const handleSuccessOnReset = (response: string) => {
+    setSuccessMessage(response);
     handleCloseModal();
   };
 
@@ -43,7 +40,10 @@ const DateExtensionsPage = () => {
     if (selectedUser && courseId) {
       resetMutation({
         courseId,
-        userId: selectedUser.id
+        params: {
+          student: selectedUser.username,
+          url: selectedUser.unitLocation,
+        }
       }, {
         onError: handleErrorOnReset,
         onSuccess: handleSuccessOnReset
@@ -67,7 +67,7 @@ const DateExtensionsPage = () => {
         onClose={handleCloseModal}
         onConfirmReset={handleConfirmReset}
       />
-      <Toast show={!!successMessage} onClose={() => {}} className="text-break">
+      <Toast show={!!successMessage} onClose={() => setSuccessMessage('')} className="text-break">
         {successMessage}
       </Toast>
       <AlertModal title={errorMessage} isOpen={!!errorMessage} footerNode={<Button onClick={() => setErrorMessage('')}>{intl.formatMessage(messages.close)}</Button>}>

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { AlertModal, Button, Toast } from '@openedx/paragon';
+import { Button } from '@openedx/paragon';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import ResetExtensionsModal from './components/ResetExtensionsModal';
 import { LearnerDateExtension } from './types';
 import { useResetDateExtensionMutation } from './data/apiHook';
+import { useAlert } from '@src/providers/AlertProvider';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
@@ -14,10 +15,10 @@ const DateExtensionsPage = () => {
   const { mutate: resetMutation } = useResetDateExtensionMutation();
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<LearnerDateExtension | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const { showToast, showModal, removeAlert, clearAlerts } = useAlert();
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
+    clearAlerts();
     setIsResetModalOpen(true);
     setSelectedUser(user);
   };
@@ -28,11 +29,16 @@ const DateExtensionsPage = () => {
   };
 
   const handleErrorOnReset = (error: any) => {
-    setErrorMessage(error.message);
+    showModal({
+      confirmText: intl.formatMessage(messages.close),
+      message: error.message,
+      variant: 'danger',
+      onConfirm: (id) => removeAlert(id)
+    });
   };
 
   const handleSuccessOnReset = (response: string) => {
-    setSuccessMessage(response);
+    showToast(response);
     handleCloseModal();
   };
 
@@ -67,12 +73,6 @@ const DateExtensionsPage = () => {
         onClose={handleCloseModal}
         onConfirmReset={handleConfirmReset}
       />
-      <Toast show={!!successMessage} onClose={() => setSuccessMessage('')} className="text-break">
-        {successMessage}
-      </Toast>
-      <AlertModal title={errorMessage} isOpen={!!errorMessage} footerNode={<Button onClick={() => setErrorMessage('')}>{intl.formatMessage(messages.close)}</Button>}>
-        {errorMessage}
-      </AlertModal>
     </div>
   );
 };

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -11,7 +11,7 @@ const mockData = [
     fullName: 'Test User',
     email: 'test@example.com',
     unitTitle: 'Test Section',
-    extendedDueDate: '2024-01-01'
+    extendedDueDate: '2025-11-07T00:00:00Z'
   }
 ];
 
@@ -36,11 +36,11 @@ describe('DateExtensionsList', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: mockData.length, results: mockData } });
     renderComponent({ onResetExtensions: mockResetExtensions });
     const user = userEvent.setup();
-    expect(screen.getByText('test_user')).toBeInTheDocument();
-    expect(screen.getByText('Test User')).toBeInTheDocument();
-    expect(screen.getByText('test@example.com')).toBeInTheDocument();
-    expect(screen.getByText('Test Section')).toBeInTheDocument();
-    expect(screen.getByText('2024-01-01')).toBeInTheDocument();
+    expect(screen.getByText(mockData[0].username)).toBeInTheDocument();
+    expect(screen.getByText(mockData[0].fullName)).toBeInTheDocument();
+    expect(screen.getByText(mockData[0].email)).toBeInTheDocument();
+    expect(screen.getByText(mockData[0].unitTitle)).toBeInTheDocument();
+    expect(screen.getByText('11/07/2025, 12:00 AM')).toBeInTheDocument();
     const resetExtensions = screen.getByRole('button', { name: /reset extensions/i });
     expect(resetExtensions).toBeInTheDocument();
     await user.click(resetExtensions);
@@ -50,7 +50,7 @@ describe('DateExtensionsList', () => {
   it('renders empty table when no data provided', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({ data: { count: 0, results: [] } });
     renderComponent({});
-    expect(screen.queryByText('test_user')).not.toBeInTheDocument();
+    expect(screen.queryByText(mockData[0].username)).not.toBeInTheDocument();
     expect(screen.getByText('No results found')).toBeInTheDocument();
   });
 });

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -34,7 +34,13 @@ const DateExtensionsList = ({
     { accessor: 'fullName', Header: intl.formatMessage(messages.fullname) },
     { accessor: 'email', Header: intl.formatMessage(messages.email) },
     { accessor: 'unitTitle', Header: intl.formatMessage(messages.gradedSubsection) },
-    { accessor: 'extendedDueDate', Header: intl.formatMessage(messages.extendedDueDate) },
+    {
+      accessor: 'extendedDueDate',
+      Header: intl.formatMessage(messages.extendedDueDate),
+      Cell: ({ value }: { value: string }) => (
+        intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+      )
+    },
   ];
 
   const additionalColumns = [{

--- a/src/dateExtensions/components/ResetExtensionsModal.test.tsx
+++ b/src/dateExtensions/components/ResetExtensionsModal.test.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ResetExtensionsModal from './ResetExtensionsModal';
+import { renderWithIntl } from '../../testUtils';
+import messages from '../messages';
+
+describe('ResetExtensionsModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    message: 'Test message',
+    title: 'Test title',
+    onCancelReset: jest.fn(),
+    onClose: jest.fn(),
+    onConfirmReset: jest.fn(),
+  };
+
+  const renderModal = (props = {}) => renderWithIntl(
+    <ResetExtensionsModal {...defaultProps} {...props} />
+  );
+
+  it('renders modal with correct title and message', () => {
+    renderModal();
+    expect(screen.getByText('Test title')).toBeInTheDocument();
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('calls onCancelReset when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: messages.cancel.defaultMessage }));
+    expect(defaultProps.onCancelReset).toHaveBeenCalled();
+  });
+
+  it('calls onConfirmReset when confirm button is clicked', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: messages.confirm.defaultMessage }));
+    expect(defaultProps.onConfirmReset).toHaveBeenCalled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByText('Test title')).not.toBeInTheDocument();
+  });
+});

--- a/src/dateExtensions/components/ResetExtensionsModal.tsx
+++ b/src/dateExtensions/components/ResetExtensionsModal.tsx
@@ -1,0 +1,35 @@
+import { useIntl } from '@openedx/frontend-base';
+import { ModalDialog, ActionRow, Button } from '@openedx/paragon';
+import messages from '../messages';
+
+interface ResetExtensionsModalProps {
+  isOpen: boolean,
+  message: string,
+  title: string,
+  onCancelReset: () => void,
+  onClose: () => void,
+  onConfirmReset: () => void,
+}
+
+const ResetExtensionsModal = ({
+  isOpen,
+  message,
+  title,
+  onCancelReset,
+  onClose,
+  onConfirmReset,
+}: ResetExtensionsModalProps) => {
+  const intl = useIntl();
+  return (
+    <ModalDialog isOpen={isOpen} onClose={onClose} hasCloseButton={false} title={title} isOverflowVisible={false} className="p-4">
+      <h4 className="mb-2.5">{title}</h4>
+      <p className="mb-2.5">{message}</p>
+      <ActionRow>
+        <Button variant="tertiary" onClick={onCancelReset}>{intl.formatMessage(messages.cancel)}</Button>
+        <Button variant="primary" onClick={onConfirmReset}>{intl.formatMessage(messages.confirm)}</Button>
+      </ActionRow>
+    </ModalDialog>
+  );
+};
+
+export default ResetExtensionsModal;

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -16,3 +16,8 @@ export const getDateExtensions = async (
   );
   return camelCaseObject(data);
 };
+
+export const resetDateExtension = async (courseId, userId) => {
+  const { data } = await getAuthenticatedHttpClient().post(`${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/date-extensions/${userId}/reset`);
+  return camelCaseObject(data);
+};

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { DateExtensionsResponse } from '../types';
+import { DateExtensionsResponse, ResetDueDateParams } from '../types';
 
 export interface PaginationQueryKeys {
   page: number,
@@ -17,7 +17,7 @@ export const getDateExtensions = async (
   return camelCaseObject(data);
 };
 
-export const resetDateExtension = async (courseId, userId) => {
-  const { data } = await getAuthenticatedHttpClient().post(`${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/date-extensions/${userId}/reset`);
+export const resetDateExtension = async (courseId: string, params: ResetDueDateParams) => {
+  const { data } = await getAuthenticatedHttpClient().post(`${getApiBaseUrl()}/courses/${courseId}/instructor/api/reset_due_date`, params);
   return camelCaseObject(data);
 };

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { getDateExtensions, PaginationQueryKeys } from './api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getDateExtensions, PaginationQueryKeys, resetDateExtension } from './api';
 import { dateExtensionsQueryKeys } from './queryKeys';
 
 export const useDateExtensions = (courseId: string, pagination: PaginationQueryKeys) => (
@@ -8,3 +8,10 @@ export const useDateExtensions = (courseId: string, pagination: PaginationQueryK
     queryFn: () => getDateExtensions(courseId, pagination),
   })
 );
+
+export const useResetDateExtensionMutation = () => {
+  return useMutation({
+    mutationFn: ({ courseId, userId }: { courseId: string, userId: number }) =>
+      resetDateExtension(courseId, userId),
+  });
+};

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -15,7 +15,7 @@ export const useResetDateExtensionMutation = () => {
   return useMutation({
     mutationFn: ({ courseId, params }: { courseId: string, params: ResetDueDateParams }) =>
       resetDateExtension(courseId, params),
-    onSuccess: ({ courseId }) => {
+    onSuccess: (_, { courseId }) => {
       queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId), exact: false });
     },
   });

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getDateExtensions, PaginationQueryKeys, resetDateExtension } from './api';
 import { dateExtensionsQueryKeys } from './queryKeys';
 
@@ -10,8 +10,12 @@ export const useDateExtensions = (courseId: string, pagination: PaginationQueryK
 );
 
 export const useResetDateExtensionMutation = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ courseId, userId }: { courseId: string, userId: number }) =>
       resetDateExtension(courseId, userId),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.all });
+    },
   });
 };

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getDateExtensions, PaginationQueryKeys, resetDateExtension } from './api';
 import { dateExtensionsQueryKeys } from './queryKeys';
+import { ResetDueDateParams } from '../types';
 
 export const useDateExtensions = (courseId: string, pagination: PaginationQueryKeys) => (
   useQuery({
@@ -12,10 +13,10 @@ export const useDateExtensions = (courseId: string, pagination: PaginationQueryK
 export const useResetDateExtensionMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ courseId, userId }: { courseId: string, userId: number }) =>
-      resetDateExtension(courseId, userId),
+    mutationFn: ({ courseId, params }: { courseId: string, params: ResetDueDateParams }) =>
+      resetDateExtension(courseId, params),
     onSuccess: ({ courseId }) => {
-      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId) });
+      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId), exact: false});
     },
   });
 };

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -16,7 +16,7 @@ export const useResetDateExtensionMutation = () => {
     mutationFn: ({ courseId, params }: { courseId: string, params: ResetDueDateParams }) =>
       resetDateExtension(courseId, params),
     onSuccess: ({ courseId }) => {
-      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId), exact: false});
+      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId), exact: false });
     },
   });
 };

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -14,8 +14,8 @@ export const useResetDateExtensionMutation = () => {
   return useMutation({
     mutationFn: ({ courseId, userId }: { courseId: string, userId: number }) =>
       resetDateExtension(courseId, userId),
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.all });
+    onSuccess: ({ courseId }) => {
+      queryClient.invalidateQueries({ queryKey: dateExtensionsQueryKeys.byCourse(courseId) });
     },
   });
 };

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -45,7 +45,27 @@ const messages = defineMessages({
     id: 'instruct.dateExtensions.page.button.resetExtensions',
     defaultMessage: 'Reset Extensions',
     description: 'Button text for resetting date extensions for a user',
-  }
+  },
+  resetConfirmationHeader: {
+    id: 'instruct.dateExtensions.page.resetModal.confirmationHeader',
+    defaultMessage: 'Reset extensions for {username}?',
+    description: 'Header for the reset confirmation modal',
+  },
+  resetConfirmationMessage: {
+    id: 'instruct.dateExtensions.page.resetModal.confirmationMessage',
+    defaultMessage: 'Resetting a problem\'s due date rescinds a due date extension for a student on a particular subsection. This will revert the due date for the student back to the problem\'s original due date.',
+    description: 'Confirmation message for resetting extensions in the reset modal',
+  },
+  cancel: {
+    id: 'instruct.dateExtensions.page.resetModal.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Label for the cancel button in the reset modal',
+  },
+  confirm: {
+    id: 'instruct.dateExtensions.page.resetModal.confirm',
+    defaultMessage: 'Reset Due Date for Student',
+    description: 'Label for the confirm button in the reset modal',
+  },
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -66,6 +66,11 @@ const messages = defineMessages({
     defaultMessage: 'Reset Due Date for Student',
     description: 'Label for the confirm button in the reset modal',
   },
+  close: {
+    id: 'instruct.dateExtensions.page.resetModal.close',
+    defaultMessage: 'Close',
+    description: 'Label for the close button in the reset modal',
+  },
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -71,6 +71,11 @@ const messages = defineMessages({
     defaultMessage: 'Close',
     description: 'Label for the close button in the reset modal',
   },
+  missingUserOrCourseIdError: {
+    id: 'instruct.dateExtensions.page.error.missingUserOrCourseId',
+    defaultMessage: 'Unable to reset extension: missing user or course ID.',
+    description: 'Error message shown when user or course ID is missing during reset',
+  }
 });
 
 export default messages;

--- a/src/dateExtensions/types.ts
+++ b/src/dateExtensions/types.ts
@@ -1,10 +1,10 @@
 export interface LearnerDateExtension {
-  id: number,
   username: string,
   fullName: string,
   email: string,
   unitTitle: string,
   extendedDueDate: string,
+  unitLocation: string,
 }
 
 export interface DateExtensionsResponse {
@@ -12,4 +12,10 @@ export interface DateExtensionsResponse {
   next: string | null,
   previous: string | null,
   results: LearnerDateExtension[],
+}
+
+export interface ResetDueDateParams {
+  student: string,
+  url: string,
+  reason?: string,
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -2,5 +2,5 @@
 
 .toast-container {
     left: unset;
-    right: 1.25rem;
+    right: var(--pgn-spacing-toast-container-gutter-lg);
 }

--- a/src/providers/AlertProvider.tsx
+++ b/src/providers/AlertProvider.tsx
@@ -21,7 +21,7 @@ interface ModalAlert {
   isOpen: boolean,
   confirmText?: string,
   cancelText?: string,
-  onConfirm?: () => void,
+  onConfirm?: (id: string) => void,
   onCancel?: () => void,
 }
 
@@ -50,7 +50,7 @@ interface AlertContextType {
     variant?: 'default' | 'warning' | 'danger' | 'success',
     confirmText?: string,
     cancelText?: string,
-    onConfirm?: () => void,
+    onConfirm?: (id: string) => void,
     onCancel?: () => void,
   }) => void,
   showInlineAlert: (message: string, variant?: 'success' | 'danger' | 'warning' | 'info', dismissible?: boolean) => string,
@@ -103,7 +103,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({ children }) => {
     variant?: 'default' | 'warning' | 'danger' | 'success',
     confirmText?: string,
     cancelText?: string,
-    onConfirm?: () => void,
+    onConfirm?: (id: string) => void,
     onCancel?: () => void,
   }) => {
     const id = `modal-${Date.now()}-${Math.random()}`;
@@ -136,7 +136,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({ children }) => {
     setModals(prev => {
       const modal = prev.find(m => m.id === id);
       if (modal?.onConfirm) {
-        modal.onConfirm();
+        modal.onConfirm(id);
       }
       return prev.filter(m => m.id !== id);
     });

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,8 +1,19 @@
 import { render } from '@testing-library/react';
 import { IntlProvider } from '@openedx/frontend-base';
+import { AlertProvider } from './providers/AlertProvider';
 
 export const renderWithIntl = (component) => {
   return render(<IntlProvider locale="en" messages={{}}>{ component }</IntlProvider>);
+};
+
+export const renderWithAlertAndIntl = (component) => {
+  return render(
+    <AlertProvider>
+      <IntlProvider locale="en" messages={{}}>
+        {component}
+      </IntlProvider>
+    </AlertProvider>
+  );
 };
 
 export const createQueryMock = (data: any = undefined, isLoading = false) => ({


### PR DESCRIPTION
### Description
Adding functionality to reset extensions link to open a confirmation modal, its success toast and error modal.

#### Screenshots
<img width="1620" height="899" alt="Screenshot 2025-11-10 at 12 59 28 p m" src="https://github.com/user-attachments/assets/eeaa7c0c-0b9d-4c26-9912-89bf351e863b" />

<img width="1623" height="895" alt="Screenshot 2025-11-10 at 1 00 39 p m" src="https://github.com/user-attachments/assets/14338cec-d92e-4be8-8724-d9199c2a38f5" />

<img width="1421" height="711" alt="Screenshot 2026-02-05 at 6 01 39 p m" src="https://github.com/user-attachments/assets/36797d8e-6af2-4008-ba1a-8373c36248b3" />

#### Support Information
Closes #58 
Needs to be reviewed/merged after https://github.com/openedx/frontend-app-instruct/pull/62