### PR TITLE
Edit cohorts

### DIFF
--- a/docs/how_tos/override-external-urls.rst
+++ b/docs/how_tos/override-external-urls.rst
@@ -12,6 +12,7 @@ URLs wrapped with getExternalLinkUrl
 Currently, the following external URLs are wrapped with `getExternalLinkUrl` in the authoring application:
 
 - https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation
+- https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_cohorts.html#assign-learners-to-cohorts-manually
 
 
 How to Override External URLs

--- a/docs/how_tos/override-external-urls.rst
+++ b/docs/how_tos/override-external-urls.rst
@@ -13,6 +13,7 @@ Currently, the following external URLs are wrapped with `getExternalLinkUrl` in 
 
 - https://openedx.atlassian.net/wiki/spaces/ENG/pages/123456789/Cohorts+Feature+Documentation
 - https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_cohorts.html#assign-learners-to-cohorts-manually
+- https://docs.openedx.org/en/latest/educators/references/advanced_features/managing_cohort_assignment.html#about-auto-cohorts
 
 
 How to Override External URLs

--- a/src/cohorts/components/CohortCard.tsx
+++ b/src/cohorts/components/CohortCard.tsx
@@ -1,9 +1,10 @@
-import { useIntl } from '@openedx/frontend-base';
+import { getExternalLinkUrl, useIntl } from '@openedx/frontend-base';
 import { Card, Tab, Tabs } from '@openedx/paragon';
 import messages from '../messages';
 import CohortsForm from './CohortsForm';
 import ManageLearners from './ManageLearners';
 import { useCohortContext } from './CohortContext';
+import { assignmentTypes } from '../constants';
 
 const CohortCard = () => {
   const { selectedCohort } = useCohortContext();
@@ -12,7 +13,13 @@ const CohortCard = () => {
   return (
     <Card className="bg-light-200 mt-3">
       <div className="mx-4 my-3.5">
-        <h3>{selectedCohort?.name}</h3>
+        <div className="d-flex align-items-center">
+          <h3 className="text-primary-700 mb-0">{selectedCohort?.name}</h3>
+          <p className="ml-3 text-primary-700 mb-0">{intl.formatMessage(messages.studentsOnCohort, { users: selectedCohort?.userCount ?? 0 })}</p>
+        </div>
+        {selectedCohort?.assignmentType === assignmentTypes.automatic && (
+          <p className="x-small mb-0 mt-2">{intl.formatMessage(messages.automaticCohortWarning)} <a href={getExternalLinkUrl('https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_cohorts.html#assign-learners-to-cohorts-manually')}>{intl.formatMessage(messages.automaticCohortLink)}</a></p>
+        )}
       </div>
       <Tabs id="cohort-management-tabs" className="mx-0" onSelect={() => {}}>
         <Tab key="manage-learners" eventKey="manage-learners" title={intl.formatMessage(messages.manageLearners)}>

--- a/src/cohorts/components/CohortCard.tsx
+++ b/src/cohorts/components/CohortCard.tsx
@@ -1,0 +1,32 @@
+import { useIntl } from '@openedx/frontend-base';
+import { Card, Tab, Tabs } from '@openedx/paragon';
+import messages from '../messages';
+import CohortsForm from './CohortsForm';
+import ManageLearners from './ManageLearners';
+import { useCohortContext } from './CohortContext';
+
+const CohortCard = () => {
+  const { selectedCohort } = useCohortContext();
+  const intl = useIntl();
+
+  return (
+    <Card className="bg-light-200 mt-3">
+      <div className="mx-4 my-3.5">
+        <h3>{selectedCohort?.name}</h3>
+      </div>
+      <Tabs id="cohort-management-tabs" className="mx-0" onSelect={() => {}}>
+        <Tab key="manage-learners" eventKey="manage-learners" title={intl.formatMessage(messages.manageLearners)}>
+          <ManageLearners />
+        </Tab>
+        <Tab key="settings" eventKey="settings" title={intl.formatMessage(messages.settings)}>
+          <CohortsForm
+            onCancel={() => {}}
+            onSubmit={() => {}}
+          />
+        </Tab>
+      </Tabs>
+    </Card>
+  );
+};
+
+export default CohortCard;

--- a/src/cohorts/components/CohortCard.tsx
+++ b/src/cohorts/components/CohortCard.tsx
@@ -1,14 +1,23 @@
 import { useParams } from 'react-router-dom';
-import { useRef } from 'react';
-import { getExternalLinkUrl, useIntl } from '@openedx/frontend-base';
-import { Card, Tab, Tabs } from '@openedx/paragon';
+import { useRef, useState } from 'react';
+import { FormattedMessage, getExternalLinkUrl, useIntl } from '@openedx/frontend-base';
+import { Card, Tab, Tabs, Toast } from '@openedx/paragon';
 import messages from '../messages';
 import CohortsForm from './CohortsForm';
 import ManageLearners from './ManageLearners';
 import { useCohortContext } from './CohortContext';
-import { assignmentTypes } from '../constants';
 import { usePatchCohort } from '../data/apiHook';
 import { CohortData } from '../types';
+
+const assignmentLink = {
+  random: 'https://docs.openedx.org/en/latest/educators/references/advanced_features/managing_cohort_assignment.html#about-auto-cohorts',
+  manual: 'https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_cohorts.html#assign-learners-to-cohorts-manually',
+};
+
+const warningMessage = {
+  random: messages.automaticCohortWarning,
+  manual: messages.manualCohortWarning,
+};
 
 const CohortCard = () => {
   const intl = useIntl();
@@ -16,6 +25,7 @@ const CohortCard = () => {
   const { selectedCohort } = useCohortContext();
   const { mutate: editCohort } = usePatchCohort(courseId);
   const formRef = useRef<{ resetForm: () => void }>(null);
+  const [showSuccessMessage, setShowSuccessMessage] = useState<boolean>(false);
 
   if (!selectedCohort) {
     return null;
@@ -24,6 +34,9 @@ const CohortCard = () => {
   const handleEditCohort = (updatedCohort: CohortData) => {
     editCohort({ cohortId: selectedCohort.id, cohortInfo: updatedCohort },
       {
+        onSuccess: () => {
+          setShowSuccessMessage(true);
+        },
         onError: (error) => console.error(error)
       }
     );
@@ -34,29 +47,34 @@ const CohortCard = () => {
   };
 
   return (
-    <Card className="bg-light-200 mt-3">
-      <div className="mx-4 my-3.5">
-        <div className="d-flex align-items-center">
-          <h3 className="text-primary-700 mb-0">{selectedCohort?.name}</h3>
-          <p className="ml-3 text-primary-700 mb-0">{intl.formatMessage(messages.studentsOnCohort, { users: selectedCohort?.userCount ?? 0 })}</p>
+    <>
+      <Card className="bg-light-200 mt-3">
+        <div className="mx-4 my-3.5">
+          <div className="d-flex align-items-center">
+            <h3 className="text-primary-700 mb-0">{selectedCohort?.name}</h3>
+            <p className="ml-3 text-primary-700 mb-0">{intl.formatMessage(messages.studentsOnCohort, { users: selectedCohort?.userCount ?? 0 })}</p>
+          </div>
+          <p className="x-small mb-0 mt-2">
+            <FormattedMessage {...warningMessage[selectedCohort.assignmentType]} /> <a href={getExternalLinkUrl(assignmentLink[selectedCohort.assignmentType])}>{intl.formatMessage(messages.warningCohortLink)}</a>
+          </p>
         </div>
-        {selectedCohort?.assignmentType === assignmentTypes.automatic && (
-          <p className="x-small mb-0 mt-2">{intl.formatMessage(messages.automaticCohortWarning)} <a href={getExternalLinkUrl('https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_cohorts.html#assign-learners-to-cohorts-manually')}>{intl.formatMessage(messages.automaticCohortLink)}</a></p>
-        )}
-      </div>
-      <Tabs id="cohort-management-tabs" className="mx-0" onSelect={() => {}}>
-        <Tab key="manage-learners" eventKey="manage-learners" title={intl.formatMessage(messages.manageLearners)}>
-          <ManageLearners />
-        </Tab>
-        <Tab key="settings" eventKey="settings" title={intl.formatMessage(messages.settings)}>
-          <CohortsForm
-            ref={formRef}
-            onCancel={handleCancelForm}
-            onSubmit={handleEditCohort}
-          />
-        </Tab>
-      </Tabs>
-    </Card>
+        <Tabs id="cohort-management-tabs" className="mx-0" onSelect={() => {}}>
+          <Tab key="manage-learners" eventKey="manage-learners" title={intl.formatMessage(messages.manageLearners)}>
+            <ManageLearners />
+          </Tab>
+          <Tab key="settings" eventKey="settings" title={intl.formatMessage(messages.settings)}>
+            <CohortsForm
+              ref={formRef}
+              onCancel={handleCancelForm}
+              onSubmit={handleEditCohort}
+            />
+          </Tab>
+        </Tabs>
+      </Card>
+      <Toast show={showSuccessMessage} onClose={() => setShowSuccessMessage(false)} className="text-break">
+        {intl.formatMessage(messages.cohortUpdateSuccessMessage)}
+      </Toast>
+    </>
   );
 };
 

--- a/src/cohorts/components/CohortCard.tsx
+++ b/src/cohorts/components/CohortCard.tsx
@@ -1,3 +1,5 @@
+import { useParams } from 'react-router-dom';
+import { useRef } from 'react';
 import { getExternalLinkUrl, useIntl } from '@openedx/frontend-base';
 import { Card, Tab, Tabs } from '@openedx/paragon';
 import messages from '../messages';
@@ -5,10 +7,31 @@ import CohortsForm from './CohortsForm';
 import ManageLearners from './ManageLearners';
 import { useCohortContext } from './CohortContext';
 import { assignmentTypes } from '../constants';
+import { usePatchCohort } from '../data/apiHook';
+import { CohortData } from '../types';
 
 const CohortCard = () => {
-  const { selectedCohort } = useCohortContext();
   const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { selectedCohort } = useCohortContext();
+  const { mutate: editCohort } = usePatchCohort(courseId);
+  const formRef = useRef<{ resetForm: () => void }>(null);
+
+  if (!selectedCohort) {
+    return null;
+  }
+
+  const handleEditCohort = (updatedCohort: CohortData) => {
+    editCohort({ cohortId: selectedCohort.id, cohortInfo: updatedCohort },
+      {
+        onError: (error) => console.error(error)
+      }
+    );
+  };
+
+  const handleCancelForm = () => {
+    formRef.current?.resetForm();
+  };
 
   return (
     <Card className="bg-light-200 mt-3">
@@ -27,8 +50,9 @@ const CohortCard = () => {
         </Tab>
         <Tab key="settings" eventKey="settings" title={intl.formatMessage(messages.settings)}>
           <CohortsForm
-            onCancel={() => {}}
-            onSubmit={() => {}}
+            ref={formRef}
+            onCancel={handleCancelForm}
+            onSubmit={handleEditCohort}
           />
         </Tab>
       </Tabs>

--- a/src/cohorts/components/CohortCard.tsx
+++ b/src/cohorts/components/CohortCard.tsx
@@ -22,7 +22,7 @@ const warningMessage = {
 const CohortCard = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const { selectedCohort } = useCohortContext();
+  const { selectedCohort, setSelectedCohort } = useCohortContext();
   const { mutate: editCohort } = usePatchCohort(courseId);
   const formRef = useRef<{ resetForm: () => void }>(null);
   const [showSuccessMessage, setShowSuccessMessage] = useState<boolean>(false);
@@ -36,6 +36,7 @@ const CohortCard = () => {
       {
         onSuccess: () => {
           setShowSuccessMessage(true);
+          setSelectedCohort({ ...selectedCohort, ...updatedCohort });
         },
         onError: (error) => console.error(error)
       }

--- a/src/cohorts/components/CohortContext.test.tsx
+++ b/src/cohorts/components/CohortContext.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import { CohortProvider, useCohortContext } from './CohortContext';
+import { assignmentTypes } from '../constants';
 
 const TestComponent: React.FC = () => {
   const {
@@ -16,12 +17,12 @@ const TestComponent: React.FC = () => {
       <button
         onClick={() =>
           setSelectedCohort({
-            id: '1',
+            id: 1,
             name: 'Cohort 1',
-            assignmentType: 'typeA',
-            contentGroupOption: 'optionA',
+            assignmentType: assignmentTypes.automatic,
             groupId: 123,
             userPartitionId: 456,
+            userCount: 0
           })}
       >
         Set Cohort
@@ -102,20 +103,12 @@ describe('CohortContext', () => {
       const { setSelectedCohort } = useCohortContext();
       React.useEffect(() => {
         setSelectedCohort({
-          id: '1',
+          id: 1,
           name: 'Cohort 1',
-          assignmentType: 'typeA',
-          contentGroupOption: 'optionA',
+          assignmentType: assignmentTypes.automatic,
           groupId: 123,
           userPartitionId: 456,
-        });
-        setSelectedCohort({
-          id: '1',
-          name: 'Cohort 1',
-          assignmentType: 'typeA',
-          contentGroupOption: 'optionA',
-          groupId: 123,
-          userPartitionId: 456,
+          userCount: 0
         });
       }, [setSelectedCohort]);
       return null;

--- a/src/cohorts/components/CohortContext.tsx
+++ b/src/cohorts/components/CohortContext.tsx
@@ -14,19 +14,24 @@ interface CohortProviderProps {
   children: ReactNode,
 }
 
+const areCohortsEqual = (prev: CohortData | null, current: CohortData): boolean => {
+  if (!prev) return false;
+  return prev.id !== current.id
+    && prev.name === current.name
+    && prev.assignmentType === current.assignmentType
+    && prev.contentGroupOption === current.contentGroupOption
+    && prev.userPartitionId === current.userPartitionId
+    && prev.userCount === current.userCount
+    && prev.groupId === current.groupId;
+};
+
 export const CohortProvider: FC<CohortProviderProps> = ({ children }) => {
   const [selectedCohort, setSelectedCohortState] = useState<CohortData | null>(null);
 
   const setSelectedCohort = useCallback((cohort: CohortData) => {
     setSelectedCohortState(prev => {
       // Only update if the values actually changed
-      if (!prev
-        || prev.id !== cohort.id
-        || prev.name !== cohort.name
-        || prev.assignmentType !== cohort.assignmentType
-        || prev.contentGroupOption !== cohort.contentGroupOption
-        || prev.userPartitionId !== cohort.userPartitionId
-        || prev.groupId !== cohort.groupId) {
+      if (!areCohortsEqual(prev, cohort)) {
         return cohort;
       }
       return prev;

--- a/src/cohorts/components/CohortContext.tsx
+++ b/src/cohorts/components/CohortContext.tsx
@@ -19,7 +19,6 @@ const areCohortsEqual = (prev: CohortData | null, current: CohortData): boolean 
   return prev.id !== current.id
     && prev.name === current.name
     && prev.assignmentType === current.assignmentType
-    && prev.contentGroupOption === current.contentGroupOption
     && prev.userPartitionId === current.userPartitionId
     && prev.userCount === current.userCount
     && prev.groupId === current.groupId;

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -142,11 +142,12 @@ describe('CohortsForm', () => {
 
     jest.spyOn(CohortContextModule, 'useCohortContext').mockReturnValue({
       selectedCohort: {
-        id: '1',
+        id: 1,
         name: 'Initial Cohort',
         assignmentType: 'manual',
         groupId: 2,
         userPartitionId: 3,
+        userCount: 0
       },
       setSelectedCohort: jest.fn(),
       clearSelectedCohort: jest.fn(),

--- a/src/cohorts/components/CohortsForm.test.tsx
+++ b/src/cohorts/components/CohortsForm.test.tsx
@@ -67,10 +67,12 @@ describe('CohortsForm', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('calls onSubmit when Save button is clicked', async () => {
+  it('calls onSubmit when Save button is enabled and clicked', async () => {
     (useContentGroupsData as jest.Mock).mockReturnValue({ data: mockContentGroups });
     renderComponent();
     const user = userEvent.setup();
+    const input = screen.getByPlaceholderText(messages.cohortName.defaultMessage);
+    await user.type(input, 'Test Cohort');
     await user.click(screen.getByText(messages.saveLabel.defaultMessage));
     expect(onSubmit).toHaveBeenCalled();
   });

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -44,6 +44,7 @@ describe('EnabledCohortsView', () => {
 
   it('calls handleSelectCohort on select change', async () => {
     (useCohorts as jest.Mock).mockReturnValue({ data: mockCohorts });
+    (useContentGroupsData as jest.Mock).mockReturnValue({ data: [] });
     renderWithCohortProvider();
     const select = screen.getByRole('combobox');
     const user = userEvent.setup();

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -16,6 +16,7 @@ jest.mock('../data/apiHook', () => ({
   useCohorts: jest.fn(),
   useContentGroupsData: jest.fn(),
   useCreateCohort: () => ({ mutate: jest.fn() }),
+  usePatchCohort: () => ({ mutate: jest.fn() }),
 }));
 
 const mockCohorts = [

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -3,13 +3,13 @@ import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Button, Card, Alert } from '@openedx/paragon';
 import { CheckCircle } from '@openedx/paragon/icons';
-import messages from '../messages';
-import { useCohorts, useCreateCohort } from '../data/apiHook';
 import CohortsForm from './CohortsForm';
 import { useCohortContext } from './CohortContext';
-import { CohortData } from '../types';
-import { assignmentTypes } from '../constants';
 import SelectedCohortInfo from './SelectedCohortInfo';
+import { CohortData, BasicCohortData } from '../types';
+import { assignmentTypes } from '../constants';
+import messages from '../messages';
+import { useCohorts, useCreateCohort } from '../data/apiHook';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();
@@ -49,7 +49,7 @@ const EnabledCohortsView = () => {
     }
   };
 
-  const handleNewCohort = (newCohort: Partial<CohortData>) => {
+  const handleNewCohort = (newCohort: BasicCohortData) => {
     createCohort(newCohort, {
       onSuccess: (newCohort: CohortData) => {
         setShowSuccessAlert(true);
@@ -67,7 +67,7 @@ const EnabledCohortsView = () => {
   return (
     <>
       <div className="d-flex mt-4.5">
-        <FormControl placeholder="Select a cohort" name="cohort" as="select" onChange={handleSelectCohort} value={selectedCohort?.id?.toString() ?? 'null'} disabled={displayAddForm}>
+        <FormControl placeholder={intl.formatMessage(messages.selectCohortPlaceholder)} name="cohort" as="select" onChange={handleSelectCohort} value={selectedCohort?.id?.toString() ?? 'null'} disabled={displayAddForm}>
           {
             cohortsList.map((cohort) => (
               <option key={cohort.id} value={cohort.id}>

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -41,6 +41,7 @@ const EnabledCohortsView = () => {
         assignmentType: selectedCohortFromApi.assignmentType ?? assignmentTypes.automatic,
         groupId: selectedCohortFromApi.groupId,
         userPartitionId: selectedCohortFromApi.userPartitionId,
+        userCount: selectedCohortFromApi.userCount ?? 0,
       };
       setSelectedCohort(cohortFormData);
     } else {

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -9,6 +9,7 @@ import CohortsForm from './CohortsForm';
 import { useCohortContext } from './CohortContext';
 import { CohortData } from '../types';
 import { assignmentTypes } from '../constants';
+import SelectedCohortInfo from './SelectedCohortInfo';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();
@@ -82,6 +83,7 @@ const EnabledCohortsView = () => {
           <CohortsForm disableManualAssignment={data.length === 0} onCancel={hideAddForm} onSubmit={handleNewCohort} />
         </Card>
       )}
+      {selectedCohort && <SelectedCohortInfo />}
     </>
   );
 };

--- a/src/cohorts/components/ManageLearners.tsx
+++ b/src/cohorts/components/ManageLearners.tsx
@@ -1,0 +1,5 @@
+const ManageLearners = () => {
+  return <div>Manage Learners Component</div>;
+};
+
+export default ManageLearners;

--- a/src/cohorts/components/SelectedCohortInfo.tsx
+++ b/src/cohorts/components/SelectedCohortInfo.tsx
@@ -1,0 +1,17 @@
+import { useIntl } from '@openedx/frontend-base';
+import CohortCard from './CohortCard';
+import messages from '../messages';
+import dataDownloadsMessages from '../../dataDownloads/messages';
+
+const SelectedCohortInfo = () => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <CohortCard />
+      <p className="mt-3">{intl.formatMessage(messages.cohortDisclaimer)} <a href="/">{intl.formatMessage(dataDownloadsMessages.pageTitle)}</a> {intl.formatMessage(messages.page)}</p>
+    </>
+  );
+};
+
+export default SelectedCohortInfo;

--- a/src/cohorts/components/SelectedCohortInfo.tsx
+++ b/src/cohorts/components/SelectedCohortInfo.tsx
@@ -1,15 +1,19 @@
 import { useIntl } from '@openedx/frontend-base';
+import { useParams } from 'react-router-dom';
 import CohortCard from './CohortCard';
 import messages from '../messages';
 import dataDownloadsMessages from '../../dataDownloads/messages';
 
 const SelectedCohortInfo = () => {
   const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
 
   return (
     <>
       <CohortCard />
-      <p className="mt-3">{intl.formatMessage(messages.cohortDisclaimer)} <a href="/">{intl.formatMessage(dataDownloadsMessages.pageTitle)}</a> {intl.formatMessage(messages.page)}</p>
+      <p className="mt-3">
+        {intl.formatMessage(messages.cohortDisclaimer)} <a href={`/instructor/${courseId}/data_downloads`}>{intl.formatMessage(dataDownloadsMessages.pageTitle)}</a> {intl.formatMessage(messages.page)}
+      </p>
     </>
   );
 };

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { CohortData } from '../types';
+import { CohortData, BasicCohortData } from '../types';
 
 export const getCohortStatus = async (courseId: string) => {
   const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;
@@ -20,7 +20,7 @@ export const toggleCohorts = async (courseId: string, isCohorted: boolean) => {
   return camelCaseObject(data);
 };
 
-export const createCohort = async (courseId: string, cohortDetails: Partial<CohortData>) => {
+export const createCohort = async (courseId: string, cohortDetails: BasicCohortData) => {
   const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/`;
   const cohortDetailsSnakeCase = snakeCaseObject(cohortDetails);
   const { data } = await getAuthenticatedHttpClient().post(url, cohortDetailsSnakeCase);
@@ -30,5 +30,12 @@ export const createCohort = async (courseId: string, cohortDetails: Partial<Coho
 export const getContentGroups = async (courseId: string) => {
   const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/content_groups/`;
   const { data } = await getAuthenticatedHttpClient().get(url);
+  return camelCaseObject(data);
+};
+
+export const patchCohort = async (courseId: string, cohortId: number, cohortDetails: CohortData) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/${cohortId}`;
+  const cohortDetailsSnakeCase = snakeCaseObject(cohortDetails);
+  const { data } = await getAuthenticatedHttpClient().patch(url, cohortDetailsSnakeCase);
   return camelCaseObject(data);
 };

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -51,8 +51,8 @@ export const usePatchCohort = (courseId: string) => {
   return useMutation({
     mutationFn: ({ cohortId, cohortInfo }: { cohortId: number, cohortInfo: CohortData }) =>
       patchCohort(courseId, cohortId, cohortInfo),
-    onSuccess: ({ cohortId }) => {
-      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.byId(courseId, cohortId) });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.byCourse(courseId) });
     },
   });
 };

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort } from './api';
+import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort, patchCohort } from './api';
 import { cohortsQueryKeys } from './queryKeys';
-import { CohortData } from '../types';
+import { CohortData, BasicCohortData } from '../types';
 
 export const useCohortStatus = (courseId: string) => (
   useQuery({
@@ -32,7 +32,7 @@ export const useToggleCohorts = (courseId: string) => {
 export const useCreateCohort = (courseId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (cohortInfo: Partial<CohortData>) => createCohort(courseId, cohortInfo),
+    mutationFn: (cohortInfo: BasicCohortData) => createCohort(courseId, cohortInfo),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.list(courseId) });
     },
@@ -45,3 +45,14 @@ export const useContentGroupsData = (courseId: string) => (
     queryFn: () => getContentGroups(courseId),
   })
 );
+
+export const usePatchCohort = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ cohortId, cohortInfo }: { cohortId: number, cohortInfo: CohortData }) =>
+      patchCohort(courseId, cohortId, cohortInfo),
+    onSuccess: ({ cohortId }) => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.byId(courseId, cohortId) });
+    },
+  });
+};

--- a/src/cohorts/data/queryKeys.ts
+++ b/src/cohorts/data/queryKeys.ts
@@ -2,9 +2,8 @@ import { appId } from '../../constants';
 
 export const cohortsQueryKeys = {
   all: [appId, 'cohorts'] as const,
-  list: (courseId: string) => [...cohortsQueryKeys.all, courseId, 'list'] as const,
-  enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
   byCourse: (courseId: string) => [...cohortsQueryKeys.all, 'byCourse', courseId] as const,
-  byId: (courseId: string, cohortId: string) => [...cohortsQueryKeys.byCourse(courseId), cohortId] as const,
+  list: (courseId: string) => [...cohortsQueryKeys.byCourse(courseId), courseId, 'list'] as const,
+  enabled: (courseId: string) => ['cohortsEnabled', courseId] as const,
   contentGroups: (courseId: string) => [...cohortsQueryKeys.byCourse(courseId), 'contentGroups'] as const,
 };

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -111,6 +111,26 @@ const messages = defineMessages({
     defaultMessage: 'The {cohortName} cohort has been created. You can manually add students to this cohort below.',
     description: 'Success message displayed when a new cohort is added'
   },
+  cohortDisclaimer: {
+    id: 'instruct.cohorts.cohortDisclaimer',
+    defaultMessage: 'To review learner cohort assignments or see the results of uploading a CSV file, download course profile information or cohort results on the',
+    description: 'Disclaimer message for cohorts'
+  },
+  page: {
+    id: 'instruct.cohorts.page',
+    defaultMessage: 'page',
+    description: 'Label for the page link'
+  },
+  settings: {
+    id: 'instruct.cohorts.settings',
+    defaultMessage: 'Settings',
+    description: 'Label for the settings tab'
+  },
+  manageLearners: {
+    id: 'instruct.cohorts.manageLearners',
+    defaultMessage: 'Manage Learners',
+    description: 'Label for the manage learners tab'
+  }
 });
 
 export default messages;

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -130,7 +130,22 @@ const messages = defineMessages({
     id: 'instruct.cohorts.manageLearners',
     defaultMessage: 'Manage Learners',
     description: 'Label for the manage learners tab'
-  }
+  },
+  studentsOnCohort: {
+    id: 'instruct.cohorts.studentsOnCohort',
+    defaultMessage: '(contains {users} students)',
+    description: 'Label showing the number of students on this cohort'
+  },
+  automaticCohortWarning: {
+    id: 'instruct.cohorts.automaticCohortWarning',
+    defaultMessage: 'Learners are added to this cohort automatically.',
+    description: 'Warning about automatic cohort assignment'
+  },
+  automaticCohortLink: {
+    id: 'instruct.cohorts.automaticCohortLink',
+    defaultMessage: 'What does this mean?',
+    description: 'Link text for more information about automatic cohort assignment'
+  },
 });
 
 export default messages;

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -141,11 +141,21 @@ const messages = defineMessages({
     defaultMessage: 'Learners are added to this cohort automatically.',
     description: 'Warning about automatic cohort assignment'
   },
-  automaticCohortLink: {
-    id: 'instruct.cohorts.automaticCohortLink',
-    defaultMessage: 'What does this mean?',
-    description: 'Link text for more information about automatic cohort assignment'
+  manualCohortWarning: {
+    id: 'instruct.cohorts.manualCohortWarning',
+    defaultMessage: 'Learners are added to this cohort only when you provide their email addresses or usernames on this page.',
+    description: 'Warning about manual cohort assignment'
   },
+  warningCohortLink: {
+    id: 'instruct.cohorts.warningCohortLink',
+    defaultMessage: 'What does this mean?',
+    description: 'Link text for more information about cohort assignment'
+  },
+  cohortUpdateSuccessMessage: {
+    id: 'instruct.cohorts.cohortUpdateSuccessMessage',
+    defaultMessage: 'Settings have been saved.',
+    description: 'Success message displayed when a cohort is updated'
+  }
 });
 
 export default messages;

--- a/src/cohorts/types.ts
+++ b/src/cohorts/types.ts
@@ -9,4 +9,5 @@ export interface CohortData {
   contentGroupOption?: string,
   groupId: number | null,
   userPartitionId: number | null,
+  userCount?: number,
 }

--- a/src/cohorts/types.ts
+++ b/src/cohorts/types.ts
@@ -2,12 +2,17 @@ import { assignmentTypes } from './constants';
 
 export type AssignmentType = typeof assignmentTypes[keyof typeof assignmentTypes];
 
-export interface CohortData {
-  id: string,
+export interface BasicCohortData {
   name: string,
   assignmentType: AssignmentType,
-  contentGroupOption?: string,
   groupId: number | null,
   userPartitionId: number | null,
-  userCount?: number,
+}
+export interface CohortData extends BasicCohortData {
+  id: number,
+  userCount: number,
+}
+
+export interface CohortForm extends BasicCohortData {
+  contentGroupOption: string,
 }

--- a/src/dataDownloads/messages.ts
+++ b/src/dataDownloads/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+  pageTitle: {
+    id: 'instruct.dataDownloads.pageTitle',
+    defaultMessage: 'Data Downloads',
+    description: 'Title for the data downloads page'
+  },
+});
+
+export default messages;

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,1 +1,6 @@
 @use "@openedx/frontend-base/shell/app.scss";
+
+.toast-container {
+    left: unset;
+    right: 1.25rem;
+}

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -3,3 +3,19 @@ import { mergeSiteConfig } from '@openedx/frontend-base';
 import '@testing-library/jest-dom';
 
 mergeSiteConfig(siteConfig);
+
+class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+
+  unobserve() {
+    // do nothing
+  }
+
+  disconnect() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = ResizeObserver;


### PR DESCRIPTION
## Description
When a cohort is selected display info with tabs Manage Learners and Settings, this PR only covers opening that section and the content for Settings Tab, Manage Learners will be handled on a different PR.

#### Screenshots
<img width="1418" height="969" alt="Screenshot 2025-12-11 at 12 33 54 p m" src="https://github.com/user-attachments/assets/ed85964a-de50-4289-af23-e170a16c2781" />

Video showing edit functionality and success message

https://github.com/user-attachments/assets/e11e0a8b-4b0b-403b-bccf-d640dc98d039



## Supporting information
Closes #53 

## Testing instructions
- Go to a valid url (existing course) for cohorts like: 
http://apps.local.openedx.io:8081/instructor/course-v1:DV-edtech+check+2025-05/cohorts 
- Select a cohort
- Click on Settings Tab
- Modify a Setting
- Save

* or cancel to reset original cohorts info

## Other information

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
