### PR TITLE
Create cohorts

### DIFF
--- a/src/cohorts/CohortsPage.test.tsx
+++ b/src/cohorts/CohortsPage.test.tsx
@@ -4,6 +4,7 @@ import CohortsPage from './CohortsPage';
 import { useCohorts, useCohortStatus, useToggleCohorts } from './data/apiHook';
 import { renderWithIntl } from '../testUtils';
 import messages from './messages';
+import { CohortProvider } from './components/CohortContext';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -14,9 +15,11 @@ jest.mock('./data/apiHook', () => ({
   useCohorts: jest.fn(),
   useCohortStatus: jest.fn(),
   useToggleCohorts: jest.fn(),
+  useCreateCohort: () => ({ mutate: jest.fn() }),
 }));
 
 describe('CohortsPage', () => {
+  const renderWithCohortsProvider = () => renderWithIntl(<CohortProvider><CohortsPage /></CohortProvider>);
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -26,7 +29,7 @@ describe('CohortsPage', () => {
     (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
     (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
-    renderWithIntl(<CohortsPage />);
+    renderWithCohortsProvider();
     expect(screen.getByText(messages.cohortsTitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Cohort 1' })).toBeInTheDocument();
     expect(screen.getByText(`+ ${messages.addCohort.defaultMessage}`)).toBeInTheDocument();
@@ -37,7 +40,7 @@ describe('CohortsPage', () => {
     (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: false } });
     (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
-    renderWithIntl(<CohortsPage />);
+    renderWithCohortsProvider();
     expect(screen.getByText(messages.noCohortsMessage.defaultMessage)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: messages.enableCohorts.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: messages.learnMore.defaultMessage })).toBeInTheDocument();
@@ -49,7 +52,7 @@ describe('CohortsPage', () => {
     (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: false } });
     (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: enableMock });
 
-    renderWithIntl(<CohortsPage />);
+    renderWithCohortsProvider();
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: messages.enableCohorts.defaultMessage }));
     expect(enableMock).toHaveBeenCalled();
@@ -60,7 +63,7 @@ describe('CohortsPage', () => {
     (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
     (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: jest.fn() });
 
-    renderWithIntl(<CohortsPage />);
+    renderWithCohortsProvider();
     const user = userEvent.setup();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
@@ -73,7 +76,7 @@ describe('CohortsPage', () => {
     (useCohortStatus as jest.Mock).mockReturnValue({ data: { isCohorted: true } });
     (useToggleCohorts as jest.Mock).mockReturnValue({ mutate: disableMock });
 
-    renderWithIntl(<CohortsPage />);
+    renderWithCohortsProvider();
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: messages.disableCohorts.defaultMessage }));
     await user.click(screen.getByRole('button', { name: messages.disableLabel.defaultMessage }));

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -8,6 +8,7 @@ import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
 import DisabledCohortsView from './components/DisabledCohortsView';
 import EnabledCohortsView from './components/EnabledCohortsView';
+import { CohortProvider } from './components/CohortContext';
 
 const CohortsPage = () => {
   const intl = useIntl();
@@ -33,29 +34,31 @@ const CohortsPage = () => {
   };
 
   return (
-    <div className="mt-4.5 mb-4 mx-4">
-      <div className="d-inline-flex align-items-center">
-        <h3 className="mb-0 text-gray-700">{intl.formatMessage(messages.cohortsTitle)}</h3>
-        {isCohorted && (
-          <div className="small">
-            <IconButton
-              alt={intl.formatMessage(messages.disableCohorts)}
-              iconAs={Settings}
-              iconClassNames="mb-2 text-gray-500"
-              size="sm"
-              variant="secondary"
-              onClick={() => setIsOpenDisableModal(true)}
-            />
-          </div>
+    <CohortProvider>
+      <div className="mt-4.5 mb-4 mx-4">
+        <div className="d-inline-flex align-items-center">
+          <h3 className="mb-0 text-gray-700">{intl.formatMessage(messages.cohortsTitle)}</h3>
+          {isCohorted && (
+            <div className="small">
+              <IconButton
+                alt={intl.formatMessage(messages.disableCohorts)}
+                iconAs={Settings}
+                iconClassNames="mb-2 text-gray-500"
+                size="sm"
+                variant="secondary"
+                onClick={() => setIsOpenDisableModal(true)}
+              />
+            </div>
+          )}
+        </div>
+        {isCohorted ? (
+          <EnabledCohortsView />
+        ) : (
+          <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
         )}
+        <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
       </div>
-      {isCohorted ? (
-        <EnabledCohortsView />
-      ) : (
-        <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
-      )}
-      <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
-    </div>
+    </CohortProvider>
   );
 };
 

--- a/src/cohorts/components/CohortContext.test.tsx
+++ b/src/cohorts/components/CohortContext.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { CohortProvider, useCohortContext } from './CohortContext';
+
+const TestComponent: React.FC = () => {
+  const {
+    selectedCohort,
+    setSelectedCohort,
+    clearSelectedCohort,
+    updateCohortField,
+  } = useCohortContext();
+
+  return (
+    <div>
+      <span>{selectedCohort ? selectedCohort.name : 'none'}</span>
+      <button
+        onClick={() =>
+          setSelectedCohort({
+            id: '1',
+            name: 'Cohort 1',
+            assignmentType: 'typeA',
+            contentGroupOption: 'optionA',
+            groupId: 123,
+            userPartitionId: 456,
+          })}
+      >
+        Set Cohort
+      </button>
+      <button onClick={clearSelectedCohort}>
+        Clear Cohort
+      </button>
+      <button
+        onClick={() => updateCohortField('name', 'Updated Cohort')}
+      >
+        Update Cohort
+      </button>
+    </div>
+  );
+};
+
+const renderWithProvider = () =>
+  render(
+    <CohortProvider>
+      <TestComponent />
+    </CohortProvider>
+  );
+
+describe('CohortContext', () => {
+  it('should provide default value', () => {
+    const { getByText } = renderWithProvider();
+    expect(getByText('none')).toBeInTheDocument();
+  });
+
+  it('should set selected cohort', () => {
+    const { getByRole, getByText } = renderWithProvider();
+    act(() => {
+      getByRole('button', { name: 'Set Cohort' }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getByText('Cohort 1')).toBeInTheDocument();
+  });
+
+  it('should clear selected cohort', () => {
+    const { getByRole, getByText } = renderWithProvider();
+    act(() => {
+      getByRole('button', { name: 'Set Cohort' }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getByText('Cohort 1')).toBeInTheDocument();
+    act(() => {
+      getByRole('button', { name: 'Clear Cohort' }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getByText('none')).toBeInTheDocument();
+  });
+
+  it('should update cohort field', () => {
+    const { getByRole, getByText } = renderWithProvider();
+    act(() => {
+      getByRole('button', { name: 'Set Cohort' }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    act(() => {
+      getByRole('button', { name: 'Update Cohort' }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getByText('Updated Cohort')).toBeInTheDocument();
+  });
+
+  it('should throw error if used outside provider', () => {
+    // Suppress error output for this test
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const BrokenComponent = () => {
+      useCohortContext();
+      return null;
+    };
+    expect(() => render(<BrokenComponent />)).toThrow(
+      'useCohortContext must be used within a CohortProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('should not update selectedCohort if values are the same', () => {
+    let renderCount = 0;
+    const RenderCountComponent = () => {
+      renderCount++;
+      const { setSelectedCohort } = useCohortContext();
+      React.useEffect(() => {
+        setSelectedCohort({
+          id: '1',
+          name: 'Cohort 1',
+          assignmentType: 'typeA',
+          contentGroupOption: 'optionA',
+          groupId: 123,
+          userPartitionId: 456,
+        });
+        setSelectedCohort({
+          id: '1',
+          name: 'Cohort 1',
+          assignmentType: 'typeA',
+          contentGroupOption: 'optionA',
+          groupId: 123,
+          userPartitionId: 456,
+        });
+      }, [setSelectedCohort]);
+      return null;
+    };
+    render(
+      <CohortProvider>
+        <RenderCountComponent />
+      </CohortProvider>
+    );
+    // Should only render twice: initial and after first setSelectedCohort
+    expect(renderCount).toBe(2);
+  });
+});

--- a/src/cohorts/components/CohortContext.tsx
+++ b/src/cohorts/components/CohortContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+
+export interface CohortData {
+  id: string,
+  name: string,
+  assignmentType: string,
+  contentGroupOption?: string,
+  groupId: number | null,
+  userPartitionId: number | null,
+}
+
+interface CohortContextType {
+  selectedCohort: CohortData | null,
+  setSelectedCohort: (cohort: CohortData) => void,
+  clearSelectedCohort: () => void,
+  updateCohortField: (field: keyof CohortData, value: string) => void,
+}
+
+const CohortContext = createContext<CohortContextType | undefined>(undefined);
+
+interface CohortProviderProps {
+  children: ReactNode,
+}
+
+export const CohortProvider: React.FC<CohortProviderProps> = ({ children }) => {
+  const [selectedCohort, setSelectedCohortState] = useState<CohortData | null>(null);
+
+  const setSelectedCohort = useCallback((cohort: CohortData) => {
+    setSelectedCohortState(prev => {
+      // Only update if the values actually changed
+      if (!prev
+        || prev.name !== cohort.name
+        || prev.assignmentType !== cohort.assignmentType
+        || prev.contentGroupOption !== cohort.contentGroupOption
+        || prev.groupId !== cohort.groupId) {
+        return cohort;
+      }
+      return prev;
+    });
+  }, []);
+
+  const clearSelectedCohort = useCallback(() => {
+    setSelectedCohortState(null);
+  }, []);
+
+  const updateCohortField = useCallback((field: keyof CohortData, value: string) => {
+    setSelectedCohortState(prev =>
+      prev ? { ...prev, [field]: value } : null
+    );
+  }, []);
+
+  return (
+    <CohortContext.Provider
+      value={{
+        selectedCohort,
+        setSelectedCohort,
+        clearSelectedCohort,
+        updateCohortField
+      }}
+    >
+      {children}
+    </CohortContext.Provider>
+  );
+};
+
+export const useCohortContext = (): CohortContextType => {
+  const context = useContext(CohortContext);
+  if (context === undefined) {
+    throw new Error('useCohortContext must be used within a CohortProvider');
+  }
+  return context;
+};

--- a/src/cohorts/components/CohortContext.tsx
+++ b/src/cohorts/components/CohortContext.tsx
@@ -1,13 +1,5 @@
-import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
-
-export interface CohortData {
-  id: string,
-  name: string,
-  assignmentType: string,
-  contentGroupOption?: string,
-  groupId: number | null,
-  userPartitionId: number | null,
-}
+import { createContext, useContext, useState, ReactNode, useCallback, FC, useMemo } from 'react';
+import { CohortData } from '../types';
 
 interface CohortContextType {
   selectedCohort: CohortData | null,
@@ -22,16 +14,18 @@ interface CohortProviderProps {
   children: ReactNode,
 }
 
-export const CohortProvider: React.FC<CohortProviderProps> = ({ children }) => {
+export const CohortProvider: FC<CohortProviderProps> = ({ children }) => {
   const [selectedCohort, setSelectedCohortState] = useState<CohortData | null>(null);
 
   const setSelectedCohort = useCallback((cohort: CohortData) => {
     setSelectedCohortState(prev => {
       // Only update if the values actually changed
       if (!prev
+        || prev.id !== cohort.id
         || prev.name !== cohort.name
         || prev.assignmentType !== cohort.assignmentType
         || prev.contentGroupOption !== cohort.contentGroupOption
+        || prev.userPartitionId !== cohort.userPartitionId
         || prev.groupId !== cohort.groupId) {
         return cohort;
       }
@@ -49,15 +43,15 @@ export const CohortProvider: React.FC<CohortProviderProps> = ({ children }) => {
     );
   }, []);
 
+  const value = useMemo(() => ({
+    selectedCohort,
+    setSelectedCohort,
+    clearSelectedCohort,
+    updateCohortField
+  }), [selectedCohort, setSelectedCohort, clearSelectedCohort, updateCohortField]);
+
   return (
-    <CohortContext.Provider
-      value={{
-        selectedCohort,
-        setSelectedCohort,
-        clearSelectedCohort,
-        updateCohortField
-      }}
-    >
+    <CohortContext.Provider value={value}>
       {children}
     </CohortContext.Provider>
   );

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -4,6 +4,7 @@ import CohortsForm from './CohortsForm';
 import messages from '../messages';
 import { renderWithIntl } from '../../testUtils';
 import { useContentGroupsData } from '../data/apiHook';
+import { CohortProvider } from './CohortContext';
 
 jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'course-v1:edX+DemoX+Demo_Course' }),
@@ -20,7 +21,14 @@ jest.mock('../data/apiHook', () => ({
 
 describe('CohortsForm', () => {
   const onCancel = jest.fn();
-  const onSubmit = jest.fn((e) => e.preventDefault());
+  const onSubmit = jest.fn();
+
+  const renderComponent = () =>
+    renderWithIntl(
+      <CohortProvider>
+        <CohortsForm onCancel={onCancel} onSubmit={onSubmit} />
+      </CohortProvider>
+    );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,20 +36,20 @@ describe('CohortsForm', () => {
 
   it('renders cohort name input', () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     expect(screen.getByPlaceholderText(messages.cohortName.defaultMessage)).toBeInTheDocument();
   });
 
   it('renders assignment method radios', () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     expect(screen.getByLabelText(messages.automatic.defaultMessage)).toBeInTheDocument();
     expect(screen.getByLabelText(messages.manual.defaultMessage)).toBeInTheDocument();
   });
 
   it('renders content group radios and select', () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     expect(screen.getByLabelText(messages.noContentGroup.defaultMessage)).toBeInTheDocument();
     expect(screen.getByLabelText(messages.selectAContentGroup.defaultMessage)).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toBeInTheDocument();
@@ -51,7 +59,7 @@ describe('CohortsForm', () => {
 
   it('calls onCancel when Cancel button is clicked', async () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     const user = userEvent.setup();
     const cancelButton = screen.getByRole('button', { name: messages.cancelLabel.defaultMessage });
     await user.click(cancelButton);
@@ -60,7 +68,7 @@ describe('CohortsForm', () => {
 
   it('calls onSubmit when Save button is clicked', async () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     const user = userEvent.setup();
     await user.click(screen.getByText(messages.saveLabel.defaultMessage));
     expect(onSubmit).toHaveBeenCalled();
@@ -68,7 +76,7 @@ describe('CohortsForm', () => {
 
   it('updates cohort name input value', async () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     const input = screen.getByPlaceholderText(messages.cohortName.defaultMessage);
     const user = userEvent.setup();
     await user.type(input, 'Test Cohort');
@@ -77,7 +85,7 @@ describe('CohortsForm', () => {
 
   it('disables select when "Select a Content Group" is not chosen', () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     const select = screen.getByRole('combobox');
     expect(select).toBeDisabled();
     fireEvent.click(screen.getByLabelText(messages.selectAContentGroup.defaultMessage));
@@ -86,7 +94,7 @@ describe('CohortsForm', () => {
 
   it('renders warning and create link when no content groups', () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
-    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    renderComponent();
     expect(screen.getByText(messages.noContentGroups.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.createContentGroup.defaultMessage)).toBeInTheDocument();
   });

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -1,6 +1,5 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import CohortsForm from './CohortsForm';
 import messages from '../messages';
 import { renderWithIntl } from '../../testUtils';
@@ -85,12 +84,13 @@ describe('CohortsForm', () => {
     expect(input).toHaveValue('Test Cohort');
   });
 
-  it('disables select when "Select a Content Group" is not chosen', () => {
+  it('disables select when "Select a Content Group" is not chosen', async () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
     renderComponent();
     const select = screen.getByRole('combobox');
     expect(select).toBeDisabled();
-    fireEvent.click(screen.getByLabelText(messages.selectAContentGroup.defaultMessage));
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText(messages.selectAContentGroup.defaultMessage));
     expect(select).not.toBeDisabled();
   });
 

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -1,0 +1,93 @@
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CohortsForm from './CohortsForm';
+import messages from '../messages';
+import { renderWithIntl } from '../../testUtils';
+import { useContentGroupsData } from '../data/apiHook';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ courseId: 'course-v1:edX+DemoX+Demo_Course' }),
+}));
+
+const mockContentGroups = [
+  { id: '1', displayName: 'Group 1' },
+  { id: '2', displayName: 'Group 2' },
+];
+
+jest.mock('../data/apiHook', () => ({
+  useContentGroupsData: jest.fn(),
+}));
+
+describe('CohortsForm', () => {
+  const onCancel = jest.fn();
+  const onSubmit = jest.fn((e) => e.preventDefault());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders cohort name input', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    expect(screen.getByPlaceholderText(messages.cohortName.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders assignment method radios', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    expect(screen.getByLabelText(messages.automatic.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByLabelText(messages.manual.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders content group radios and select', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    expect(screen.getByLabelText(messages.noContentGroup.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByLabelText(messages.selectAContentGroup.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText(mockContentGroups[0].displayName)).toBeInTheDocument();
+    expect(screen.getByText(mockContentGroups[1].displayName)).toBeInTheDocument();
+  });
+
+  it('calls onCancel when Cancel button is clicked', async () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    const user = userEvent.setup();
+    const cancelButton = screen.getByRole('button', { name: messages.cancelLabel.defaultMessage });
+    await user.click(cancelButton);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('calls onSubmit when Save button is clicked', async () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText(messages.saveLabel.defaultMessage));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('updates cohort name input value', async () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(messages.cohortName.defaultMessage);
+    const user = userEvent.setup();
+    await user.type(input, 'Test Cohort');
+    expect(input).toHaveValue('Test Cohort');
+  });
+
+  it('disables select when "Select a Content Group" is not chosen', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    const select = screen.getByRole('combobox');
+    expect(select).toBeDisabled();
+    fireEvent.click(screen.getByLabelText(messages.selectAContentGroup.defaultMessage));
+    expect(select).not.toBeDisabled();
+  });
+
+  it('renders warning and create link when no content groups', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
+    renderWithIntl(<CohortsForm onCancel={onCancel} onSubmit={onSubmit} />);
+    expect(screen.getByText(messages.noContentGroups.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.createContentGroup.defaultMessage)).toBeInTheDocument();
+  });
+});

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -1,18 +1,20 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import CohortsForm from './CohortsForm';
 import messages from '../messages';
 import { renderWithIntl } from '../../testUtils';
 import { useContentGroupsData } from '../data/apiHook';
 import { CohortProvider } from './CohortContext';
+import * as CohortContextModule from './CohortContext';
 
 jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'course-v1:edX+DemoX+Demo_Course' }),
 }));
 
 const mockContentGroups = [
-  { id: '1', displayName: 'Group 1' },
-  { id: '2', displayName: 'Group 2' },
+  { id: '1:2', displayName: 'Group 1' },
+  { id: '2:3', displayName: 'Group 2' },
 ];
 
 jest.mock('../data/apiHook', () => ({
@@ -97,5 +99,78 @@ describe('CohortsForm', () => {
     renderComponent();
     expect(screen.getByText(messages.noContentGroups.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.createContentGroup.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('submits correct data when selecting a content group', async () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByLabelText(messages.selectAContentGroup.defaultMessage));
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, mockContentGroups[1].id);
+
+    const input = screen.getByPlaceholderText(messages.cohortName.defaultMessage);
+    await user.clear(input);
+    await user.type(input, 'Cohort With Group');
+
+    await user.click(screen.getByText(messages.saveLabel.defaultMessage));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Cohort With Group',
+        groupId: null,
+        userPartitionId: null,
+        assignmentType: 'random',
+      })
+    );
+  });
+
+  it('disables manual assignment radio when disableManualAssignment is true', () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+    renderWithIntl(
+      <CohortProvider>
+        <CohortsForm onCancel={onCancel} onSubmit={onSubmit} disableManualAssignment />
+      </CohortProvider>
+    );
+    const manualRadio = screen.getByLabelText(messages.manual.defaultMessage);
+    expect(manualRadio).toBeDisabled();
+  });
+
+  it('shows initial values in context', async () => {
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
+
+    jest.spyOn(CohortContextModule, 'useCohortContext').mockReturnValue({
+      selectedCohort: {
+        id: '1',
+        name: 'Initial Cohort',
+        assignmentType: 'manual',
+        groupId: 2,
+        userPartitionId: 3,
+      },
+      setSelectedCohort: jest.fn(),
+      clearSelectedCohort: jest.fn(),
+      updateCohortField: jest.fn(),
+    });
+
+    renderWithIntl(
+      <CohortProvider>
+        <CohortsForm onCancel={onCancel} onSubmit={onSubmit} />
+      </CohortProvider>
+    );
+
+    await waitFor(() => {
+      const nameInput = screen.getByDisplayValue('Initial Cohort');
+      expect(nameInput).toBeInTheDocument();
+    });
+
+    const manualRadio = screen.getByLabelText(messages.manual.defaultMessage);
+    expect(manualRadio).toBeChecked();
+
+    const selectGroupRadio = screen.getByLabelText(messages.selectAContentGroup.defaultMessage);
+    expect(selectGroupRadio).toBeChecked();
+
+    const groupSelect = screen.getByRole('combobox');
+    expect(groupSelect).toHaveValue('2:3');
   });
 });

--- a/src/cohorts/components/CohortsForm.tsx
+++ b/src/cohorts/components/CohortsForm.tsx
@@ -1,42 +1,69 @@
 import { useParams } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ActionRow, Button, Form, FormControl, FormGroup, FormLabel, FormRadioSet, Hyperlink, Icon } from '@openedx/paragon';
 import { useIntl } from '@openedx/frontend-base';
 import messages from '../messages';
 import { useContentGroupsData } from '../data/apiHook';
 import { Warning } from '@openedx/paragon/icons';
 import { assignmentTypes } from '../constants';
+import { CohortData, useCohortContext } from './CohortContext';
 
 interface CohortsFormProps {
   disableManualAssignment?: boolean,
   onCancel: () => void,
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void,
+  onSubmit: (data: Partial<CohortData>) => void,
 }
 
 const CohortsForm = ({ disableManualAssignment = false, onCancel, onSubmit }: CohortsFormProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const { data = [] } = useContentGroupsData(courseId);
-  const [selectedGroupId, setSelectedGroupId] = useState<string>('0');
-  const [selectedContentGroupOption, setSelectedContentGroupOption] = useState<string>('noContentGroup');
-  const [selectedAssignmentMethod, setSelectedAssignmentMethod] = useState<string>('automatic');
-  const [cohortName, setCohortName] = useState<string>('');
+  const { selectedCohort } = useCohortContext();
 
-  const contentGroups = [{ id: '', displayName: intl.formatMessage(messages.notSelected) }, ...data];
+  const initialCohortName = (selectedCohort?.name) ?? '';
+  const initialAssignmentType = selectedCohort?.assignmentType ?? assignmentTypes.automatic;
+  const initialContentGroupOption = selectedCohort?.groupId ? 'selectContentGroup' : 'noContentGroup';
+  const initialContentGroup = selectedCohort?.groupId && selectedCohort?.userPartitionId ? `${selectedCohort.groupId}:${selectedCohort.userPartitionId}` : 'null';
+
+  const [selectedContentGroup, setSelectedContentGroup] = useState<string>(initialContentGroup);
+  const [selectedContentGroupOption, setSelectedContentGroupOption] = useState<string>(initialContentGroupOption);
+  const [selectedAssignmentType, setSelectedAssignmentType] = useState<string>(initialAssignmentType);
+  const [name, setName] = useState<string>(initialCohortName);
+
+  useEffect(() => {
+    if (selectedCohort) {
+      const contentGroup = selectedCohort.groupId && selectedCohort.userPartitionId ? `${selectedCohort.groupId}:${selectedCohort.userPartitionId}` : 'null';
+      setName(selectedCohort.name);
+      setSelectedAssignmentType(selectedCohort.assignmentType);
+      setSelectedContentGroupOption(selectedCohort.groupId ? 'selectContentGroup' : 'noContentGroup');
+      setSelectedContentGroup(contentGroup);
+    }
+  }, [selectedCohort]);
+
+  const contentGroups = [{ id: 'null', displayName: intl.formatMessage(messages.notSelected) }, ...data];
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    onSubmit(event);
+    event.preventDefault();
+    const contentGroups = selectedContentGroupOption.split(':');
+    const groupId = contentGroups.length > 1 ? Number(contentGroups[0]) : null;
+    const userPartitionId = contentGroups.length > 1 ? Number(contentGroups[1]) : null;
+    onSubmit({
+      name,
+      assignmentType: selectedAssignmentType,
+      groupId,
+      userPartitionId,
+    });
   };
 
   return (
     <Form className="my-3.5 mx-4" onSubmit={handleSubmit}>
       <FormGroup className="w-md-50">
         <FormLabel className="text-primary-500">{intl.formatMessage(messages.cohortName)}</FormLabel>
-        <FormControl value={cohortName} onChange={(e) => setCohortName(e.target.value)} placeholder={intl.formatMessage(messages.cohortName)} />
+        <FormControl value={name} onChange={(e) => setName(e.target.value)} placeholder={intl.formatMessage(messages.cohortName)} />
       </FormGroup>
       <FormGroup>
         <FormLabel className="text-primary-500">{intl.formatMessage(messages.cohortAssignmentMethod)}</FormLabel>
-        <FormRadioSet name="cohortAssignmentMethod" value={selectedAssignmentMethod} onChange={(e) => setSelectedAssignmentMethod(e.target.value)}>
+        <FormRadioSet name="assignmentType" value={selectedAssignmentType} onChange={(e) => setSelectedAssignmentType(e.target.value)}>
           <Form.Radio className="mb-2" value={assignmentTypes.automatic}>{intl.formatMessage(messages.automatic)}</Form.Radio>
           <Form.Radio disabled={disableManualAssignment} value={assignmentTypes.manual}>{intl.formatMessage(messages.manual)}</Form.Radio>
         </FormRadioSet>
@@ -59,8 +86,8 @@ const CohortsForm = ({ disableManualAssignment = false, onCancel, onSubmit }: Co
                     size="sm"
                     disabled={selectedContentGroupOption !== 'selectContentGroup'}
                     name="contentGroup"
-                    onChange={(e) => setSelectedGroupId(e.target.value)}
-                    value={selectedGroupId}
+                    onChange={(e) => setSelectedContentGroup(e.target.value)}
+                    value={selectedContentGroup}
                   >
                     {
                       contentGroups.map((contentGroup) => (

--- a/src/cohorts/components/CohortsForm.tsx
+++ b/src/cohorts/components/CohortsForm.tsx
@@ -6,7 +6,8 @@ import messages from '../messages';
 import { useContentGroupsData } from '../data/apiHook';
 import { Warning } from '@openedx/paragon/icons';
 import { assignmentTypes } from '../constants';
-import { CohortData, useCohortContext } from './CohortContext';
+import { useCohortContext } from './CohortContext';
+import { CohortData } from '../types';
 
 interface CohortsFormProps {
   disableManualAssignment?: boolean,

--- a/src/cohorts/components/CohortsForm.tsx
+++ b/src/cohorts/components/CohortsForm.tsx
@@ -1,0 +1,92 @@
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { ActionRow, Button, Form, FormControl, FormGroup, FormLabel, FormRadioSet, Hyperlink, Icon } from '@openedx/paragon';
+import { useIntl } from '@openedx/frontend-base';
+import messages from '../messages';
+import { useContentGroupsData } from '../data/apiHook';
+import { Warning } from '@openedx/paragon/icons';
+import { assignmentTypes } from '../constants';
+
+interface CohortsFormProps {
+  disableManualAssignment?: boolean,
+  onCancel: () => void,
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void,
+}
+
+const CohortsForm = ({ disableManualAssignment = false, onCancel, onSubmit }: CohortsFormProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { data = [] } = useContentGroupsData(courseId);
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('0');
+  const [selectedContentGroupOption, setSelectedContentGroupOption] = useState<string>('noContentGroup');
+  const [selectedAssignmentMethod, setSelectedAssignmentMethod] = useState<string>('automatic');
+  const [cohortName, setCohortName] = useState<string>('');
+
+  const contentGroups = [{ id: '', displayName: intl.formatMessage(messages.notSelected) }, ...data];
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    onSubmit(event);
+  };
+
+  return (
+    <Form className="my-3.5 mx-4" onSubmit={handleSubmit}>
+      <FormGroup className="w-md-50">
+        <FormLabel className="text-primary-500">{intl.formatMessage(messages.cohortName)}</FormLabel>
+        <FormControl value={cohortName} onChange={(e) => setCohortName(e.target.value)} placeholder={intl.formatMessage(messages.cohortName)} />
+      </FormGroup>
+      <FormGroup>
+        <FormLabel className="text-primary-500">{intl.formatMessage(messages.cohortAssignmentMethod)}</FormLabel>
+        <FormRadioSet name="cohortAssignmentMethod" value={selectedAssignmentMethod} onChange={(e) => setSelectedAssignmentMethod(e.target.value)}>
+          <Form.Radio className="mb-2" value={assignmentTypes.automatic}>{intl.formatMessage(messages.automatic)}</Form.Radio>
+          <Form.Radio disabled={disableManualAssignment} value={assignmentTypes.manual}>{intl.formatMessage(messages.manual)}</Form.Radio>
+        </FormRadioSet>
+      </FormGroup>
+      <FormGroup className="mb-3.5">
+        <FormLabel className="text-primary-500">{intl.formatMessage(messages.associatedContentGroup)}</FormLabel>
+        <FormRadioSet
+          name="associatedContentGroup"
+          value={selectedContentGroupOption}
+          onChange={(e) => setSelectedContentGroupOption(e.target.value)}
+        >
+          <Form.Radio value="noContentGroup">{intl.formatMessage(messages.noContentGroup)}</Form.Radio>
+          <div className="d-flex align-items-center">
+            <Form.Radio value="selectContentGroup" disabled={data.length === 0}>{intl.formatMessage(messages.selectAContentGroup)}</Form.Radio>
+            { data.length > 0
+              ? (
+                  <FormControl
+                    as="select"
+                    className="ml-2"
+                    size="sm"
+                    disabled={selectedContentGroupOption !== 'selectContentGroup'}
+                    name="contentGroup"
+                    onChange={(e) => setSelectedGroupId(e.target.value)}
+                    value={selectedGroupId}
+                  >
+                    {
+                      contentGroups.map((contentGroup) => (
+                        <option key={contentGroup.id} value={contentGroup.id}>
+                          {contentGroup.displayName}
+                        </option>
+                      ))
+                    }
+                  </FormControl>
+                )
+              : (
+                  <div className="d-flex align-items-center small">
+                    <Icon className="ml-2 text-danger-500" src={Warning} size="sm" />
+                    <p className="mb-0 ml-1 text-danger-500">{intl.formatMessage(messages.noContentGroups)}</p>
+                    <Hyperlink className="ml-1">{intl.formatMessage(messages.createContentGroup)}</Hyperlink>
+                  </div>
+                )}
+          </div>
+        </FormRadioSet>
+      </FormGroup>
+      <ActionRow>
+        <Button variant="tertiary" onClick={onCancel}>{intl.formatMessage(messages.cancelLabel)}</Button>
+        <Button type="submit">{intl.formatMessage(messages.saveLabel)}</Button>
+      </ActionRow>
+    </Form>
+  );
+};
+
+export default CohortsForm;

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -5,6 +5,7 @@ import { renderWithIntl } from '../../testUtils';
 import { useCohorts, useContentGroupsData } from '../data/apiHook';
 import messages from '../messages';
 import EnabledCohortsView from './EnabledCohortsView';
+import { CohortProvider } from './CohortContext';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -14,6 +15,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('../data/apiHook', () => ({
   useCohorts: jest.fn(),
   useContentGroupsData: jest.fn(),
+  useCreateCohort: () => ({ mutate: jest.fn() }),
 }));
 
 const mockCohorts = [
@@ -22,6 +24,8 @@ const mockCohorts = [
 ];
 
 describe('EnabledCohortsView', () => {
+  const renderWithCohortProvider = () => renderWithIntl(<CohortProvider><EnabledCohortsView /></CohortProvider>);
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useParams as jest.Mock).mockReturnValue({ courseId: 'course-v1:edX+Test+2024' });
@@ -32,7 +36,7 @@ describe('EnabledCohortsView', () => {
       data: mockCohorts,
     });
 
-    renderWithIntl(<EnabledCohortsView />);
+    renderWithCohortProvider();
     expect(screen.getByText(messages.selectCohortPlaceholder.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(mockCohorts[0].name)).toBeInTheDocument();
     expect(screen.getByText(mockCohorts[1].name)).toBeInTheDocument();
@@ -41,14 +45,14 @@ describe('EnabledCohortsView', () => {
   // TODO: Modify test when add functionality to select
   it('calls handleSelectCohort on select change', () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: mockCohorts });
-    renderWithIntl(<EnabledCohortsView />);
+    renderWithCohortProvider();
   });
 
   // TODO: Modify test when add functionality to button
   it('calls handleAddCohort on button click', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
-    renderWithIntl(<EnabledCohortsView />);
+    renderWithCohortProvider();
     const user = userEvent.setup();
     const button = screen.getByRole('button', { name: `+ ${messages.addCohort.defaultMessage}` });
     await user.click(button);
@@ -56,7 +60,7 @@ describe('EnabledCohortsView', () => {
 
   it('renders correctly when no cohorts are returned', () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
-    renderWithIntl(<EnabledCohortsView />);
+    renderWithCohortProvider();
     const cohortsOptions = screen.getAllByRole('option');
     expect(cohortsOptions.length).toBe(1);
     expect(cohortsOptions[0]).toHaveTextContent(messages.selectCohortPlaceholder.defaultMessage);
@@ -65,7 +69,7 @@ describe('EnabledCohortsView', () => {
   it('uses default courseId if not present in params', () => {
     (useParams as jest.Mock).mockReturnValue({});
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
-    renderWithIntl(<EnabledCohortsView />);
+    renderWithCohortProvider();
     expect(useCohorts).toHaveBeenCalledWith('');
   });
 });

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -42,13 +42,15 @@ describe('EnabledCohortsView', () => {
     expect(screen.getByText(mockCohorts[1].name)).toBeInTheDocument();
   });
 
-  // TODO: Modify test when add functionality to select
-  it('calls handleSelectCohort on select change', () => {
+  it('calls handleSelectCohort on select change', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: mockCohorts });
     renderWithCohortProvider();
+    const select = screen.getByRole('combobox');
+    const user = userEvent.setup();
+    await user.selectOptions(select, '1');
+    expect((select as HTMLSelectElement).value).toBe('1');
   });
 
-  // TODO: Modify test when add functionality to button
   it('calls handleAddCohort on button click', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
@@ -56,6 +58,8 @@ describe('EnabledCohortsView', () => {
     const user = userEvent.setup();
     const button = screen.getByRole('button', { name: `+ ${messages.addCohort.defaultMessage}` });
     await user.click(button);
+    expect(screen.getByPlaceholderText(messages.cohortName.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.saveLabel.defaultMessage })).toBeInTheDocument();
   });
 
   it('renders correctly when no cohorts are returned', () => {

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useParams } from 'react-router-dom';
 import { renderWithIntl } from '../../testUtils';
-import { useCohorts } from '../data/apiHook';
+import { useCohorts, useContentGroupsData } from '../data/apiHook';
 import messages from '../messages';
 import EnabledCohortsView from './EnabledCohortsView';
 
@@ -13,6 +13,7 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('../data/apiHook', () => ({
   useCohorts: jest.fn(),
+  useContentGroupsData: jest.fn(),
 }));
 
 const mockCohorts = [
@@ -46,6 +47,7 @@ describe('EnabledCohortsView', () => {
   // TODO: Modify test when add functionality to button
   it('calls handleAddCohort on button click', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: [] });
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
     renderWithIntl(<EnabledCohortsView />);
     const user = userEvent.setup();
     const button = screen.getByRole('button', { name: `+ ${messages.addCohort.defaultMessage}` });

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -1,19 +1,21 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { FormControl, Button } from '@openedx/paragon';
+import { FormControl, Button, Card } from '@openedx/paragon';
 import messages from '../messages';
 import { useCohorts } from '../data/apiHook';
+import CohortsForm from './CohortsForm';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
   const { data = [] } = useCohorts(courseId);
+  const [displayAddForm, setDisplayAddForm] = useState(false);
 
   const cohortsList = [{ id: null, name: intl.formatMessage(messages.selectCohortPlaceholder) }, ...data];
 
   const handleAddCohort = () => {
-    // Handle adding a new cohort
-    console.log('Add Cohort');
+    setDisplayAddForm(true);
   };
 
   const handleSelectCohort = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -21,19 +23,33 @@ const EnabledCohortsView = () => {
     console.log(event);
   };
 
+  const handleNewCohort = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    console.log('New cohort created', event);
+    // Logic to handle new cohort creation goes here
+    hideAddForm();
+  };
+
+  const hideAddForm = () => {
+    setDisplayAddForm(false);
+  };
+
   return (
-    <div className="d-flex mt-4.5">
-      <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
-        {
-          cohortsList.map((cohort) => (
-            <option key={cohort.id} value={cohort.id}>
-              {cohort.name}
-            </option>
-          ))
-        }
-      </FormControl>
-      <Button onClick={handleAddCohort}>+ {intl.formatMessage(messages.addCohort)}</Button>
-    </div>
+    <>
+      <div className="d-flex mt-4.5">
+        <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
+          {
+            cohortsList.map((cohort) => (
+              <option key={cohort.id} value={cohort.id}>
+                {cohort.name}
+              </option>
+            ))
+          }
+        </FormControl>
+        <Button onClick={handleAddCohort}>+ {intl.formatMessage(messages.addCohort)}</Button>
+      </div>
+      {displayAddForm && <Card className="mt-3 bg-light-200"><CohortsForm disableManualAssignment={data.length === 0} onCancel={hideAddForm} onSubmit={handleNewCohort} /></Card>}
+    </>
   );
 };
 

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Button, Card, Alert } from '@openedx/paragon';
+import { CheckCircle } from '@openedx/paragon/icons';
 import messages from '../messages';
 import { useCohorts, useCreateCohort } from '../data/apiHook';
 import CohortsForm from './CohortsForm';
-import { useCohortContext, CohortData } from './CohortContext';
+import { useCohortContext } from './CohortContext';
+import { CohortData } from '../types';
 import { assignmentTypes } from '../constants';
-import { CheckCircle } from '@openedx/paragon/icons';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -1,33 +1,60 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { FormControl, Button, Card } from '@openedx/paragon';
+import { FormControl, Button, Card, Alert } from '@openedx/paragon';
 import messages from '../messages';
-import { useCohorts } from '../data/apiHook';
+import { useCohorts, useCreateCohort } from '../data/apiHook';
 import CohortsForm from './CohortsForm';
+import { useCohortContext, CohortData } from './CohortContext';
+import { assignmentTypes } from '../constants';
+import { CheckCircle } from '@openedx/paragon/icons';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
   const { data = [] } = useCohorts(courseId);
+  const { mutate: createCohort } = useCreateCohort(courseId);
+  const { clearSelectedCohort, selectedCohort, setSelectedCohort } = useCohortContext();
   const [displayAddForm, setDisplayAddForm] = useState(false);
+  const [showSuccessAlert, setShowSuccessAlert] = useState(false);
 
-  const cohortsList = [{ id: null, name: intl.formatMessage(messages.selectCohortPlaceholder) }, ...data];
+  const cohortsList = [{ id: 'null', name: intl.formatMessage(messages.selectCohortPlaceholder) }, ...data];
 
   const handleAddCohort = () => {
+    clearSelectedCohort();
+    setShowSuccessAlert(false);
     setDisplayAddForm(true);
   };
 
   const handleSelectCohort = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    // Handle cohort selection
-    console.log(event);
+    setShowSuccessAlert(false);
+    const selectedValue = event.target.value;
+    const selectedCohortFromApi = cohortsList.find(cohort => cohort.id?.toString() === selectedValue);
+    setDisplayAddForm(false);
+
+    if (selectedCohortFromApi && selectedCohortFromApi.id !== 'null') {
+      const cohortFormData: CohortData = {
+        id: selectedCohortFromApi.id,
+        name: selectedCohortFromApi.name,
+        assignmentType: selectedCohortFromApi.assignmentType ?? assignmentTypes.automatic,
+        groupId: selectedCohortFromApi.groupId,
+        userPartitionId: selectedCohortFromApi.userPartitionId,
+      };
+      setSelectedCohort(cohortFormData);
+    } else {
+      clearSelectedCohort();
+    }
   };
 
-  const handleNewCohort = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    console.log('New cohort created', event);
-    // Logic to handle new cohort creation goes here
-    hideAddForm();
+  const handleNewCohort = (newCohort: Partial<CohortData>) => {
+    createCohort(newCohort, {
+      onSuccess: (newCohort: CohortData) => {
+        setShowSuccessAlert(true);
+        setSelectedCohort(newCohort);
+        hideAddForm();
+      },
+      onError: (error) => console.error(error)
+    });
   };
 
   const hideAddForm = () => {
@@ -37,7 +64,7 @@ const EnabledCohortsView = () => {
   return (
     <>
       <div className="d-flex mt-4.5">
-        <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort}>
+        <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort} value={selectedCohort?.id?.toString() ?? 'null'} disabled={displayAddForm}>
           {
             cohortsList.map((cohort) => (
               <option key={cohort.id} value={cohort.id}>
@@ -46,9 +73,14 @@ const EnabledCohortsView = () => {
             ))
           }
         </FormControl>
-        <Button onClick={handleAddCohort}>+ {intl.formatMessage(messages.addCohort)}</Button>
+        <Button onClick={handleAddCohort} disabled={displayAddForm}>+ {intl.formatMessage(messages.addCohort)}</Button>
       </div>
-      {displayAddForm && <Card className="mt-3 bg-light-200"><CohortsForm disableManualAssignment={data.length === 0} onCancel={hideAddForm} onSubmit={handleNewCohort} /></Card>}
+      {showSuccessAlert && <Alert className="mt-3" icon={CheckCircle} variant="success">{intl.formatMessage(messages.addCohortSuccessMessage, { cohortName: selectedCohort?.name })}</Alert>}
+      {displayAddForm && (
+        <Card className="mt-3 bg-light-200">
+          <CohortsForm disableManualAssignment={data.length === 0} onCancel={hideAddForm} onSubmit={handleNewCohort} />
+        </Card>
+      )}
     </>
   );
 };

--- a/src/cohorts/constants.ts
+++ b/src/cohorts/constants.ts
@@ -1,0 +1,4 @@
+export const assignmentTypes = {
+  automatic: 'random',
+  manual: 'manual'
+};

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -1,5 +1,6 @@
-import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
+import { CohortData } from '../components/CohortContext';
 
 export const getCohortStatus = async (courseId: string) => {
   const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
@@ -19,11 +20,10 @@ export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
   return camelCaseObject(data);
 };
 
-export const createCohort = async (courseId: string, cohortDetails: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/`;
-  const { data } = await getAuthenticatedHttpClient().post(url, {
-    name: cohortDetails,
-  });
+export const createCohort = async (courseId: string, cohortDetails: Partial<CohortData>) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/`;
+  const cohortDetailsSnakeCase = snakeCaseObject(cohortDetails);
+  const { data } = await getAuthenticatedHttpClient().post(url, cohortDetailsSnakeCase);
   return camelCaseObject(data);
 };
 

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { CohortData } from '../components/CohortContext';
+import { CohortData } from '../types';
 
 export const getCohortStatus = async (courseId: string) => {
   const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -18,3 +18,17 @@ export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
   const { data } = await getAuthenticatedHttpClient().put(url, { is_cohorted: isCohorted });
   return camelCaseObject(data);
 };
+
+export const createCohort = async (courseId: string, cohortDetails: string) => {
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/cohorts/`;
+  const { data } = await getAuthenticatedHttpClient().post(url, {
+    name: cohortDetails,
+  });
+  return camelCaseObject(data);
+};
+
+export const getContentGroups = async (courseId: string) => {
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/content_groups/`;
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return camelCaseObject(data);
+};

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort } from './api';
 import { cohortsQueryKeys } from './queryKeys';
-import { CohortData } from '../components/CohortContext';
+import { CohortData } from '../types';
 
 export const useCohortStatus = (courseId: string) => (
   useQuery({

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts } from './api';
+import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort } from './api';
 import { cohortsQueryKeys } from './queryKeys';
+import { CohortData } from '../components/CohortContext';
 
 export const useCohortStatus = (courseId: string) => (
   useQuery({
@@ -26,6 +27,16 @@ export const useToggleCohorts = (courseId: string) => {
       queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.enabled(courseId) });
     },
   }));
+};
+
+export const useCreateCohort = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (cohortInfo: Partial<CohortData>) => createCohort(courseId, cohortInfo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.list(courseId) });
+    },
+  });
 };
 
 export const useContentGroupsData = (courseId: string) => (

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCohorts, getCohortStatus, toggleCohorts } from './api';
+import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts } from './api';
 import { cohortsQueryKeys } from './queryKeys';
 
 export const useCohortStatus = (courseId: string) => (
@@ -27,3 +27,10 @@ export const useToggleCohorts = (courseId: string) => {
     },
   }));
 };
+
+export const useContentGroupsData = (courseId: string) => (
+  useQuery({
+    queryKey: cohortsQueryKeys.contentGroups(courseId),
+    queryFn: () => getContentGroups(courseId),
+  })
+);

--- a/src/cohorts/data/queryKeys.ts
+++ b/src/cohorts/data/queryKeys.ts
@@ -4,4 +4,7 @@ export const cohortsQueryKeys = {
   all: [appId, 'cohorts'] as const,
   list: (courseId: string) => [...cohortsQueryKeys.all, courseId, 'list'] as const,
   enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
+  byCourse: (courseId: string) => [...cohortsQueryKeys.all, 'byCourse', courseId] as const,
+  byId: (courseId: string, cohortId: string) => [...cohortsQueryKeys.byCourse(courseId), cohortId] as const,
+  contentGroups: (courseId: string) => [...cohortsQueryKeys.byCourse(courseId), 'contentGroups'] as const,
 };

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -105,7 +105,12 @@ const messages = defineMessages({
     id: 'instruct.cohorts.addForm.createContentGroup',
     defaultMessage: 'Create a content group',
     description: 'Label for the create a content group link'
-  }
+  },
+  addCohortSuccessMessage: {
+    id: 'instruct.cohorts.addForm.successMessage',
+    defaultMessage: 'The {cohortName} cohort has been created. You can manually add students to this cohort below.',
+    description: 'Success message displayed when a new cohort is added'
+  },
 });
 
 export default messages;

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -50,6 +50,61 @@ const messages = defineMessages({
     id: 'instruct.cohorts.selectCohortPlaceholder',
     defaultMessage: 'Select a cohort',
     description: 'Placeholder text for the select cohort dropdown'
+  },
+  cohortName: {
+    id: 'instruct.cohorts.cohortName',
+    defaultMessage: 'Cohort Name',
+    description: 'Label for the cohort name input field'
+  },
+  saveLabel: {
+    id: 'instruct.cohorts.saveLabel',
+    defaultMessage: 'Save',
+    description: 'Label for the save button'
+  },
+  cohortAssignmentMethod: {
+    id: 'instruct.cohorts.addForm.cohortAssignmentMethod',
+    defaultMessage: 'Cohort Assignment Method',
+    description: 'Label for the cohort assignment method section'
+  },
+  automatic: {
+    id: 'instruct.cohorts.addForm.automatic',
+    defaultMessage: 'Automatic',
+    description: 'Label for the automatic cohort assignment method option'
+  },
+  manual: {
+    id: 'instruct.cohorts.addForm.manual',
+    defaultMessage: 'Manual',
+    description: 'Label for the manual cohort assignment method option'
+  },
+  associatedContentGroup: {
+    id: 'instruct.cohorts.addForm.associatedContentGroup',
+    defaultMessage: 'Associated Content Group',
+    description: 'Label for the associated content group section'
+  },
+  noContentGroup: {
+    id: 'instruct.cohorts.addForm.noContentGroup',
+    defaultMessage: 'No Content Group',
+    description: 'Label for the no content group option'
+  },
+  selectAContentGroup: {
+    id: 'instruct.cohorts.addForm.selectAContentGroup',
+    defaultMessage: 'Select a Content Group',
+    description: 'Label for the select a content group option'
+  },
+  notSelected: {
+    id: 'instruct.cohorts.addForm.notSelected',
+    defaultMessage: 'Not Selected',
+    description: 'Label for the not selected content group option'
+  },
+  noContentGroups: {
+    id: 'instruct.cohorts.addForm.noContentGroups',
+    defaultMessage: 'No content groups exist.',
+    description: 'Message displayed when there are no content groups'
+  },
+  createContentGroup: {
+    id: 'instruct.cohorts.addForm.createContentGroup',
+    defaultMessage: 'Create a content group',
+    description: 'Label for the create a content group link'
   }
 });
 

--- a/src/cohorts/types.ts
+++ b/src/cohorts/types.ts
@@ -1,0 +1,12 @@
+import { assignmentTypes } from './constants';
+
+export type AssignmentType = typeof assignmentTypes[keyof typeof assignmentTypes];
+
+export interface CohortData {
+  id: string,
+  name: string,
+  assignmentType: AssignmentType,
+  contentGroupOption?: string,
+  groupId: number | null,
+  userPartitionId: number | null,
+}


### PR DESCRIPTION
## Description
Features added:
- Create add cohort Form as a reusable component so later it can be also used on Settings tab when viewing cohort details.
- When a cohort is created a success alert message is displayed and will be cleared if you change selection or click on add cohort.
- Added a cohort context so we can access to selected cohort on other components and avoid prop drilling

Note: Cohort details and management will be handled on a different PR.
Pending: Backend endpoint to get content groups is still in progress.

#### Screenshot
- Content groups exist
<img width="1416" height="883" alt="Screenshot 2025-12-17 at 1 38 53 p m" src="https://github.com/user-attachments/assets/c868088d-95d7-48c9-936c-d2797a000d0c" />

- No content groups
<img width="1419" height="887" alt="Screenshot 2025-12-17 at 1 31 23 p m" src="https://github.com/user-attachments/assets/55c51fef-ef00-468d-bfd0-e97b35dcc98b" />

- Success alert
<img width="1412" height="694" alt="Screenshot 2025-12-17 at 1 20 28 p m" src="https://github.com/user-attachments/assets/155c5772-ceba-4512-b251-00ef0b3d30f7" />


## Supporting information
Closes #51 

## Testing instructions
- Go to a valid path with courseid for example:
http://apps.local.openedx.io:8080/instructor/course-v1:DV-edtech+check+2025-05/cohorts

- Click on Add Cohort button

- Fill all the required info

- Click on save button

## Other information
Review and merge after #70 

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
