### PR TITLE
Enable cohorts

### DIFF
--- a/docs/how_tos/override-external-urls.rst
+++ b/docs/how_tos/override-external-urls.rst
@@ -1,0 +1,55 @@
+Override External URLs
+======================
+
+What is getExternalLinkUrl?
+---------------------------
+
+The `getExternalLinkUrl` function is a utility from `@openedx/frontend-base` that allows for centralized management of external URLs. It enables the override of external links through configuration, making it possible to customize external references without modifying the source code directly.
+
+URLs wrapped with getExternalLinkUrl
+------------------------------------
+
+Currently, the following external URLs are wrapped with `getExternalLinkUrl` in the authoring application:
+
+- https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation
+
+
+How to Override External URLs
+-----------------------------
+
+To override external URLs, you can use the frontend platform's configuration system.
+This object should be added to the config object defined in the env.config.[js,jsx,ts,tsx], and must be named externalLinkUrlOverrides.
+
+1. **Environment Configuration**
+   Add the URL overrides to your environment configuration:
+
+   .. code-block:: javascript
+
+      const config = {
+        // Other config options...
+        externalLinkUrlOverrides: {
+          'https://www.edx.org/accessibility': 'https://your-custom-domain.com/accessibility',
+          // Add other URL overrides here
+        }
+      };
+
+Examples
+--------
+
+**Original URL:** Default community accessibility link
+**Override:** Your institution's accessibility policy page
+
+.. code-block:: javascript
+
+   // In your app configuration
+   getExternalLinkUrl('https://www.edx.org/accessibility')
+   // Returns: 'https://your-custom-domain.com/accessibility'
+   // Instead of the default Open edX community link
+
+Benefits
+--------
+
+- **Customization**: Institutions can point to their own resources
+- **Maintainability**: URLs can be changed without code modifications  
+- **Consistency**: Centralized URL management across the application
+- **Flexibility**: Different environments can have different external links

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ const app: App = {
   slots: [],
   config: {
     NODE_ENV: 'development',
-    LMS_BASE_URL: 'http://local.openedx.io:8000'
+    CMS_BASE_URL: 'http://local.openedx.io:8000'
   }
 };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ const app: App = {
   slots: [],
   config: {
     NODE_ENV: 'development',
-    CMS_BASE_URL: 'http://local.openedx.io:8000'
+    LMS_BASE_URL: 'http://local.openedx.io:8000'
   }
 };
 

--- a/src/cohorts/CohortsPage.test.tsx
+++ b/src/cohorts/CohortsPage.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CohortsPage from './CohortsPage';
-import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook';
+import { useCohorts, useCohortStatus, useToggleCohorts } from '../data/apiHook';
 import { renderWithIntl } from '../testUtils';
 import messages from './messages';
 
@@ -12,8 +12,8 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('../data/apiHook', () => ({
   useCohorts: jest.fn(),
-  useEnableCohorts: jest.fn(),
-  useDisableCohorts: jest.fn(),
+  useCohortStatus: jest.fn(),
+  useToggleCohorts: jest.fn(),
 }));
 
 describe('CohortsPage', () => {
@@ -23,8 +23,8 @@ describe('CohortsPage', () => {
 
   it('renders cohorts list and add button when cohorts exist', () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
-    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
-    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
+    (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
     renderWithIntl(<CohortsPage />);
     expect(screen.getByText(messages.cohortsTitle.defaultMessage)).toBeInTheDocument();
@@ -34,8 +34,8 @@ describe('CohortsPage', () => {
 
   it('renders no cohorts message and enable button when no cohorts', () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
-    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
-    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: false } });
+    (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
     renderWithIntl(<CohortsPage />);
     expect(screen.getByText(messages.noCohortsMessage.defaultMessage)).toBeInTheDocument();
@@ -46,8 +46,8 @@ describe('CohortsPage', () => {
   it('calls enableCohortsMutate when enable button is clicked', async () => {
     const enableMock = jest.fn();
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
-    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: enableMock });
-    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: false } });
+    (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: enableMock });
 
     renderWithIntl(<CohortsPage />);
     const user = userEvent.setup();
@@ -57,8 +57,8 @@ describe('CohortsPage', () => {
 
   it('opens and closes the disable cohorts modal', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
-    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
-    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
+    (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
     renderWithIntl(<CohortsPage />);
     const user = userEvent.setup();
@@ -71,11 +71,13 @@ describe('CohortsPage', () => {
   it('calls disableCohortsMutate and closes modal on confirm', async () => {
     const disableMock = jest.fn();
     (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
-    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
-    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: disableMock });
+    (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
+    (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: disableMock });
 
     renderWithIntl(<CohortsPage />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
+    await user.click(screen.getByRole('button', { name: messages.disableLabel.defaultMessage }));
+    expect(disableMock).toHaveBeenCalled();
   });
 });

--- a/src/cohorts/CohortsPage.test.tsx
+++ b/src/cohorts/CohortsPage.test.tsx
@@ -63,7 +63,6 @@ describe('CohortsPage', () => {
     renderWithIntl(<CohortsPage />);
     const user = userEvent.setup();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    screen.debug();
     await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
     expect(screen.getByRole('dialog', { name: messages.disableCohorts.defaultMessage })).toBeInTheDocument();
   });

--- a/src/cohorts/CohortsPage.test.tsx
+++ b/src/cohorts/CohortsPage.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CohortsPage from './CohortsPage';
-import { useCohorts, useCohortStatus, useToggleCohorts } from '../data/apiHook';
+import { useCohorts, useCohortStatus, useToggleCohorts } from './data/apiHook';
 import { renderWithIntl } from '../testUtils';
 import messages from './messages';
 
@@ -10,7 +10,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
 }));
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('./data/apiHook', () => ({
   useCohorts: jest.fn(),
   useCohortStatus: jest.fn(),
   useToggleCohorts: jest.fn(),

--- a/src/cohorts/CohortsPage.test.tsx
+++ b/src/cohorts/CohortsPage.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CohortsPage from './CohortsPage';
+import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook';
+import { renderWithIntl } from '../testUtils';
+import messages from './messages';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useCohorts: jest.fn(),
+  useEnableCohorts: jest.fn(),
+  useDisableCohorts: jest.fn(),
+}));
+
+describe('CohortsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders cohorts list and add button when cohorts exist', () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
+    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+
+    renderWithIntl(<CohortsPage />);
+    expect(screen.getByText(messages.cohortsTitle.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Cohort 1' })).toBeInTheDocument();
+    expect(screen.getByText(`+ ${messages.addCohort.defaultMessage}`)).toBeInTheDocument();
+  });
+
+  it('renders no cohorts message and enable button when no cohorts', () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+
+    renderWithIntl(<CohortsPage />);
+    expect(screen.getByText(messages.noCohortsMessage.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.enableCohorts.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: messages.learnMore.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('calls enableCohortsMutate when enable button is clicked', async () => {
+    const enableMock = jest.fn();
+    (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: enableMock });
+    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+
+    renderWithIntl(<CohortsPage />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: messages.enableCohorts.defaultMessage }));
+    expect(enableMock).toHaveBeenCalled();
+  });
+
+  it('opens and closes the disable cohorts modal', async () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
+    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+
+    renderWithIntl(<CohortsPage />);
+    const user = userEvent.setup();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    screen.debug();
+    await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
+    expect(screen.getByRole('dialog', { name: messages.disableCohorts.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('calls disableCohortsMutate and closes modal on confirm', async () => {
+    const disableMock = jest.fn();
+    (useCohorts as jest.Mock).mockReturnValue({ data: [{ id: '1', name: 'Cohort 1' }] });
+    (useEnableCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+    (useDisableCohorts as jest.Mock).mockReturnValue({ mutate: disableMock });
+
+    renderWithIntl(<CohortsPage />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
+  });
+});

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '@openedx/paragon';
 import { Settings } from '@openedx/paragon/icons';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
-import { useCohortStatus, useToggleCohorts } from '../data/apiHook';
+import { useCohortStatus, useToggleCohorts } from './data/apiHook';
 import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
 import DisabledCohortsView from './components/DisabledCohortsView';

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from '@openedx/frontend-base';
-import { Button, Container, FormControl, IconButton } from '@openedx/paragon';
+import { Button, FormControl, IconButton } from '@openedx/paragon';
 import { Settings } from '@openedx/paragon/icons';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
@@ -7,7 +7,7 @@ import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook
 import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
 
-// const list = [{ id: 'Select a cohort', name: '' }, {
+// const list = [{ id: 'Select a cohort', name: 'Select a cohort' }, {
 //   id: 'Cohort 1',
 //   name: 'cohort1'
 // }];
@@ -43,15 +43,17 @@ const CohortsPage = () => {
   };
 
   return (
-    <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
+    <div className="mt-4.5 mb-4 mx-4">
       <div className="d-inline-flex align-items-center">
         <h3 className="mb-0">{intl.formatMessage(messages.cohortsTitle)}</h3>
-        <div className="small">
-          <IconButton iconAs={Settings} alt={intl.formatMessage(messages.disableCohorts)} variant="secondary" size="sm" onClick={() => setIsOpenDisableModal(true)} iconClassNames="mb-2" />
-        </div>
+        {cohortsList.length > 0 && (
+          <div className="small">
+            <IconButton iconAs={Settings} alt={intl.formatMessage(messages.disableCohorts)} variant="secondary" size="sm" onClick={() => setIsOpenDisableModal(true)} iconClassNames="mb-2" />
+          </div>
+        )}
       </div>
       {cohortsList.length > 0 ? (
-        <div className="d-flex">
+        <div className="d-flex mt-4.5">
           <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
             {
               cohortsList.map((cohort) => (
@@ -72,7 +74,7 @@ const CohortsPage = () => {
         </div>
       )}
       <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
-    </Container>
+    </div>
   );
 };
 

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -3,28 +3,23 @@ import { IconButton } from '@openedx/paragon';
 import { Settings } from '@openedx/paragon/icons';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
-import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook';
+import { useCohortStatus, useToggleCohorts } from '../data/apiHook';
 import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
 import DisabledCohortsView from './components/DisabledCohortsView';
 import EnabledCohortsView from './components/EnabledCohortsView';
 
-// const list = [{ id: 'Select a cohort', name: 'Select a cohort' }, {
-//   id: 'Cohort 1',
-//   name: 'cohort1'
-// }];
-
 const CohortsPage = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
-  const { data: cohortsList = [] } = useCohorts(courseId);
-  const { mutate: enableCohortsMutate } = useEnableCohorts(courseId);
-  const { mutate: disableCohortsMutate } = useDisableCohorts(courseId);
+  const { data: cohortStatus } = useCohortStatus(courseId);
+  const { mutate: toggleCohortsMutate } = useToggleCohorts(courseId);
   const [isOpenDisableModal, setIsOpenDisableModal] = useState(false);
+  const { isCohorted = false } = cohortStatus ?? {};
 
   const handleEnableCohorts = () => {
     try {
-      enableCohortsMutate();
+      toggleCohortsMutate({ isCohorted: true });
     } catch (error) {
       // Handle error
     }
@@ -32,7 +27,7 @@ const CohortsPage = () => {
 
   const handleDisableCohorts = () => {
     try {
-      disableCohortsMutate();
+      toggleCohortsMutate({ isCohorted: false });
       setIsOpenDisableModal(false);
     } catch (error) {
       // Handle error
@@ -43,14 +38,14 @@ const CohortsPage = () => {
     <div className="mt-4.5 mb-4 mx-4">
       <div className="d-inline-flex align-items-center">
         <h3 className="mb-0">{intl.formatMessage(messages.cohortsTitle)}</h3>
-        {cohortsList.length > 0 && (
+        {isCohorted && (
           <div className="small">
             <IconButton iconAs={Settings} alt={intl.formatMessage(messages.disableCohorts)} variant="secondary" size="sm" onClick={() => setIsOpenDisableModal(true)} iconClassNames="mb-2" />
           </div>
         )}
       </div>
-      {cohortsList.length > 0 ? (
-        <EnabledCohortsView cohortsList={cohortsList} />
+      {isCohorted ? (
+        <EnabledCohortsView />
       ) : (
         <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
       )}

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -1,0 +1,79 @@
+import { useIntl } from '@openedx/frontend-base';
+import { Button, Container, FormControl, IconButton } from '@openedx/paragon';
+import { Settings } from '@openedx/paragon/icons';
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook';
+import DisableCohortsModal from './components/DisableCohortsModal';
+import messages from './messages';
+
+// const list = [{ id: 'Select a cohort', name: '' }, {
+//   id: 'Cohort 1',
+//   name: 'cohort1'
+// }];
+
+const CohortsPage = () => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams();
+  const { data: cohortsList = [] } = useCohorts(courseId);
+  const { mutate: enableCohortsMutate } = useEnableCohorts(courseId);
+  const { mutate: disableCohortsMutate } = useDisableCohorts(courseId);
+  const [isOpenDisableModal, setIsOpenDisableModal] = useState(false);
+
+  const handleEnableCohorts = () => {
+    try {
+      enableCohortsMutate();
+    } catch (error) {
+      // Handle error
+    }
+  };
+
+  const handleDisableCohorts = () => {
+    try {
+      disableCohortsMutate();
+      setIsOpenDisableModal(false);
+    } catch (error) {
+      // Handle error
+    }
+  };
+
+  const handleSelectCohort = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    // Handle cohort selection
+    console.log(event);
+  };
+
+  return (
+    <Container className="mt-4.5 mb-4 mx-4" fluid="xl">
+      <div className="d-inline-flex align-items-center">
+        <h3 className="mb-0">{intl.formatMessage(messages.cohortsTitle)}</h3>
+        <div className="small">
+          <IconButton iconAs={Settings} alt={intl.formatMessage(messages.disableCohorts)} variant="secondary" size="sm" onClick={() => setIsOpenDisableModal(true)} iconClassNames="mb-2" />
+        </div>
+      </div>
+      {cohortsList.length > 0 ? (
+        <div className="d-flex">
+          <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
+            {
+              cohortsList.map((cohort) => (
+                <option key={cohort.id} value={cohort.id}>
+                  {cohort.name}
+                </option>
+              ))
+            }
+          </FormControl>
+          <Button>+ {intl.formatMessage(messages.addCohort)}</Button>
+        </div>
+      ) : (
+        <div className="d-flex bg-light-200 border border-light-400 p-5 mt-4.5 align-items-center">
+          <p className="m-0">
+            {intl.formatMessage(messages.noCohortsMessage)} <a href="https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation">{intl.formatMessage(messages.learnMore)}</a>
+          </p>
+          <Button className="ml-3 flex-shrink-0" onClick={handleEnableCohorts}>{intl.formatMessage(messages.enableCohorts)}</Button>
+        </div>
+      )}
+      <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
+    </Container>
+  );
+};
+
+export default CohortsPage;

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -18,29 +18,34 @@ const CohortsPage = () => {
   const { isCohorted = false } = cohortStatus ?? {};
 
   const handleEnableCohorts = () => {
-    try {
-      toggleCohortsMutate({ isCohorted: true });
-    } catch (error) {
-      // Handle error
-    }
+    toggleCohortsMutate({ isCohorted: true },
+      {
+        onError: (error) => console.log(error)
+      });
   };
 
   const handleDisableCohorts = () => {
-    try {
-      toggleCohortsMutate({ isCohorted: false });
-      setIsOpenDisableModal(false);
-    } catch (error) {
-      // Handle error
-    }
+    toggleCohortsMutate({ isCohorted: false },
+      {
+        onError: (error) => console.log(error)
+      });
+    setIsOpenDisableModal(false);
   };
 
   return (
     <div className="mt-4.5 mb-4 mx-4">
       <div className="d-inline-flex align-items-center">
-        <h3 className="mb-0">{intl.formatMessage(messages.cohortsTitle)}</h3>
+        <h3 className="mb-0 text-gray-700">{intl.formatMessage(messages.cohortsTitle)}</h3>
         {isCohorted && (
           <div className="small">
-            <IconButton iconAs={Settings} alt={intl.formatMessage(messages.disableCohorts)} variant="secondary" size="sm" onClick={() => setIsOpenDisableModal(true)} iconClassNames="mb-2" />
+            <IconButton
+              alt={intl.formatMessage(messages.disableCohorts)}
+              iconAs={Settings}
+              iconClassNames="mb-2 text-gray-500"
+              size="sm"
+              variant="secondary"
+              onClick={() => setIsOpenDisableModal(true)}
+            />
           </div>
         )}
       </div>

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -1,11 +1,13 @@
 import { useIntl } from '@openedx/frontend-base';
-import { Button, FormControl, IconButton } from '@openedx/paragon';
+import { IconButton } from '@openedx/paragon';
 import { Settings } from '@openedx/paragon/icons';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { useCohorts, useDisableCohorts, useEnableCohorts } from '../data/apiHook';
 import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
+import DisabledCohortsView from './components/DisabledCohortsView';
+import EnabledCohortsView from './components/EnabledCohortsView';
 
 // const list = [{ id: 'Select a cohort', name: 'Select a cohort' }, {
 //   id: 'Cohort 1',
@@ -37,11 +39,6 @@ const CohortsPage = () => {
     }
   };
 
-  const handleSelectCohort = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    // Handle cohort selection
-    console.log(event);
-  };
-
   return (
     <div className="mt-4.5 mb-4 mx-4">
       <div className="d-inline-flex align-items-center">
@@ -53,25 +50,9 @@ const CohortsPage = () => {
         )}
       </div>
       {cohortsList.length > 0 ? (
-        <div className="d-flex mt-4.5">
-          <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
-            {
-              cohortsList.map((cohort) => (
-                <option key={cohort.id} value={cohort.id}>
-                  {cohort.name}
-                </option>
-              ))
-            }
-          </FormControl>
-          <Button>+ {intl.formatMessage(messages.addCohort)}</Button>
-        </div>
+        <EnabledCohortsView cohortsList={cohortsList} />
       ) : (
-        <div className="d-flex bg-light-200 border border-light-400 p-5 mt-4.5 align-items-center">
-          <p className="m-0">
-            {intl.formatMessage(messages.noCohortsMessage)} <a href="https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation">{intl.formatMessage(messages.learnMore)}</a>
-          </p>
-          <Button className="ml-3 flex-shrink-0" onClick={handleEnableCohorts}>{intl.formatMessage(messages.enableCohorts)}</Button>
-        </div>
+        <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
       )}
       <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
     </div>

--- a/src/cohorts/components/DisableCohortsModal.test.tsx
+++ b/src/cohorts/components/DisableCohortsModal.test.tsx
@@ -20,7 +20,7 @@ describe('DisableCohortsModal', () => {
         onConfirmDisable={onConfirmDisable}
       />
     );
-    expect(screen.getByRole('dialog', { name: messages.modalTitle.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: messages.disableCohorts.defaultMessage })).toBeInTheDocument();
     expect(screen.getByText(messages.disableMessage.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.cancelLabel.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.disableLabel.defaultMessage)).toBeInTheDocument();
@@ -34,7 +34,7 @@ describe('DisableCohortsModal', () => {
         onConfirmDisable={onConfirmDisable}
       />
     );
-    expect(screen.queryByText(messages.modalTitle.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.disableCohorts.defaultMessage)).not.toBeInTheDocument();
   });
 
   it('calls onClose when cancel button is clicked', async () => {

--- a/src/cohorts/components/DisableCohortsModal.test.tsx
+++ b/src/cohorts/components/DisableCohortsModal.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DisableCohortsModal from './DisableCohortsModal';
+import { renderWithIntl } from '../../testUtils';
+import messages from '../messages';
+
+describe('DisableCohortsModal', () => {
+  const onClose = jest.fn();
+  const onConfirmDisable = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal when isOpen is true', () => {
+    renderWithIntl(
+      <DisableCohortsModal
+        isOpen={true}
+        onClose={onClose}
+        onConfirmDisable={onConfirmDisable}
+      />
+    );
+    expect(screen.getByRole('dialog', { name: messages.modalTitle.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByText(messages.disableMessage.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.cancelLabel.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.disableLabel.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('does not render modal when isOpen is false', () => {
+    renderWithIntl(
+      <DisableCohortsModal
+        isOpen={false}
+        onClose={onClose}
+        onConfirmDisable={onConfirmDisable}
+      />
+    );
+    expect(screen.queryByText(messages.modalTitle.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    renderWithIntl(
+      <DisableCohortsModal
+        isOpen={true}
+        onClose={onClose}
+        onConfirmDisable={onConfirmDisable}
+      />
+    );
+    const user = userEvent.setup();
+    const cancelButton = screen.getByRole('button', { name: messages.cancelLabel.defaultMessage });
+    await user.click(cancelButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onConfirmDisable when disable button is clicked', async () => {
+    renderWithIntl(
+      <DisableCohortsModal
+        isOpen={true}
+        onClose={onClose}
+        onConfirmDisable={onConfirmDisable}
+      />
+    );
+    const user = userEvent.setup();
+    const disableButton = screen.getByRole('button', { name: messages.disableLabel.defaultMessage });
+    await user.click(disableButton);
+    expect(onConfirmDisable).toHaveBeenCalled();
+  });
+});

--- a/src/cohorts/components/DisableCohortsModal.tsx
+++ b/src/cohorts/components/DisableCohortsModal.tsx
@@ -1,0 +1,29 @@
+import { ActionRow, Button, ModalDialog } from '@openedx/paragon';
+import { useIntl } from '@openedx/frontend-base';
+import messages from '../messages';
+
+interface DisableCohortsModalProps {
+  isOpen: boolean,
+  onClose: () => void,
+  onConfirmDisable: () => void,
+}
+
+const DisableCohortsModal = ({ isOpen, onClose, onConfirmDisable }: DisableCohortsModalProps) => {
+  const intl = useIntl();
+
+  return (
+    <ModalDialog title={intl.formatMessage(messages.modalTitle)} onClose={onClose} isOpen={isOpen} size="sm" hasCloseButton={false} isOverflowVisible={false}>
+      <div className="mx-4 mt-4 mb-2.5">
+        <p>{intl.formatMessage(messages.disableMessage)}</p>
+      </div>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelLabel)}</Button>
+          <Button variant="primary" onClick={onConfirmDisable}>{intl.formatMessage(messages.disableLabel)}</Button>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default DisableCohortsModal;

--- a/src/cohorts/components/DisableCohortsModal.tsx
+++ b/src/cohorts/components/DisableCohortsModal.tsx
@@ -12,7 +12,7 @@ const DisableCohortsModal = ({ isOpen, onClose, onConfirmDisable }: DisableCohor
   const intl = useIntl();
 
   return (
-    <ModalDialog title={intl.formatMessage(messages.modalTitle)} onClose={onClose} isOpen={isOpen} size="sm" hasCloseButton={false} isOverflowVisible={false}>
+    <ModalDialog title={intl.formatMessage(messages.disableCohorts)} onClose={onClose} isOpen={isOpen} size="sm" hasCloseButton={false} isOverflowVisible={false}>
       <div className="mx-4 mt-4 mb-2.5">
         <p>{intl.formatMessage(messages.disableMessage)}</p>
       </div>

--- a/src/cohorts/components/DisabledCohortsView.test.tsx
+++ b/src/cohorts/components/DisabledCohortsView.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+import { renderWithIntl } from '../../testUtils';
+import messages from '../messages';
+import DisabledCohortsView from './DisabledCohortsView';
+import userEvent from '@testing-library/user-event';
+
+describe('DisabledCohortsView', () => {
+  const onEnableCohorts = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the no cohorts message', () => {
+    renderWithIntl(<DisabledCohortsView onEnableCohorts={onEnableCohorts} />);
+    expect(screen.getByText(messages.noCohortsMessage.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders the learn more link with correct href', () => {
+    renderWithIntl(<DisabledCohortsView onEnableCohorts={onEnableCohorts} />);
+    const link = screen.getByRole('link', { name: messages.learnMore.defaultMessage }) as HTMLAnchorElement;
+    expect(link).toBeInTheDocument();
+    expect(link.href).toContain('https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation');
+  });
+
+  it('renders the enable cohorts button', () => {
+    renderWithIntl(<DisabledCohortsView onEnableCohorts={onEnableCohorts} />);
+    expect(screen.getByRole('button', { name: messages.enableCohorts.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('calls onEnableCohorts when button is clicked', async () => {
+    renderWithIntl(<DisabledCohortsView onEnableCohorts={onEnableCohorts} />);
+    const user = userEvent.setup();
+    const enableCohortsButton = screen.getByRole('button', { name: messages.enableCohorts.defaultMessage });
+    await user.click(enableCohortsButton);
+    expect(onEnableCohorts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cohorts/components/DisabledCohortsView.tsx
+++ b/src/cohorts/components/DisabledCohortsView.tsx
@@ -1,4 +1,4 @@
-import { useIntl } from '@openedx/frontend-base';
+import { getExternalLinkUrl, useIntl } from '@openedx/frontend-base';
 import { Button } from '@openedx/paragon';
 import messages from '../messages';
 
@@ -12,7 +12,7 @@ const DisabledCohortsView = ({ onEnableCohorts }: DisabledCohortsViewProps) => {
   return (
     <div className="d-flex bg-light-200 border border-light-400 p-5 mt-4.5 align-items-center">
       <p className="m-0">
-        {intl.formatMessage(messages.noCohortsMessage)} <a href="https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation">{intl.formatMessage(messages.learnMore)}</a>
+        {intl.formatMessage(messages.noCohortsMessage)} <a href={getExternalLinkUrl('https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation')}>{intl.formatMessage(messages.learnMore)}</a>
       </p>
       <Button className="ml-3 flex-shrink-0" onClick={onEnableCohorts}>{intl.formatMessage(messages.enableCohorts)}</Button>
     </div>

--- a/src/cohorts/components/DisabledCohortsView.tsx
+++ b/src/cohorts/components/DisabledCohortsView.tsx
@@ -1,0 +1,22 @@
+import { useIntl } from '@openedx/frontend-base';
+import { Button } from '@openedx/paragon';
+import messages from '../messages';
+
+interface DisabledCohortsViewProps {
+  onEnableCohorts: () => void,
+}
+
+const DisabledCohortsView = ({ onEnableCohorts }: DisabledCohortsViewProps) => {
+  const intl = useIntl();
+
+  return (
+    <div className="d-flex bg-light-200 border border-light-400 p-5 mt-4.5 align-items-center">
+      <p className="m-0">
+        {intl.formatMessage(messages.noCohortsMessage)} <a href="https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation">{intl.formatMessage(messages.learnMore)}</a>
+      </p>
+      <Button className="ml-3 flex-shrink-0" onClick={onEnableCohorts}>{intl.formatMessage(messages.enableCohorts)}</Button>
+    </div>
+  );
+};
+
+export default DisabledCohortsView;

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useParams } from 'react-router-dom';
 import { renderWithIntl } from '../../testUtils';
-import { useCohorts } from '../../data/apiHook';
+import { useCohorts } from '../data/apiHook';
 import messages from '../messages';
 import EnabledCohortsView from './EnabledCohortsView';
 
@@ -11,7 +11,7 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../../data/apiHook', () => ({
+jest.mock('../data/apiHook', () => ({
   useCohorts: jest.fn(),
 }));
 

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useParams } from 'react-router-dom';
+import { renderWithIntl } from '../../testUtils';
+import { useCohorts } from '../../data/apiHook';
+import messages from '../messages';
+import EnabledCohortsView from './EnabledCohortsView';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../data/apiHook', () => ({
+  useCohorts: jest.fn(),
+}));
+
+const mockCohorts = [
+  { id: 1, name: 'Cohort 1' },
+  { id: 2, name: 'Cohort 2' },
+];
+
+describe('EnabledCohortsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useParams as jest.Mock).mockReturnValue({ courseId: 'course-v1:edX+Test+2024' });
+  });
+
+  it('renders select with placeholder and cohorts', () => {
+    (useCohorts as jest.Mock).mockReturnValue({
+      data: mockCohorts,
+    });
+
+    renderWithIntl(<EnabledCohortsView />);
+    expect(screen.getByText(messages.selectCohortPlaceholder.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(mockCohorts[0].name)).toBeInTheDocument();
+    expect(screen.getByText(mockCohorts[1].name)).toBeInTheDocument();
+  });
+
+  // TODO: Modify test when add functionality to select
+  it('calls handleSelectCohort on select change', () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: mockCohorts });
+    renderWithIntl(<EnabledCohortsView />);
+  });
+
+  // TODO: Modify test when add functionality to button
+  it('calls handleAddCohort on button click', async () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    renderWithIntl(<EnabledCohortsView />);
+    const user = userEvent.setup();
+    const button = screen.getByRole('button', { name: `+ ${messages.addCohort.defaultMessage}` });
+    await user.click(button);
+  });
+
+  it('renders correctly when no cohorts are returned', () => {
+    (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    renderWithIntl(<EnabledCohortsView />);
+    const cohortsOptions = screen.getAllByRole('option');
+    expect(cohortsOptions.length).toBe(1);
+    expect(cohortsOptions[0]).toHaveTextContent(messages.selectCohortPlaceholder.defaultMessage);
+  });
+
+  it('uses default courseId if not present in params', () => {
+    (useParams as jest.Mock).mockReturnValue({});
+    (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    renderWithIntl(<EnabledCohortsView />);
+    expect(useCohorts).toHaveBeenCalledWith('');
+  });
+});

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -1,0 +1,38 @@
+import { useIntl } from '@openedx/frontend-base';
+import { FormControl, Button } from '@openedx/paragon';
+import messages from '../messages';
+
+interface EnabledCohortsViewProps {
+  cohortsList: { id: string, name: string }[],
+}
+
+const EnabledCohortsView = ({ cohortsList }: EnabledCohortsViewProps) => {
+  const intl = useIntl();
+
+  const handleAddCohort = () => {
+    // Handle adding a new cohort
+    console.log('Add Cohort');
+  };
+
+  const handleSelectCohort = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    // Handle cohort selection
+    console.log(event);
+  };
+
+  return (
+    <div className="d-flex mt-4.5">
+      <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
+        {
+          cohortsList.map((cohort) => (
+            <option key={cohort.id} value={cohort.id}>
+              {cohort.name}
+            </option>
+          ))
+        }
+      </FormControl>
+      <Button onClick={handleAddCohort}>+ {intl.formatMessage(messages.addCohort)}</Button>
+    </div>
+  );
+};
+
+export default EnabledCohortsView;

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Button } from '@openedx/paragon';
 import messages from '../messages';
-import { useCohorts } from '../../data/apiHook';
+import { useCohorts } from '../data/apiHook';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -1,13 +1,15 @@
+import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Button } from '@openedx/paragon';
 import messages from '../messages';
+import { useCohorts } from '../../data/apiHook';
 
-interface EnabledCohortsViewProps {
-  cohortsList: { id: string, name: string }[],
-}
-
-const EnabledCohortsView = ({ cohortsList }: EnabledCohortsViewProps) => {
+const EnabledCohortsView = () => {
   const intl = useIntl();
+  const { courseId = '' } = useParams();
+  const { data = [] } = useCohorts(courseId);
+
+  const cohortsList = [{ id: null, name: intl.formatMessage(messages.selectCohortPlaceholder) }, ...data];
 
   const handleAddCohort = () => {
     // Handle adding a new cohort

--- a/src/cohorts/data/api.test.ts
+++ b/src/cohorts/data/api.test.ts
@@ -1,0 +1,95 @@
+import { getCohortStatus, getCohorts, toggleCohorts } from './api';
+import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { appId } from '../../constants';
+
+jest.mock('@openedx/frontend-base');
+
+const mockBaseUrl = 'https://cms.example.com';
+
+const mockHttpClient = {
+  get: jest.fn(),
+  put: jest.fn(),
+};
+
+const mockGetAppConfig = getAppConfig as jest.MockedFunction<typeof getAppConfig>;
+const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
+const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
+
+describe('getCohortStatus', () => {
+  const mockCohortStatusData = { is_cohorted: true };
+  const mockCamelCaseCohortStatusData = { isCohorted: true };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseCohortStatusData);
+    mockHttpClient.get.mockResolvedValue({ data: mockCohortStatusData });
+  });
+
+  it('should fetch cohort status and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+
+    const result = await getCohortStatus(courseId);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`
+    );
+    expect(mockCamelCaseObject).toHaveBeenCalledWith(mockCohortStatusData);
+    expect(result).toEqual(mockCamelCaseCohortStatusData);
+  });
+});
+
+describe('getCohorts', () => {
+  const mockData = [{ id: 1, name: 'Cohort 1' }];
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockData);
+    mockHttpClient.get.mockResolvedValue({ data: mockData });
+  });
+
+  it('should fetch cohorts and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+    mockHttpClient.get.mockResolvedValue({ data: mockData });
+
+    const result = await getCohorts(courseId);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/courses/${courseId}/cohorts/`
+    );
+    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
+    expect(result).toEqual(mockData);
+  });
+});
+
+describe('toggleCohorts', () => {
+  const mockData = { is_cohorted: true };
+  const mockCamelCasedData = { isCohorted: true };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCasedData);
+  });
+
+  it('should toggle cohorts and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+    const isCohorted = true;
+    mockHttpClient.put.mockResolvedValue({ data: mockData });
+
+    const result = await toggleCohorts(courseId, isCohorted);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`,
+      { is_cohorted: isCohorted }
+    );
+    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
+    expect(result).toEqual(mockCamelCasedData);
+  });
+});

--- a/src/cohorts/data/api.test.ts
+++ b/src/cohorts/data/api.test.ts
@@ -21,7 +21,7 @@ describe('getCohortStatus', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCaseCohortStatusData);
     mockHttpClient.get.mockResolvedValue({ data: mockCohortStatusData });
@@ -45,7 +45,7 @@ describe('getCohorts', () => {
   const mockData = [{ id: 1, name: 'Cohort 1' }];
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockData);
     mockHttpClient.get.mockResolvedValue({ data: mockData });
@@ -72,7 +72,7 @@ describe('toggleCohorts', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCasedData);
   });

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -1,0 +1,20 @@
+import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { getApiBaseUrl } from '../../data/api';
+
+export const getCohortStatus = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return camelCaseObject(data);
+};
+
+export const getCohorts = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return camelCaseObject(data);
+};
+
+export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
+  const { data } = await getAuthenticatedHttpClient().put(url, { is_cohorted: isCohorted });
+  return camelCaseObject(data);
+};

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCohorts, getCohortStatus, toggleCohorts } from './api';
+import { cohortsQueryKeys } from './queryKeys';
+
+export const useCohortStatus = (courseId: string) => (
+  useQuery({
+    queryKey: cohortsQueryKeys.enabled(courseId),
+    queryFn: () => getCohortStatus(courseId),
+    enabled: !!courseId,
+  })
+);
+
+export const useCohorts = (courseId: string) => (
+  useQuery({
+    queryKey: cohortsQueryKeys.list(courseId),
+    queryFn: () => getCohorts(courseId),
+    enabled: !!courseId,
+  })
+);
+
+export const useToggleCohorts = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return (useMutation({
+    mutationFn: ({ isCohorted }: { isCohorted: boolean }) => toggleCohorts(courseId, isCohorted),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.enabled(courseId) });
+    },
+  }));
+};

--- a/src/cohorts/data/queryKeys.ts
+++ b/src/cohorts/data/queryKeys.ts
@@ -1,0 +1,7 @@
+import { appId } from '../../constants';
+
+export const cohortsQueryKeys = {
+  all: [appId, 'cohorts'] as const,
+  list: (courseId: string) => [...cohortsQueryKeys.all, courseId, 'list'] as const,
+  enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
+};

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -1,0 +1,56 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+  cohortsTitle: {
+    id: 'instruct.cohorts.title',
+    defaultMessage: 'Cohorts',
+    description: 'Title for the cohorts page'
+  },
+  addCohort: {
+    id: 'instruct.cohorts.addCohort',
+    defaultMessage: 'Add Cohort',
+    description: 'Button label for adding a new cohort'
+  },
+  disableMessage: {
+    id: 'instruct.cohorts.disableModal.disableMessage',
+    defaultMessage: 'Disable Cohorts? Disabling cohorts while a course is in progress will cause an unexpected change for your learners.',
+    description: 'Message displayed in the disable cohorts confirmation modal'
+  },
+  cancelLabel: {
+    id: 'instruct.cohorts.disableModal.cancelLabel',
+    defaultMessage: 'Cancel',
+    description: 'Label for the cancel button in the disable cohorts modal'
+  },
+  disableLabel: {
+    id: 'instruct.cohorts.disableModal.disableLabel',
+    defaultMessage: 'Disable',
+    description: 'Label for the disable button in the disable cohorts modal'
+  },
+  modalTitle: {
+    id: 'instruct.cohorts.disableModal.title',
+    defaultMessage: 'Disable Cohorts',
+    description: 'Title for the disable cohorts confirmation modal'
+  },
+  noCohortsMessage: {
+    id: 'instruct.cohorts.noCohortsMessage',
+    defaultMessage: 'You can use Cohorts to create smaller communities in your course, or to design different course experiences for different groups of learners.',
+    description: 'Message displayed when there are no cohorts'
+  },
+  learnMore: {
+    id: 'instruct.cohorts.learnMore',
+    defaultMessage: 'Learn more',
+    description: 'Label for the learn more link'
+  },
+  enableCohorts: {
+    id: 'instruct.cohorts.enableCohorts',
+    defaultMessage: 'Enable Cohorts',
+    description: 'Label for the enable cohorts button'
+  },
+  disableCohorts: {
+    id: 'instruct.cohorts.disableCohorts',
+    defaultMessage: 'Disable Cohorts',
+    description: 'Label for the disable cohorts button'
+  },
+});
+
+export default messages;

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -26,11 +26,6 @@ const messages = defineMessages({
     defaultMessage: 'Disable',
     description: 'Label for the disable button in the disable cohorts modal'
   },
-  modalTitle: {
-    id: 'instruct.cohorts.disableModal.title',
-    defaultMessage: 'Disable Cohorts',
-    description: 'Title for the disable cohorts confirmation modal'
-  },
   noCohortsMessage: {
     id: 'instruct.cohorts.noCohortsMessage',
     defaultMessage: 'You can use Cohorts to create smaller communities in your course, or to design different course experiences for different groups of learners.',
@@ -51,6 +46,11 @@ const messages = defineMessages({
     defaultMessage: 'Disable Cohorts',
     description: 'Label for the disable cohorts button'
   },
+  selectCohortPlaceholder: {
+    id: 'instruct.cohorts.selectCohortPlaceholder',
+    defaultMessage: 'Select a cohort',
+    description: 'Placeholder text for the select cohort dropdown'
+  }
 });
 
 export default messages;

--- a/src/data/api.test.ts
+++ b/src/data/api.test.ts
@@ -18,7 +18,7 @@ describe('getCourseInfo', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: 'https://test-lms.com' });
+    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://test-lms.com' });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
     mockHttpClient.get.mockResolvedValue({ data: mockCourseData });

--- a/src/data/api.test.ts
+++ b/src/data/api.test.ts
@@ -1,10 +1,7 @@
-import { getCourseInfo, getCohortStatus, getCohorts, toggleCohorts } from './api';
+import { getCourseInfo } from './api';
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { appId } from '../constants';
 
 jest.mock('@openedx/frontend-base');
-
-const mockBaseUrl = 'https://cms.example.com';
 
 const mockHttpClient = {
   get: jest.fn(),
@@ -41,84 +38,5 @@ describe('getCourseInfo', () => {
     const error = new Error('Network error');
     mockHttpClient.get.mockRejectedValue(error);
     await expect(getCourseInfo('test-course')).rejects.toThrow('Network error');
-  });
-});
-
-describe('getCohortStatus', () => {
-  const mockCohortStatusData = { is_cohorted: true };
-  const mockCamelCaseCohortStatusData = { isCohorted: true };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
-    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
-    mockCamelCaseObject.mockReturnValue(mockCamelCaseCohortStatusData);
-    mockHttpClient.get.mockResolvedValue({ data: mockCohortStatusData });
-  });
-
-  it('should fetch cohort status and return camelCased data', async () => {
-    const courseId = 'course-v1:edX+DemoX+Demo_Course';
-
-    const result = await getCohortStatus(courseId);
-
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
-    expect(mockHttpClient.get).toHaveBeenCalledWith(
-      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`
-    );
-    expect(mockCamelCaseObject).toHaveBeenCalledWith(mockCohortStatusData);
-    expect(result).toEqual(mockCamelCaseCohortStatusData);
-  });
-});
-
-describe('getCohorts', () => {
-  const mockData = [{ id: 1, name: 'Cohort 1' }];
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
-    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
-    mockCamelCaseObject.mockReturnValue(mockData);
-    mockHttpClient.get.mockResolvedValue({ data: mockData });
-  });
-
-  it('should fetch cohorts and return camelCased data', async () => {
-    const courseId = 'course-v1:edX+DemoX+Demo_Course';
-    mockHttpClient.get.mockResolvedValue({ data: mockData });
-
-    const result = await getCohorts(courseId);
-
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
-    expect(mockHttpClient.get).toHaveBeenCalledWith(
-      `${mockBaseUrl}/api/cohorts/v1/courses/${courseId}/cohorts/`
-    );
-    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
-    expect(result).toEqual(mockData);
-  });
-});
-
-describe('toggleCohorts', () => {
-  const mockData = { is_cohorted: true };
-  const mockCamelCasedData = { isCohorted: true };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
-    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
-    mockCamelCaseObject.mockReturnValue(mockCamelCasedData);
-  });
-
-  it('should toggle cohorts and return camelCased data', async () => {
-    const courseId = 'course-v1:edX+DemoX+Demo_Course';
-    const isCohorted = true;
-    mockHttpClient.put.mockResolvedValue({ data: mockData });
-
-    const result = await toggleCohorts(courseId, isCohorted);
-
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
-    expect(mockHttpClient.put).toHaveBeenCalledWith(
-      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`,
-      { is_cohorted: isCohorted }
-    );
-    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
-    expect(result).toEqual(mockCamelCasedData);
   });
 });

--- a/src/data/api.test.ts
+++ b/src/data/api.test.ts
@@ -1,22 +1,27 @@
-import { getCourseInfo } from './api';
+import { getCourseInfo, getCohortStatus, getCohorts, toggleCohorts } from './api';
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { appId } from '../constants';
 
 jest.mock('@openedx/frontend-base');
+
+const mockBaseUrl = 'https://cms.example.com';
+
+const mockHttpClient = {
+  get: jest.fn(),
+  put: jest.fn(),
+};
 
 const mockGetAppConfig = getAppConfig as jest.MockedFunction<typeof getAppConfig>;
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
 describe('getCourseInfo', () => {
-  const mockHttpClient = {
-    get: jest.fn(),
-  };
   const mockCourseData = { course_name: 'Test Course' };
   const mockCamelCaseData = { courseName: 'Test Course' };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://test-lms.com' });
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: 'https://test-lms.com' });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
     mockHttpClient.get.mockResolvedValue({ data: mockCourseData });
@@ -36,5 +41,84 @@ describe('getCourseInfo', () => {
     const error = new Error('Network error');
     mockHttpClient.get.mockRejectedValue(error);
     await expect(getCourseInfo('test-course')).rejects.toThrow('Network error');
+  });
+});
+
+describe('getCohortStatus', () => {
+  const mockCohortStatusData = { is_cohorted: true };
+  const mockCamelCaseCohortStatusData = { isCohorted: true };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseCohortStatusData);
+    mockHttpClient.get.mockResolvedValue({ data: mockCohortStatusData });
+  });
+
+  it('should fetch cohort status and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+
+    const result = await getCohortStatus(courseId);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`
+    );
+    expect(mockCamelCaseObject).toHaveBeenCalledWith(mockCohortStatusData);
+    expect(result).toEqual(mockCamelCaseCohortStatusData);
+  });
+});
+
+describe('getCohorts', () => {
+  const mockData = [{ id: 1, name: 'Cohort 1' }];
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockData);
+    mockHttpClient.get.mockResolvedValue({ data: mockData });
+  });
+
+  it('should fetch cohorts and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+    mockHttpClient.get.mockResolvedValue({ data: mockData });
+
+    const result = await getCohorts(courseId);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/courses/${courseId}/cohorts/`
+    );
+    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
+    expect(result).toEqual(mockData);
+  });
+});
+
+describe('toggleCohorts', () => {
+  const mockData = { is_cohorted: true };
+  const mockCamelCasedData = { isCohorted: true };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAppConfig.mockReturnValue({ CMS_BASE_URL: mockBaseUrl });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCasedData);
+  });
+
+  it('should toggle cohorts and return camelCased data', async () => {
+    const courseId = 'course-v1:edX+DemoX+Demo_Course';
+    const isCohorted = true;
+    mockHttpClient.put.mockResolvedValue({ data: mockData });
+
+    const result = await toggleCohorts(courseId, isCohorted);
+
+    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(mockHttpClient.put).toHaveBeenCalledWith(
+      `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`,
+      { is_cohorted: isCohorted }
+    );
+    expect(camelCaseObject).toHaveBeenCalledWith(mockData);
+    expect(result).toEqual(mockCamelCasedData);
   });
 });

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -13,3 +13,21 @@ export const getCourseInfo = async (courseId) => {
     .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}`);
   return camelCaseObject(data);
 };
+
+export const getCohorts = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return data;
+};
+
+export const enableCohorts = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/enable/`;
+  const { data } = await getAuthenticatedHttpClient().post(url);
+  return camelCaseObject(data);
+};
+
+export const disableCohorts = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/disable/`;
+  const { data } = await getAuthenticatedHttpClient().post(url);
+  return camelCaseObject(data);
+};

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { appId } from '../constants';
 
-const getApiBaseUrl = () => getAppConfig(appId).CMS_BASE_URL;
+export const getApiBaseUrl = () => getAppConfig(appId).CMS_BASE_URL;
 
 /**
  * Get course settings.
@@ -11,23 +11,5 @@ const getApiBaseUrl = () => getAppConfig(appId).CMS_BASE_URL;
 export const getCourseInfo = async (courseId) => {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}`);
-  return camelCaseObject(data);
-};
-
-export const getCohortStatus = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
-  const { data } = await getAuthenticatedHttpClient().get(url);
-  return camelCaseObject(data);
-};
-
-export const getCohorts = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/`;
-  const { data } = await getAuthenticatedHttpClient().get(url);
-  return camelCaseObject(data);
-};
-
-export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
-  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
-  const { data } = await getAuthenticatedHttpClient().put(url, { is_cohorted: isCohorted });
   return camelCaseObject(data);
 };

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { appId } from '../constants';
 
-const getApiBaseUrl = () => getAppConfig(appId).LMS_BASE_URL;
+const getApiBaseUrl = () => getAppConfig(appId).CMS_BASE_URL;
 
 /**
  * Get course settings.
@@ -14,20 +14,20 @@ export const getCourseInfo = async (courseId) => {
   return camelCaseObject(data);
 };
 
-export const getCohorts = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/`;
+export const getCohortStatus = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
   const { data } = await getAuthenticatedHttpClient().get(url);
-  return data;
-};
-
-export const enableCohorts = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/enable/`;
-  const { data } = await getAuthenticatedHttpClient().post(url);
   return camelCaseObject(data);
 };
 
-export const disableCohorts = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/disable/`;
-  const { data } = await getAuthenticatedHttpClient().post(url);
+export const getCohorts = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return camelCaseObject(data);
+};
+
+export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
+  const { data } = await getAuthenticatedHttpClient().put(url, { is_cohorted: isCohorted });
   return camelCaseObject(data);
 };

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { appId } from '../constants';
 
-export const getApiBaseUrl = () => getAppConfig(appId).CMS_BASE_URL;
+export const getApiBaseUrl = () => getAppConfig(appId).LMS_BASE_URL;
 
 /**
  * Get course settings.

--- a/src/data/apiHook.ts
+++ b/src/data/apiHook.ts
@@ -1,6 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCourseInfo, getCohorts, getCohortStatus, toggleCohorts } from './api';
-import { courseInfoQueryKeys, cohortsQueryKeys } from './queryKeys';
+import { useQuery } from '@tanstack/react-query';
+import { getCourseInfo } from './api';
+import { courseInfoQueryKeys } from './queryKeys';
 
 export const useCourseInfo = (courseId: string) => (
   useQuery({
@@ -8,29 +8,3 @@ export const useCourseInfo = (courseId: string) => (
     queryFn: () => getCourseInfo(courseId),
   })
 );
-
-export const useCohortStatus = (courseId: string) => (
-  useQuery({
-    queryKey: cohortsQueryKeys.enabled(courseId),
-    queryFn: () => getCohortStatus(courseId),
-    enabled: !!courseId,
-  })
-);
-
-export const useCohorts = (courseId: string) => (
-  useQuery({
-    queryKey: cohortsQueryKeys.list(courseId),
-    queryFn: () => getCohorts(courseId),
-    enabled: !!courseId,
-  })
-);
-
-export const useToggleCohorts = (courseId: string) => {
-  const queryClient = useQueryClient();
-  return (useMutation({
-    mutationFn: ({ isCohorted }: { isCohorted: boolean }) => toggleCohorts(courseId, isCohorted),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.enabled(courseId) });
-    },
-  }));
-};

--- a/src/data/apiHook.ts
+++ b/src/data/apiHook.ts
@@ -1,21 +1,18 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { getCourseInfo, disableCohorts, enableCohorts, getCohorts } from './api';
-import { appId } from '../constants';
-
-const courseInfoQueryKeys = {
-  all: [appId, 'courseInfo'] as const,
-  byCourse: (courseId: string) => [appId, 'courseInfo', courseId] as const,
-};
-
-export const cohortsQueryKeys = {
-  all: [appId, 'cohorts'] as const,
-  list: (courseId: string) => [...cohortsQueryKeys.all, 'list', courseId] as const,
-};
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCourseInfo, getCohorts, getCohortStatus, toggleCohorts } from './api';
+import { courseInfoQueryKeys, cohortsQueryKeys } from './queryKeys';
 
 export const useCourseInfo = (courseId: string) => (
   useQuery({
     queryKey: courseInfoQueryKeys.byCourse(courseId),
     queryFn: () => getCourseInfo(courseId),
+  })
+);
+
+export const useCohortStatus = (courseId: string) => (
+  useQuery({
+    queryKey: cohortsQueryKeys.enabled(courseId),
+    queryFn: () => getCohortStatus(courseId),
   })
 );
 
@@ -26,14 +23,12 @@ export const useCohorts = (courseId: string) => (
   })
 );
 
-export const useEnableCohorts = (courseId: string) => (
-  useMutation({
-    mutationFn: () => enableCohorts(courseId),
-  })
-);
-
-export const useDisableCohorts = (courseId: string) => (
-  useMutation({
-    mutationFn: () => disableCohorts(courseId),
-  })
-);
+export const useToggleCohorts = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return (useMutation({
+    mutationFn: ({ isCohorted }: { isCohorted: boolean }) => toggleCohorts(courseId, isCohorted),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.enabled(courseId) });
+    },
+  }));
+};

--- a/src/data/apiHook.ts
+++ b/src/data/apiHook.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { getCourseInfo } from './api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getCourseInfo, disableCohorts, enableCohorts, getCohorts } from './api';
 import { appId } from '../constants';
 
 const courseInfoQueryKeys = {
@@ -7,9 +7,33 @@ const courseInfoQueryKeys = {
   byCourse: (courseId: string) => [appId, 'courseInfo', courseId] as const,
 };
 
+export const cohortsQueryKeys = {
+  all: [appId, 'cohorts'] as const,
+  list: (courseId: string) => [...cohortsQueryKeys.all, 'list', courseId] as const,
+};
+
 export const useCourseInfo = (courseId: string) => (
   useQuery({
     queryKey: courseInfoQueryKeys.byCourse(courseId),
     queryFn: () => getCourseInfo(courseId),
+  })
+);
+
+export const useCohorts = (courseId: string) => (
+  useQuery({
+    queryKey: cohortsQueryKeys.list(courseId),
+    queryFn: () => getCohorts(courseId),
+  })
+);
+
+export const useEnableCohorts = (courseId: string) => (
+  useMutation({
+    mutationFn: () => enableCohorts(courseId),
+  })
+);
+
+export const useDisableCohorts = (courseId: string) => (
+  useMutation({
+    mutationFn: () => disableCohorts(courseId),
   })
 );

--- a/src/data/apiHook.ts
+++ b/src/data/apiHook.ts
@@ -13,6 +13,7 @@ export const useCohortStatus = (courseId: string) => (
   useQuery({
     queryKey: cohortsQueryKeys.enabled(courseId),
     queryFn: () => getCohortStatus(courseId),
+    enabled: !!courseId,
   })
 );
 
@@ -20,6 +21,7 @@ export const useCohorts = (courseId: string) => (
   useQuery({
     queryKey: cohortsQueryKeys.list(courseId),
     queryFn: () => getCohorts(courseId),
+    enabled: !!courseId,
   })
 );
 

--- a/src/data/queryKeys.ts
+++ b/src/data/queryKeys.ts
@@ -1,0 +1,12 @@
+import { appId } from '../constants';
+
+export const courseInfoQueryKeys = {
+  all: [appId, 'courseInfo'] as const,
+  byCourse: (courseId: string) => [appId, 'courseInfo', courseId] as const,
+};
+
+export const cohortsQueryKeys = {
+  all: [appId, 'cohorts'] as const,
+  list: (courseId: string) => [...cohortsQueryKeys.all, courseId, 'list'] as const,
+  enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
+};

--- a/src/data/queryKeys.ts
+++ b/src/data/queryKeys.ts
@@ -4,9 +4,3 @@ export const courseInfoQueryKeys = {
   all: [appId, 'courseInfo'] as const,
   byCourse: (courseId: string) => [appId, 'courseInfo', courseId] as const,
 };
-
-export const cohortsQueryKeys = {
-  all: [appId, 'cohorts'] as const,
-  list: (courseId: string) => [...cohortsQueryKeys.all, courseId, 'list'] as const,
-  enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
-};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,3 +1,4 @@
+import CohortsPage from './cohorts/CohortsPage';
 import CourseInfoPage from './courseInfo/CourseInfoPage';
 import Main from './Main';
 
@@ -18,10 +19,10 @@ const routes = [
       //   path: 'membership',
       //   element: <MembershipPage />
       // },
-      // {
-      //   path: 'cohorts',
-      //   element: <CohortsPage />
-      // },
+      {
+        path: 'cohorts',
+        element: <CohortsPage />
+      },
       // {
       //   path: 'extensions',
       //   element: <ExtensionsPage />


### PR DESCRIPTION
## Description

We introduce Main cohorts page including:
- 2 states enabled/disabled cohorts
- A dialog when you click on settings icon to disable cohorts on current course
- Features without interactions (Will be handled on a diff PR): 
  - Add a cohort 
  - Selection of a cohort

### Screenshots
- Disabled cohorts view
<img width="1587" height="935" alt="Screenshot 2025-12-09 at 3 37 49 p m" src="https://github.com/user-attachments/assets/9d586659-9a90-419b-a921-a1888fb3d72d" />

- Enabled cohorts view
<img width="1584" height="761" alt="Screenshot 2025-12-09 at 3 39 00 p m" src="https://github.com/user-attachments/assets/590491c7-dd49-43ab-981b-343fefce9191" />

- onClick settings button
<img width="1477" height="609" alt="Screenshot 2025-11-26 at 6 34 40 p m" src="https://github.com/user-attachments/assets/0bfc19f1-afd4-4947-9d75-6dc356754ca2" />

## Supporting information
Closes #50 

## Testing instructions
- Go to a valid url with courseId and cohorts path, example:
http://apps.local.openedx.io:8080/instructor/course-v1:OpenedX+DemoX+DemoCourse/cohorts 

- Click on enable cohorts, learn more or if you already have it enabled click on settings icon and disable cohorts.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
