### PR TITLE
Date extensions Filter and Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
-        "@tanstack/react-query-devtools": "^5.90.2"
+        "@tanstack/react-query-devtools": "^5.90.2",
+        "lodash": "^4.17.23"
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.5.0",
@@ -10771,7 +10772,6 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
       "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -19081,7 +19081,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -19102,7 +19101,6 @@
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.97.3.tgz",
       "integrity": "sha512-eKzFy13Nk+IRHhlAwP3sfuv+PzOrvzUkwJK2hdoCKYcWGSdmwFpeGpWmyewdw8EgBnsKaSBtgf/0b2K635ecSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/openedx-atlas": "^0.7.0",
-    "@tanstack/react-query-devtools": "^5.90.2"
+    "@tanstack/react-query-devtools": "^5.90.2",
+    "lodash": "^4.17.23"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DateExtensionsPage from './DateExtensionsPage';
-import { useDateExtensions, useResetDateExtensionMutation } from './data/apiHook';
+import { useDateExtensions, useGradedSubsections, useAddDateExtensionMutation, useResetDateExtensionMutation } from './data/apiHook';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 
 jest.mock('react-router-dom', () => ({
@@ -15,6 +15,7 @@ jest.mock('./data/apiHook', () => ({
   useDateExtensions: jest.fn(),
   useResetDateExtensionMutation: jest.fn(),
   useAddDateExtensionMutation: jest.fn(() => ({ mutate: jest.fn() })),
+  useGradedSubsections: jest.fn(),
 }));
 
 const mockDateExtensions = [
@@ -28,6 +29,13 @@ const mockDateExtensions = [
   },
 ];
 
+const mockGradedSubsections = [
+  {
+    subsectionId: 'subsection-1block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+    displayName: 'Three body diagrams'
+  }
+];
+
 const mutateMock = jest.fn();
 
 describe('DateExtensionsPage', () => {
@@ -38,6 +46,13 @@ describe('DateExtensionsPage', () => {
     });
     (useResetDateExtensionMutation as jest.Mock).mockReturnValue({
       mutate: mutateMock,
+    });
+    (useAddDateExtensionMutation as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
+    });
+    (useGradedSubsections as jest.Mock).mockReturnValue({
+      data: { items: mockGradedSubsections },
+      isLoading: false,
     });
   });
 
@@ -54,7 +69,7 @@ describe('DateExtensionsPage', () => {
   it('renders date extensions list', () => {
     renderWithAlertAndIntl(<DateExtensionsPage />);
     expect(screen.getByText('Ed Byun')).toBeInTheDocument();
-    expect(screen.getByText('Three body diagrams')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Three body diagrams' })).toBeInTheDocument();
   });
 
   it('shows loading state on table when fetching data', () => {

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -78,7 +78,7 @@ describe('DateExtensionsPage', () => {
       isLoading: true,
     });
     renderWithAlertAndIntl(<DateExtensionsPage />);
-    expect(document.querySelectorAll('.react-loading-skeleton')).toHaveLength(6);
+    expect(screen.getByTestId('data-table-spinner')).toBeInTheDocument();
   });
 
   it('renders reset link for each row', () => {

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -78,7 +78,7 @@ describe('DateExtensionsPage', () => {
       isLoading: true,
     });
     renderWithAlertAndIntl(<DateExtensionsPage />);
-    expect(screen.getByTestId('data-table-spinner')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders reset link for each row', () => {

--- a/src/dateExtensions/DateExtensionsPage.test.tsx
+++ b/src/dateExtensions/DateExtensionsPage.test.tsx
@@ -78,7 +78,7 @@ describe('DateExtensionsPage', () => {
       isLoading: true,
     });
     renderWithAlertAndIntl(<DateExtensionsPage />);
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(document.querySelectorAll('.react-loading-skeleton')).toHaveLength(6);
   });
 
   it('renders reset link for each row', () => {

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { Button } from '@openedx/paragon';
+import { Button, FormControl, Icon } from '@openedx/paragon';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import ResetExtensionsModal from './components/ResetExtensionsModal';
@@ -11,6 +11,7 @@ import { useAlert } from '@src/providers/AlertProvider';
 import AddExtensionModal from './components/AddExtensionModal';
 import { APIError } from '@src/types';
 import SelectGradedSubsection from './components/SelectGradedSubsection';
+import { Search } from '@openedx/paragon/icons';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
@@ -21,6 +22,8 @@ const DateExtensionsPage = () => {
   const isResetModalOpen = selectedUser !== null;
   const { showToast, showModal, removeAlert, clearAlerts } = useAlert();
   const [isAddExtensionModalOpen, setIsAddExtensionModalOpen] = useState(false);
+  const [searchedLearner, setSearchedLearner] = useState<string>('');
+  const [gradedSubsectionFilter, setGradedSubsectionFilter] = useState<string>('');
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
     clearAlerts();
@@ -86,15 +89,26 @@ const DateExtensionsPage = () => {
     <div className="mt-4.5 mb-4 mx-4">
       <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
       <div className="d-flex align-items-center justify-content-between mb-3.5">
-        <div>
+        <div className="d-flex">
+          <FormControl
+            onChange={(e) => setSearchedLearner(e.target.value)}
+            placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
+            trailingElement={<Icon src={Search} />}
+            value={searchedLearner}
+          />
           <SelectGradedSubsection
             placeholder={intl.formatMessage(messages.allGradedSubsections)}
-            onChange={() => {}}
+            onChange={(e) => setGradedSubsectionFilter(e.target.value)}
+            value={gradedSubsectionFilter}
           />
         </div>
         <Button onClick={() => setIsAddExtensionModalOpen(true)}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
-      <DateExtensionsList onResetExtensions={handleResetExtensions} />
+      <DateExtensionsList
+        emailOrUsername={searchedLearner}
+        blockId={gradedSubsectionFilter}
+        onResetExtensions={handleResetExtensions}
+      />
       <AddExtensionModal
         isOpen={isAddExtensionModalOpen}
         title={intl.formatMessage(messages.addIndividualDueDateExtension)}

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, FormControl, Icon } from '@openedx/paragon';
 import messages from './messages';
 import DateExtensionsList from './components/DateExtensionsList';
 import ResetExtensionsModal from './components/ResetExtensionsModal';
@@ -10,8 +9,6 @@ import { useAddDateExtensionMutation, useResetDateExtensionMutation } from './da
 import { useAlert } from '@src/providers/AlertProvider';
 import AddExtensionModal from './components/AddExtensionModal';
 import { APIError } from '@src/types';
-import SelectGradedSubsection from './components/SelectGradedSubsection';
-import { Search } from '@openedx/paragon/icons';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
@@ -22,8 +19,6 @@ const DateExtensionsPage = () => {
   const isResetModalOpen = selectedUser !== null;
   const { showToast, showModal, removeAlert, clearAlerts } = useAlert();
   const [isAddExtensionModalOpen, setIsAddExtensionModalOpen] = useState(false);
-  const [searchedLearner, setSearchedLearner] = useState<string>('');
-  const [gradedSubsectionFilter, setGradedSubsectionFilter] = useState<string>('');
 
   const handleResetExtensions = (user: LearnerDateExtension) => {
     clearAlerts();
@@ -87,26 +82,9 @@ const DateExtensionsPage = () => {
 
   return (
     <div className="mt-4.5 mb-4 mx-4">
-      <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
-      <div className="d-flex align-items-center justify-content-between mb-3.5">
-        <div className="d-flex">
-          <FormControl
-            onChange={(e) => setSearchedLearner(e.target.value)}
-            placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
-            trailingElement={<Icon src={Search} />}
-            value={searchedLearner}
-          />
-          <SelectGradedSubsection
-            placeholder={intl.formatMessage(messages.allGradedSubsections)}
-            onChange={(e) => setGradedSubsectionFilter(e.target.value)}
-            value={gradedSubsectionFilter}
-          />
-        </div>
-        <Button onClick={() => setIsAddExtensionModalOpen(true)}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
-      </div>
+      <h3 className="mb-4.5">{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
       <DateExtensionsList
-        emailOrUsername={searchedLearner}
-        blockId={gradedSubsectionFilter}
+        onClickAdd={() => setIsAddExtensionModalOpen(true)}
         onResetExtensions={handleResetExtensions}
       />
       <AddExtensionModal

--- a/src/dateExtensions/DateExtensionsPage.tsx
+++ b/src/dateExtensions/DateExtensionsPage.tsx
@@ -10,6 +10,7 @@ import { useAddDateExtensionMutation, useResetDateExtensionMutation } from './da
 import { useAlert } from '@src/providers/AlertProvider';
 import AddExtensionModal from './components/AddExtensionModal';
 import { APIError } from '@src/types';
+import SelectGradedSubsection from './components/SelectGradedSubsection';
 
 const DateExtensionsPage = () => {
   const intl = useIntl();
@@ -85,7 +86,12 @@ const DateExtensionsPage = () => {
     <div className="mt-4.5 mb-4 mx-4">
       <h3>{intl.formatMessage(messages.dateExtensionsTitle)}</h3>
       <div className="d-flex align-items-center justify-content-between mb-3.5">
-        <p>filters</p>
+        <div>
+          <SelectGradedSubsection
+            placeholder={intl.formatMessage(messages.allGradedSubsections)}
+            onChange={() => {}}
+          />
+        </div>
         <Button onClick={() => setIsAddExtensionModalOpen(true)}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
       <DateExtensionsList onResetExtensions={handleResetExtensions} />

--- a/src/dateExtensions/components/AddExtensionModal.test.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.test.tsx
@@ -1,0 +1,78 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddExtensionModal from './AddExtensionModal';
+import { renderWithQueryClient } from '@src/testUtils';
+
+const mockProps = {
+  isOpen: true,
+  title: 'Add Extension Test',
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+};
+
+describe('AddExtensionModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal when isOpen is true', () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} />);
+    expect(screen.getByText(mockProps.title)).toBeInTheDocument();
+  });
+
+  it('does not render modal when isOpen is false', () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} isOpen={false} />);
+    expect(screen.queryByText(mockProps.title)).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits form with correct data', async () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} />);
+    const user = userEvent.setup();
+
+    const dueDateInput = screen.getByLabelText(/extension date/i);
+    const dueTimeInput = document.querySelector('input[type="time"]') as HTMLInputElement;
+    const reasonInput = screen.getByPlaceholderText(/reason/i);
+
+    await user.type(dueDateInput, '2024-12-31');
+    await user.type(dueTimeInput, '23:59');
+    await user.type(reasonInput, 'Medical emergency');
+
+    await user.click(screen.getByRole('button', { name: /add extension/i }));
+
+    await waitFor(() => {
+      expect(mockProps.onSubmit).toHaveBeenCalledWith({
+        emailOrUsername: '',
+        blockId: '',
+        dueDatetime: new Date('2024-12-31T23:59').toISOString(),
+        reason: 'Medical emergency'
+      });
+    });
+  });
+
+  it('updates form data when input values change', async () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} />);
+    const user = userEvent.setup();
+
+    const reasonInput = screen.getByPlaceholderText(/reason/i);
+    await user.type(reasonInput, 'Test reason');
+
+    expect(reasonInput).toHaveValue('Test reason');
+  });
+
+  it('renders all required form fields', () => {
+    renderWithQueryClient(<AddExtensionModal {...mockProps} />);
+
+    expect(screen.getByLabelText(/Specify Learner/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Select Graded Subsection/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/extension date/i)).toBeInTheDocument();
+    expect(document.querySelector('input[type="time"]')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/reason/i)).toBeInTheDocument();
+  });
+});

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -41,10 +41,10 @@ describe('DateExtensionsList', () => {
     <DateExtensionsList {...props} />
   );
 
-  it('renders skeletons when loading', () => {
+  it('renders loading state on the table', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: true, data: { count: 0, results: [] } });
     renderComponent({});
-    expect(screen.getByTestId('data-table-spinner')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('renders table with data', async () => {

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -17,6 +17,7 @@ const mockData = [
 
 jest.mock('../data/apiHook', () => ({
   useDateExtensions: jest.fn(),
+  useGradedSubsections: jest.fn().mockReturnValue({ data: { items: [] } }),
 }));
 
 const mockResetExtensions = jest.fn();
@@ -26,10 +27,10 @@ describe('DateExtensionsList', () => {
     <DateExtensionsList {...props} />
   );
 
-  it('renders loading state on the table', () => {
+  it('renders skeletons when loading', () => {
     (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: true, data: { count: 0, results: [] } });
     renderComponent({});
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(document.querySelectorAll('.react-loading-skeleton')).toHaveLength(6);
   });
 
   it('renders table with data', async () => {

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -1,8 +1,10 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DateExtensionsList, { DateExtensionListProps } from './DateExtensionsList';
 import { renderWithIntl } from '../../testUtils';
-import { useDateExtensions } from '../data/apiHook';
+import { useDateExtensions, useGradedSubsections } from '../data/apiHook';
+
+const testCourseId = 'course-v1:edX+DemoX+Demo_Course';
 
 const mockData = [
   {
@@ -15,12 +17,24 @@ const mockData = [
   }
 ];
 
+const mockGradedSubsections = [
+  {
+    subsectionId: 'subsection-1block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+    displayName: 'Three body diagrams'
+  }
+];
+
 jest.mock('../data/apiHook', () => ({
   useDateExtensions: jest.fn(),
   useGradedSubsections: jest.fn().mockReturnValue({ data: { items: [] } }),
 }));
 
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ courseId: testCourseId }),
+}));
+
 const mockResetExtensions = jest.fn();
+const mockOnClickAdd = jest.fn();
 
 describe('DateExtensionsList', () => {
   const renderComponent = (props: DateExtensionListProps) => renderWithIntl(
@@ -53,5 +67,181 @@ describe('DateExtensionsList', () => {
     renderComponent({});
     expect(screen.queryByText(mockData[0].username)).not.toBeInTheDocument();
     expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('renders add extension button and handles click', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: 0, results: [] } });
+    renderComponent({ onClickAdd: mockOnClickAdd });
+    const user = userEvent.setup();
+
+    const addButton = screen.getByRole('button', { name: /add individual extension/i });
+    expect(addButton).toBeInTheDocument();
+
+    await user.click(addButton);
+    expect(mockOnClickAdd).toHaveBeenCalled();
+  });
+
+  it('filters by username/email when typing in search input', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: mockData.length, results: mockData } });
+    renderComponent({});
+    const user = userEvent.setup();
+
+    const searchInput = screen.getByPlaceholderText(/search for a learner/i);
+    expect(searchInput).toBeInTheDocument();
+
+    await user.type(searchInput, 'test_user');
+
+    await waitFor(() => {
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: '',
+        emailOrUsername: 'test_user',
+        page: 0,
+        pageSize: 25,
+      });
+    }, { timeout: 700 });
+  });
+
+  it('debounces search input to avoid excessive API calls', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: mockData.length, results: mockData } });
+    renderComponent({});
+    const user = userEvent.setup();
+
+    const searchInput = screen.getByPlaceholderText(/search for a learner/i);
+
+    // Type multiple characters quickly
+    await user.type(searchInput, 'test');
+
+    // Should not call immediately
+    expect(useDateExtensions).not.toHaveBeenCalledWith(testCourseId, {
+      blockId: '',
+      emailOrUsername: 'test',
+      page: 0,
+      pageSize: 25,
+    });
+
+    // Wait for debounce
+    await waitFor(() => {
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: '',
+        emailOrUsername: 'test',
+        page: 0,
+        pageSize: 25,
+      });
+    }, { timeout: 700 });
+  });
+
+  it('filters by graded subsection when selecting from dropdown', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({ isLoading: false, data: { count: mockData.length, results: mockData } });
+    (useGradedSubsections as jest.Mock).mockReturnValue({
+      data: { items: mockGradedSubsections },
+      isLoading: false,
+    });
+    renderComponent({});
+    const user = userEvent.setup();
+
+    const subsectionSelect = screen.getByPlaceholderText('All Graded Subsections');
+    expect(subsectionSelect).toBeInTheDocument();
+
+    await user.selectOptions(subsectionSelect, mockGradedSubsections[0].subsectionId);
+
+    await waitFor(() => {
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: mockGradedSubsections[0].subsectionId,
+        emailOrUsername: '',
+        page: 0,
+        pageSize: 25,
+      });
+    }, { timeout: 700 });
+  });
+
+  it('resets page to 0 when filters change', async () => {
+    // Start with some data on page 1
+    (useDateExtensions as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: { count: 50, results: mockData, numPages: 2 }
+    });
+
+    renderComponent({});
+    const user = userEvent.setup();
+
+    // Navigate to page 2 first (simulate pagination)
+    const nextPageButton = screen.getByLabelText(/next/i);
+    if (nextPageButton) {
+      await user.click(nextPageButton);
+    }
+
+    // Now apply a filter
+    const searchInput = screen.getByPlaceholderText(/search for a learner/i);
+    await user.type(searchInput, 'test');
+
+    // Should reset to page 0 when filter changes
+    await waitFor(() => {
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: '',
+        emailOrUsername: 'test',
+        page: 0,
+        pageSize: 25,
+      });
+    }, { timeout: 700 });
+  });
+
+  it('handles pagination correctly', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: { count: 50, results: mockData, numPages: 2 }
+    });
+
+    renderComponent({});
+    const user = userEvent.setup();
+
+    const nextPageButton = screen.getByLabelText(/next/i);
+    if (nextPageButton) {
+      await user.click(nextPageButton);
+
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: '',
+        emailOrUsername: '',
+        page: 1,
+        pageSize: 25,
+      });
+    }
+  });
+
+  it('maintains filters when paginating', async () => {
+    (useDateExtensions as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: { count: 50, results: mockData, numPages: 2 }
+    });
+
+    renderComponent({});
+    const user = userEvent.setup();
+
+    // Apply a filter first
+    const searchInput = screen.getByPlaceholderText(/search for a learner/i);
+    await user.type(searchInput, 'test');
+
+    await waitFor(() => {
+      expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+        blockId: '',
+        emailOrUsername: 'test',
+        page: 0,
+        pageSize: 25,
+      });
+    }, { timeout: 700 });
+
+    // Then paginate
+    const nextPageButton = screen.getByLabelText(/next/i);
+    if (nextPageButton) {
+      await user.click(nextPageButton);
+
+      await waitFor(() => {
+        expect(useDateExtensions).toHaveBeenCalledWith(testCourseId, {
+          blockId: '',
+          emailOrUsername: 'test',
+          page: 1,
+          pageSize: 25,
+        });
+      }, { timeout: 700 });
+    }
   });
 });

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -123,14 +123,16 @@ const DateExtensionsList = ({
     const blockIdFilter = data.filters.find((filter) => filter.id === 'unitTitle');
     const newBlockId = blockIdFilter ? blockIdFilter.value : '';
 
-    // Always reset to page 0 when filters change
-    if (newEmailOrUsername !== filters.emailOrUsername || newBlockId !== filters.blockId) {
-      setFilters({ page: 0, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
-      return;
-    }
+    const filterChanged = newEmailOrUsername !== filters.emailOrUsername || newBlockId !== filters.blockId;
+    const pageChanged = data.pageIndex !== filters.page;
 
-    if (data.pageIndex !== filters.page) {
-      setFilters((prev) => ({ ...prev, page: data.pageIndex }));
+    // If filters changed, reset to page 0
+    if (filterChanged) {
+      setFilters({ page: 0, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
+    }
+    // If only page changed (filters didn't change), update page
+    else if (pageChanged) {
+      setFilters({ page: data.pageIndex, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
     }
   };
 

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { debounce } from 'lodash';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, DataTable, FormControl, Icon, Skeleton } from '@openedx/paragon';
 import messages from '../messages';
@@ -8,6 +7,7 @@ import { LearnerDateExtension } from '../types';
 import { useDateExtensions } from '../data/apiHook';
 import { Search } from '@openedx/paragon/icons';
 import SelectGradedSubsection from './SelectGradedSubsection';
+import { useDebouncedFilter } from '../../hooks/useDebouncedFilter';
 
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
@@ -40,34 +40,23 @@ const DateExtensionsList = ({
     pageSize: DATE_EXTENSIONS_PAGE_SIZE,
   });
 
-  // Added that time for debounce after testing on 3G network
-  // It seems to be a good middle ground between responsiveness and reducing the number of API calls made when users are typing in the search input or changing filters.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedSetFilter = useCallback(
-    debounce((setFilter: (value: string) => void, value: string) => setFilter(value), 600),
-    []
-  );
-
   const tableColumns = [
     { accessor: 'username',
       Header: intl.formatMessage(messages.username),
       Filter: ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
-        const [inputValue, setInputValue] = useState(filterValue || '');
+        const { inputValue, handleChange } = useDebouncedFilter({
+          filterValue,
+          setFilter,
+        });
 
-        useEffect(() => {
-          setInputValue(filterValue || '');
-        }, [filterValue]);
-
-        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-          const value = e.target.value;
-          setInputValue(value);
-          debouncedSetFilter(setFilter, value);
+        const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+          handleChange(e.target.value);
         };
 
         return (
           <FormControl
             className="mb-0"
-            onChange={handleChange}
+            onChange={handleInputChange}
             placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
             trailingElement={<Icon src={Search} />}
             value={inputValue}
@@ -80,22 +69,19 @@ const DateExtensionsList = ({
     { accessor: 'unitTitle',
       Header: intl.formatMessage(messages.gradedSubsection),
       Filter: ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
-        const [inputValue, setInputValue] = useState(filterValue || '');
+        const { inputValue, handleChange } = useDebouncedFilter({
+          filterValue,
+          setFilter,
+        });
 
-        useEffect(() => {
-          setInputValue(filterValue || '');
-        }, [filterValue]);
-
-        const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-          const value = e.target.value;
-          setInputValue(value);
-          debouncedSetFilter(setFilter, value);
+        const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+          handleChange(e.target.value);
         };
 
         return (
           <SelectGradedSubsection
             placeholder={intl.formatMessage(messages.allGradedSubsections)}
-            onChange={handleChange}
+            onChange={handleSelectChange}
             value={inputValue}
           />
         );

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -10,6 +10,8 @@ const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
 export interface DateExtensionListProps {
   onResetExtensions?: (user: LearnerDateExtension) => void,
+  emailOrUsername?: string,
+  blockId?: string,
 }
 
 interface DataTableFetchDataProps {
@@ -18,13 +20,17 @@ interface DataTableFetchDataProps {
 
 const DateExtensionsList = ({
   onResetExtensions = () => {},
+  emailOrUsername = '',
+  blockId = '',
 }: DateExtensionListProps) => {
   const intl = useIntl();
-  const { courseId } = useParams();
+  const { courseId = '' } = useParams<{ courseId: string }>();
   const [page, setPage] = useState(0);
   const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useDateExtensions(courseId ?? '', {
     page,
-    pageSize: DATE_EXTENSIONS_PAGE_SIZE
+    pageSize: DATE_EXTENSIONS_PAGE_SIZE,
+    emailOrUsername,
+    blockId
   });
 
   const tableColumns = [

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -129,9 +129,8 @@ const DateExtensionsList = ({
     // If filters changed, reset to page 0
     if (filterChanged) {
       setFilters({ page: 0, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
-    }
-    // If only page changed (filters didn't change), update page
-    else if (pageChanged) {
+    } else if (pageChanged) {
+      // If only page changed (filters didn't change), update page
       setFilters({ page: data.pageIndex, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
     }
   };

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -1,17 +1,18 @@
 import { useIntl } from '@openedx/frontend-base';
-import { Button, DataTable } from '@openedx/paragon';
+import { Button, DataTable, FormControl, Icon } from '@openedx/paragon';
 import messages from '../messages';
 import { LearnerDateExtension } from '../types';
 import { useDateExtensions } from '../data/apiHook';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
+import { Search } from '@openedx/paragon/icons';
+import SelectGradedSubsection from './SelectGradedSubsection';
 
 const DATE_EXTENSIONS_PAGE_SIZE = 25;
 
 export interface DateExtensionListProps {
   onResetExtensions?: (user: LearnerDateExtension) => void,
-  emailOrUsername?: string,
-  blockId?: string,
+  onClickAdd?: () => void,
 }
 
 interface DataTableFetchDataProps {
@@ -20,17 +21,19 @@ interface DataTableFetchDataProps {
 
 const DateExtensionsList = ({
   onResetExtensions = () => {},
-  emailOrUsername = '',
-  blockId = '',
+  onClickAdd = () => {},
 }: DateExtensionListProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [page, setPage] = useState(0);
+  const [searchedLearner, setSearchedLearner] = useState<string>('');
+  const [gradedSubsectionFilter, setGradedSubsectionFilter] = useState<string>('');
+
   const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useDateExtensions(courseId ?? '', {
     page,
     pageSize: DATE_EXTENSIONS_PAGE_SIZE,
-    emailOrUsername,
-    blockId
+    emailOrUsername: searchedLearner,
+    blockId: gradedSubsectionFilter,
   });
 
   const tableColumns = [
@@ -82,7 +85,30 @@ const DateExtensionsList = ({
       manualPagination
       pageSize={DATE_EXTENSIONS_PAGE_SIZE}
       pageCount={data.numPages}
-    />
+    >
+      <div className="pt-3 mx-3 mb-3">
+        <div className="d-flex justify-content-between align-items-center mb-2">
+          <div className="d-flex">
+            <FormControl
+              className="mb-0"
+              onChange={(e) => setSearchedLearner(e.target.value)}
+              placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
+              trailingElement={<Icon src={Search} />}
+              value={searchedLearner}
+            />
+            <SelectGradedSubsection
+              placeholder={intl.formatMessage(messages.allGradedSubsections)}
+              onChange={(e) => setGradedSubsectionFilter(e.target.value)}
+              value={gradedSubsectionFilter}
+            />
+          </div>
+          <Button onClick={onClickAdd}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
+        </div>
+        <DataTable.TableControlBar />
+      </div>
+      <DataTable.Table />
+      <DataTable.TableFooter />
+    </DataTable>
   );
 };
 

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -1,10 +1,11 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { debounce } from 'lodash';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, DataTable, FormControl, Icon } from '@openedx/paragon';
+import { Button, DataTable, FormControl, Icon, Skeleton } from '@openedx/paragon';
 import messages from '../messages';
 import { LearnerDateExtension } from '../types';
 import { useDateExtensions } from '../data/apiHook';
-import { useParams } from 'react-router-dom';
-import { useState } from 'react';
 import { Search } from '@openedx/paragon/icons';
 import SelectGradedSubsection from './SelectGradedSubsection';
 
@@ -16,6 +17,7 @@ export interface DateExtensionListProps {
 }
 
 interface DataTableFetchDataProps {
+  filters: { id: string, value: string }[],
   pageIndex: number,
 }
 
@@ -25,28 +27,87 @@ const DateExtensionsList = ({
 }: DateExtensionListProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const [page, setPage] = useState(0);
-  const [searchedLearner, setSearchedLearner] = useState<string>('');
-  const [gradedSubsectionFilter, setGradedSubsectionFilter] = useState<string>('');
-
-  const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useDateExtensions(courseId ?? '', {
-    page,
-    pageSize: DATE_EXTENSIONS_PAGE_SIZE,
-    emailOrUsername: searchedLearner,
-    blockId: gradedSubsectionFilter,
+  const [filters, setFilters] = useState<{ page: number, emailOrUsername: string, blockId: string }>({
+    page: 0,
+    emailOrUsername: '',
+    blockId: '',
   });
 
+  const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useDateExtensions(courseId ?? '', {
+    blockId: filters.blockId,
+    emailOrUsername: filters.emailOrUsername,
+    page: filters.page,
+    pageSize: DATE_EXTENSIONS_PAGE_SIZE,
+  });
+
+  // Added that time for debounce after testing on 3G network
+  // It seems to be a good middle ground between responsiveness and reducing the number of API calls made when users are typing in the search input or changing filters.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedSetFilter = useCallback(
+    debounce((setFilter: (value: string) => void, value: string) => setFilter(value), 600),
+    []
+  );
+
   const tableColumns = [
-    { accessor: 'username', Header: intl.formatMessage(messages.username) },
-    { accessor: 'fullName', Header: intl.formatMessage(messages.fullname) },
-    { accessor: 'email', Header: intl.formatMessage(messages.email) },
-    { accessor: 'unitTitle', Header: intl.formatMessage(messages.gradedSubsection) },
+    { accessor: 'username',
+      Header: intl.formatMessage(messages.username),
+      Filter: ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
+        const [inputValue, setInputValue] = useState(filterValue || '');
+
+        useEffect(() => {
+          setInputValue(filterValue || '');
+        }, [filterValue]);
+
+        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+          const value = e.target.value;
+          setInputValue(value);
+          debouncedSetFilter(setFilter, value);
+        };
+
+        return (
+          <FormControl
+            className="mb-0"
+            onChange={handleChange}
+            placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
+            trailingElement={<Icon src={Search} />}
+            value={inputValue}
+          />
+        );
+      }
+    },
+    { accessor: 'fullName', Header: intl.formatMessage(messages.fullname), disableFilters: true, },
+    { accessor: 'email', Header: intl.formatMessage(messages.email), disableFilters: true, },
+    { accessor: 'unitTitle',
+      Header: intl.formatMessage(messages.gradedSubsection),
+      Filter: ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
+        const [inputValue, setInputValue] = useState(filterValue || '');
+
+        useEffect(() => {
+          setInputValue(filterValue || '');
+        }, [filterValue]);
+
+        const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+          const value = e.target.value;
+          setInputValue(value);
+          debouncedSetFilter(setFilter, value);
+        };
+
+        return (
+          <SelectGradedSubsection
+            placeholder={intl.formatMessage(messages.allGradedSubsections)}
+            onChange={handleChange}
+            value={inputValue}
+          />
+        );
+      }
+    },
     {
       accessor: 'extendedDueDate',
       Header: intl.formatMessage(messages.extendedDueDate),
       Cell: ({ value }: { value: string }) => (
         intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
-      )
+      ),
+      disableFilters: true,
     },
   ];
 
@@ -65,8 +126,29 @@ const DateExtensionsList = ({
   }];
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
-    setPage(data.pageIndex);
+    const emailOrUsernameFilter = data.filters.find((filter) => filter.id === 'username');
+    const newEmailOrUsername = emailOrUsernameFilter ? emailOrUsernameFilter.value : '';
+    const blockIdFilter = data.filters.find((filter) => filter.id === 'unitTitle');
+    const newBlockId = blockIdFilter ? blockIdFilter.value : '';
+    if (newEmailOrUsername !== filters.emailOrUsername || newBlockId !== filters.blockId) {
+      setFilters({ page: 0, emailOrUsername: newEmailOrUsername, blockId: newBlockId });
+      return;
+    }
+
+    if (data.pageIndex !== filters.page) {
+      setFilters((prev) => ({ ...prev, page: data.pageIndex }));
+    }
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <Skeleton className="mt-4 mb-2 lead" />
+        <Skeleton className="mb-3 small" width="25%" />
+        <Skeleton className="mt-3 lead" count={4} />
+      </>
+    );
+  }
 
   return (
     <DataTable
@@ -75,9 +157,21 @@ const DateExtensionsList = ({
       data={data.results}
       fetchData={handleFetchData}
       initialState={{
-        pageIndex: page,
+        pageIndex: filters.page,
         pageSize: DATE_EXTENSIONS_PAGE_SIZE,
+        filters: [
+          {
+            id: 'username',
+            value: filters.emailOrUsername,
+          },
+          {
+            id: 'unitTitle',
+            value: filters.blockId,
+          }
+        ]
       }}
+      isFilterable
+      numBreakoutFilters={2}
       isLoading={isLoading}
       isPaginated
       itemCount={data.count}
@@ -85,28 +179,14 @@ const DateExtensionsList = ({
       manualPagination
       pageSize={DATE_EXTENSIONS_PAGE_SIZE}
       pageCount={data.numPages}
+      FilterStatusComponent={DataTable.RowStatus}
     >
-      <div className="pt-3 mx-3 mb-3">
-        <div className="d-flex justify-content-between align-items-center mb-2">
-          <div className="d-flex">
-            <FormControl
-              className="mb-0"
-              onChange={(e) => setSearchedLearner(e.target.value)}
-              placeholder={intl.formatMessage(messages.searchLearnerPlaceholder)}
-              trailingElement={<Icon src={Search} />}
-              value={searchedLearner}
-            />
-            <SelectGradedSubsection
-              placeholder={intl.formatMessage(messages.allGradedSubsections)}
-              onChange={(e) => setGradedSubsectionFilter(e.target.value)}
-              value={gradedSubsectionFilter}
-            />
-          </div>
-          <Button onClick={onClickAdd}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
-        </div>
+      <div className="d-flex justify-content-between align-items-start pt-1 mx-3 mb-3">
         <DataTable.TableControlBar />
+        <Button className="mt-2.5" onClick={onClickAdd}>+ {intl.formatMessage(messages.addIndividualExtension)}</Button>
       </div>
       <DataTable.Table />
+      <DataTable.EmptyTable content={intl.formatMessage(messages.noDateExtensions)} />
       <DataTable.TableFooter />
     </DataTable>
   );

--- a/src/dateExtensions/components/SelectGradedSubsection.tsx
+++ b/src/dateExtensions/components/SelectGradedSubsection.tsx
@@ -5,13 +5,15 @@ import { useGradedSubsections } from '../data/apiHook';
 interface SelectGradedSubsectionProps {
   label?: string,
   placeholder: string,
+  value?: string,
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void,
 }
 
-const SelectGradedSubsection = ({ label, placeholder, onChange }: SelectGradedSubsectionProps) => {
+const SelectGradedSubsection = ({ label, placeholder, value, onChange }: SelectGradedSubsectionProps) => {
   const { courseId = '' } = useParams<{ courseId: string }>();
   const { data = { items: [] } } = useGradedSubsections(courseId);
   const selectOptions = [{ displayName: placeholder, subsectionId: '' }, ...data.items];
+
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     onChange(event);
   };
@@ -19,7 +21,14 @@ const SelectGradedSubsection = ({ label, placeholder, onChange }: SelectGradedSu
   return (
     <FormGroup size="sm">
       {label && <FormLabel>{label}</FormLabel>}
-      <FormControl placeholder={placeholder} name="blockId" as="select" onChange={handleChange} size="md">
+      <FormControl
+        as="select"
+        name="blockId"
+        placeholder={placeholder}
+        size="md"
+        value={value}
+        onChange={handleChange}
+      >
         {
           selectOptions.map((option) => (
             <option key={option.subsectionId} value={option.subsectionId}>

--- a/src/dateExtensions/components/SelectGradedSubsection.tsx
+++ b/src/dateExtensions/components/SelectGradedSubsection.tsx
@@ -19,7 +19,7 @@ const SelectGradedSubsection = ({ label, placeholder, value, onChange }: SelectG
   };
 
   return (
-    <FormGroup size="sm">
+    <FormGroup className="mb-0" size="sm">
       {label && <FormLabel>{label}</FormLabel>}
       <FormControl
         as="select"

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -3,12 +3,31 @@ import { getApiBaseUrl } from '../../data/api';
 import { AddDateExtensionParams, LearnerDateExtension, ResetDueDateParams } from '../types';
 import { DataList, PaginationQueryKeys } from '@src/types';
 
+export interface DateExtensionQueryParams extends PaginationQueryKeys {
+  emailOrUsername?: string,
+  blockId?: string,
+}
+
 export const getDateExtensions = async (
   courseId: string,
-  pagination: PaginationQueryKeys
+  params: DateExtensionQueryParams
 ): Promise<DataList<LearnerDateExtension>> => {
+  const queryParams = new URLSearchParams({
+    page: (params.page + 1).toString(),
+    page_size: params.pageSize.toString(),
+  });
+
+  if (params.emailOrUsername) {
+    queryParams.append('email_or_username', params.emailOrUsername);
+  }
+
+  if (params.blockId) {
+    const blockId = encodeURIComponent(params.blockId);
+    queryParams.append('block_id', blockId);
+  }
+
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions?page=${pagination.page + 1}&page_size=${pagination.pageSize}`
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/unit_extensions?${queryParams.toString()}`
   );
   return camelCaseObject(data);
 };

--- a/src/dateExtensions/data/api.ts
+++ b/src/dateExtensions/data/api.ts
@@ -1,12 +1,7 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { AddDateExtensionParams, LearnerDateExtension, ResetDueDateParams } from '../types';
-import { DataList, PaginationQueryKeys } from '@src/types';
-
-export interface DateExtensionQueryParams extends PaginationQueryKeys {
-  emailOrUsername?: string,
-  blockId?: string,
-}
+import { AddDateExtensionParams, DateExtensionQueryParams, LearnerDateExtension, ResetDueDateParams } from '../types';
+import { DataList } from '@src/types';
 
 export const getDateExtensions = async (
   courseId: string,
@@ -22,7 +17,7 @@ export const getDateExtensions = async (
   }
 
   if (params.blockId) {
-    const blockId = encodeURIComponent(params.blockId);
+    const blockId = encodeURI(params.blockId);
     queryParams.append('block_id', blockId);
   }
 
@@ -37,7 +32,7 @@ export const resetDateExtension = async (courseId: string, params: ResetDueDateP
   return camelCaseObject(data);
 };
 
-export const addDateExtension = async (courseId, extensionData: AddDateExtensionParams) => {
+export const addDateExtension = async (courseId: string, extensionData: AddDateExtensionParams) => {
   const snakeCaseData = snakeCaseObject(extensionData);
   const { data } = await getAuthenticatedHttpClient().post(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/change_due_date`, snakeCaseData);
   return camelCaseObject(data);

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getDateExtensions, resetDateExtension, addDateExtension, getGradedSubsections } from './api';
+import { getDateExtensions, resetDateExtension, addDateExtension, getGradedSubsections, DateExtensionQueryParams } from './api';
 import { dateExtensionsQueryKeys, gradedSubsectionsQueryKeys } from './queryKeys';
 import { ResetDueDateParams } from '../types';
-import { PaginationQueryKeys } from '@src/types';
 
-export const useDateExtensions = (courseId: string, pagination: PaginationQueryKeys) => (
+export const useDateExtensions = (courseId: string, params: DateExtensionQueryParams) => (
   useQuery({
-    queryKey: dateExtensionsQueryKeys.byCoursePaginated(courseId, pagination),
-    queryFn: () => getDateExtensions(courseId, pagination),
+    queryKey: dateExtensionsQueryKeys.byCoursePaginated(courseId, params),
+    queryFn: () => getDateExtensions(courseId, params),
+    enabled: !!courseId,
   })
 );
 

--- a/src/dateExtensions/data/apiHook.ts
+++ b/src/dateExtensions/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getDateExtensions, resetDateExtension, addDateExtension, getGradedSubsections, DateExtensionQueryParams } from './api';
+import { getDateExtensions, resetDateExtension, addDateExtension, getGradedSubsections } from './api';
 import { dateExtensionsQueryKeys, gradedSubsectionsQueryKeys } from './queryKeys';
-import { ResetDueDateParams } from '../types';
+import { DateExtensionQueryParams, ResetDueDateParams } from '../types';
 
 export const useDateExtensions = (courseId: string, params: DateExtensionQueryParams) => (
   useQuery({

--- a/src/dateExtensions/data/queryKeys.ts
+++ b/src/dateExtensions/data/queryKeys.ts
@@ -1,10 +1,19 @@
-import { PaginationQueryKeys } from '@src/types';
 import { appId } from '../../constants';
+import { DateExtensionQueryParams } from '../types';
 
 export const dateExtensionsQueryKeys = {
   all: [appId, 'dateExtensions'] as const,
   byCourse: (courseId: string) => [...dateExtensionsQueryKeys.all, courseId] as const,
-  byCoursePaginated: (courseId: string, pagination: PaginationQueryKeys) => [...dateExtensionsQueryKeys.byCourse(courseId), pagination.page] as const,
+  byCoursePaginated: (
+    courseId: string,
+    params: DateExtensionQueryParams
+  ) => [
+    ...dateExtensionsQueryKeys.byCourse(courseId),
+    params.page,
+    params.pageSize,
+    params.emailOrUsername || '',
+    params.blockId || ''
+  ] as const,
 };
 
 export const gradedSubsectionsQueryKeys = {

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -116,6 +116,11 @@ const messages = defineMessages({
     defaultMessage: 'All Graded Subsections',
     description: 'Label for the all graded subsections option in filters',
   },
+  searchLearnerPlaceholder: {
+    id: 'instruct.dateExtensions.page.filters.searchLearnerPlaceholder',
+    defaultMessage: 'Search for a Learner',
+    description: 'Placeholder text for the search learner input field',
+  }
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -120,7 +120,12 @@ const messages = defineMessages({
     id: 'instruct.dateExtensions.page.filters.searchLearnerPlaceholder',
     defaultMessage: 'Search for a Learner',
     description: 'Placeholder text for the search learner input field',
-  }
+  },
+  noDateExtensions: {
+    id: 'instruct.dateExtensions.page.noDateExtensions',
+    defaultMessage: 'No results found',
+    description: 'Message shown when there are no date extensions to display in the table',
+  },
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -111,6 +111,11 @@ const messages = defineMessages({
     defaultMessage: 'Select Graded Subsection',
     description: 'Label for the select graded subsection field',
   },
+  allGradedSubsections: {
+    id: 'instruct.dateExtensions.page.filters.allGradedSubsections',
+    defaultMessage: 'All Graded Subsections',
+    description: 'Label for the all graded subsections option in filters',
+  },
 });
 
 export default messages;

--- a/src/dateExtensions/types.ts
+++ b/src/dateExtensions/types.ts
@@ -1,3 +1,5 @@
+import { PaginationQueryKeys } from '@src/types';
+
 export interface LearnerDateExtension {
   username: string,
   fullName: string,
@@ -18,4 +20,9 @@ export interface AddDateExtensionParams {
   blockId: string,
   dueDatetime: string,
   reason: string,
+}
+
+export interface DateExtensionQueryParams extends PaginationQueryKeys {
+  emailOrUsername?: string,
+  blockId?: string,
 }

--- a/src/hooks/useDebouncedFilter.test.ts
+++ b/src/hooks/useDebouncedFilter.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedFilter } from './useDebouncedFilter';
+
+// Mock lodash debounce to call the function immediately for testing
+jest.mock('lodash', () => ({
+  debounce: (fn: any) => {
+    fn.cancel = jest.fn();
+    return fn;
+  },
+}));
+
+describe('useDebouncedFilter', () => {
+  let setFilter: jest.Mock;
+
+  beforeEach(() => {
+    setFilter = jest.fn();
+  });
+
+  it('should initialize inputValue with filterValue', () => {
+    const { result } = renderHook(() =>
+      useDebouncedFilter({ filterValue: 'test', setFilter }),
+    );
+    expect(result.current.inputValue).toBe('test');
+  });
+
+  it('should update inputValue and call setFilter on handleChange', () => {
+    const { result } = renderHook(() =>
+      useDebouncedFilter({ filterValue: '', setFilter }),
+    );
+    act(() => {
+      result.current.handleChange('new value');
+    });
+    expect(result.current.inputValue).toBe('new value');
+    expect(setFilter).toHaveBeenCalledWith('new value');
+  });
+
+  it('should update inputValue when filterValue prop changes', () => {
+    const { result, rerender } = renderHook(
+      ({ filterValue }) =>
+        useDebouncedFilter({ filterValue, setFilter }),
+      { initialProps: { filterValue: 'first' } }
+    );
+    expect(result.current.inputValue).toBe('first');
+    rerender({ filterValue: 'second' });
+    expect(result.current.inputValue).toBe('second');
+  });
+
+  it('should set inputValue to empty string if filterValue is undefined', () => {
+    const { result } = renderHook(() =>
+      useDebouncedFilter({ filterValue: undefined as any, setFilter }),
+    );
+    expect(result.current.inputValue).toBe('');
+  });
+});

--- a/src/hooks/useDebouncedFilter.ts
+++ b/src/hooks/useDebouncedFilter.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react';
+import { debounce } from 'lodash';
+
+interface UseDebouncedFilterProps {
+  filterValue: string,
+  setFilter: (value: string) => void,
+  delay?: number,
+}
+
+/**
+ * Hook for handling debounced filter input with automatic synchronization
+ * @param filterValue - Current filter value from parent component
+ * @param setFilter - Function to update the filter in parent component
+ * @param delay - Debounce delay in milliseconds (default: 600ms)
+ */
+export const useDebouncedFilter = ({
+  filterValue,
+  setFilter,
+  delay = 600
+}: UseDebouncedFilterProps) => {
+  const [inputValue, setInputValue] = useState(filterValue || '');
+
+  // Debounced function to update the filter
+  // Added 600ms delay after testing on 3G network - good balance between responsiveness and reducing API calls
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedSetFilter = useCallback(
+    debounce((value: string) => setFilter(value), delay),
+    [setFilter, delay]
+  );
+
+  useEffect(() => {
+    setInputValue(filterValue || '');
+  }, [filterValue]);
+
+  const handleChange = (value: string) => {
+    setInputValue(value);
+    debouncedSetFilter(value);
+  };
+
+  return {
+    inputValue,
+    handleChange,
+  };
+};


### PR DESCRIPTION
## Description
We introduce Select filter for graded subsections and search learner field for date extensions data table.

#### Demo
https://github.com/user-attachments/assets/1361a6b7-8922-47fc-a366-7a7f12548120


## Supporting information
Closes #57 
Link to other information about the change, such as GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions
- npm run dev
- you will need to go to a date extensions url with a valid courseid. Example: http://apps.local.openedx.io:2003/instructor/course-v1:OpenedX+DemoX+DemoCourse/date_extensions
- To see info you will need at least a unit with a subsection that has a date for completion, if not you will have to set that on studio, and on menu of a subsection go to configure to configure that
<img width="804" height="590" alt="Screenshot 2026-02-18 at 11 22 21 a m" src="https://github.com/user-attachments/assets/b57b2f32-2bd7-4d90-998f-474cb6d5f963" />
- If you dont have date extensions add one with add button, and after that you will see the records on the table
- Now you can search for username or email on the search filter or filter by graded subsection


## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
