### PR TITLE
Manage learners tab

### DIFF
--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -8,14 +8,15 @@ import DisableCohortsModal from './components/DisableCohortsModal';
 import messages from './messages';
 import DisabledCohortsView from './components/DisabledCohortsView';
 import EnabledCohortsView from './components/EnabledCohortsView';
-import { CohortProvider } from './components/CohortContext';
+import { CohortProvider, useCohortContext } from './components/CohortContext';
 
-const CohortsPage = () => {
+const CohortsPageContent = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
   const { data: cohortStatus } = useCohortStatus(courseId);
   const { mutate: toggleCohortsMutate } = useToggleCohorts(courseId);
   const [isOpenDisableModal, setIsOpenDisableModal] = useState(false);
+  const { clearSelectedCohort } = useCohortContext();
   const { isCohorted = false } = cohortStatus ?? {};
 
   const handleEnableCohorts = () => {
@@ -28,36 +29,44 @@ const CohortsPage = () => {
   const handleDisableCohorts = () => {
     toggleCohortsMutate({ isCohorted: false },
       {
+        onSuccess: () => clearSelectedCohort(),
         onError: (error) => console.log(error)
       });
     setIsOpenDisableModal(false);
   };
 
   return (
-    <CohortProvider>
-      <div className="mt-4.5 mb-4 mx-4">
-        <div className="d-inline-flex align-items-center">
-          <h3 className="mb-0 text-gray-700">{intl.formatMessage(messages.cohortsTitle)}</h3>
-          {isCohorted && (
-            <div className="small">
-              <IconButton
-                alt={intl.formatMessage(messages.disableCohorts)}
-                iconAs={Settings}
-                iconClassNames="mb-2 text-gray-500"
-                size="sm"
-                variant="secondary"
-                onClick={() => setIsOpenDisableModal(true)}
-              />
-            </div>
-          )}
-        </div>
-        {isCohorted ? (
-          <EnabledCohortsView />
-        ) : (
-          <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
+    <div className="mt-4.5 mb-4 mx-4">
+      <div className="d-inline-flex align-items-center">
+        <h3 className="mb-0 text-gray-700">{intl.formatMessage(messages.cohortsTitle)}</h3>
+        {isCohorted && (
+          <div className="small">
+            <IconButton
+              alt={intl.formatMessage(messages.disableCohorts)}
+              iconAs={Settings}
+              iconClassNames="mb-2 text-gray-500"
+              size="sm"
+              variant="secondary"
+              onClick={() => setIsOpenDisableModal(true)}
+            />
+          </div>
         )}
-        <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
       </div>
+      {isCohorted ? (
+        <EnabledCohortsView />
+      ) : (
+        <DisabledCohortsView onEnableCohorts={handleEnableCohorts} />
+      )}
+      <DisableCohortsModal isOpen={isOpenDisableModal} onClose={() => setIsOpenDisableModal(false)} onConfirmDisable={handleDisableCohorts} />
+    </div>
+  );
+};
+
+// It was necessary to wrap the entire content with CohortProvider here to avoid errors in the use of cohort hooks within a provider
+const CohortsPage = () => {
+  return (
+    <CohortProvider>
+      <CohortsPageContent />
     </CohortProvider>
   );
 };

--- a/src/cohorts/CohortsPage.tsx
+++ b/src/cohorts/CohortsPage.tsx
@@ -3,12 +3,12 @@ import { IconButton } from '@openedx/paragon';
 import { Settings } from '@openedx/paragon/icons';
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
-import { useCohortStatus, useToggleCohorts } from './data/apiHook';
-import DisableCohortsModal from './components/DisableCohortsModal';
-import messages from './messages';
-import DisabledCohortsView from './components/DisabledCohortsView';
-import EnabledCohortsView from './components/EnabledCohortsView';
-import { CohortProvider, useCohortContext } from './components/CohortContext';
+import { CohortProvider, useCohortContext } from '@src/cohorts/components/CohortContext';
+import DisableCohortsModal from '@src/cohorts/components/DisableCohortsModal';
+import DisabledCohortsView from '@src/cohorts/components/DisabledCohortsView';
+import EnabledCohortsView from '@src/cohorts/components/EnabledCohortsView';
+import { useCohortStatus, useToggleCohorts } from '@src/cohorts/data/apiHook';
+import messages from '@src/cohorts/messages';
 
 const CohortsPageContent = () => {
   const intl = useIntl();

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -1,18 +1,18 @@
+import { useParams } from 'react-router-dom';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useParams } from 'react-router-dom';
 import { renderWithIntl } from '@src/testUtils';
-import { useCohorts, useContentGroupsData } from '../data/apiHook';
-import messages from '../messages';
-import EnabledCohortsView from './EnabledCohortsView';
-import { CohortProvider } from './CohortContext';
+import { CohortProvider } from '@src/cohorts/components/CohortContext';
+import EnabledCohortsView from '@src/cohorts/components/EnabledCohortsView';
+import { useCohorts, useContentGroupsData } from '@src/cohorts/data/apiHook';
+import messages from '@src/cohorts/messages';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(),
 }));
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/cohorts/data/apiHook', () => ({
   useCohorts: jest.fn(),
   useContentGroupsData: jest.fn(),
   useCreateCohort: () => ({ mutate: jest.fn() }),

--- a/src/cohorts/components/EnabledCohortsView.test.tsx
+++ b/src/cohorts/components/EnabledCohortsView.test.tsx
@@ -17,6 +17,7 @@ jest.mock('../data/apiHook', () => ({
   useContentGroupsData: jest.fn(),
   useCreateCohort: () => ({ mutate: jest.fn() }),
   usePatchCohort: () => ({ mutate: jest.fn() }),
+  useAddLearnersToCohort: () => ({ mutate: jest.fn() }),
 }));
 
 const mockCohorts = [

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -3,13 +3,13 @@ import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Button, Card, Alert } from '@openedx/paragon';
 import { CheckCircle } from '@openedx/paragon/icons';
-import CohortsForm from './CohortsForm';
-import { useCohortContext } from './CohortContext';
-import SelectedCohortInfo from './SelectedCohortInfo';
-import { CohortData, BasicCohortData } from '../types';
-import { assignmentTypes } from '../constants';
-import messages from '../messages';
-import { useCohorts, useCreateCohort } from '../data/apiHook';
+import { useCohortContext } from '@src/cohorts/components/CohortContext';
+import CohortsForm from '@src/cohorts/components/CohortsForm';
+import SelectedCohortInfo from '@src/cohorts/components/SelectedCohortInfo';
+import { useCohorts, useCreateCohort } from '@src/cohorts/data/apiHook';
+import { assignmentTypes } from '@src/cohorts/constants';
+import messages from '@src/cohorts/messages';
+import { CohortData, BasicCohortData } from '@src/cohorts/types';
 
 const EnabledCohortsView = () => {
   const intl = useIntl();

--- a/src/cohorts/components/EnabledCohortsView.tsx
+++ b/src/cohorts/components/EnabledCohortsView.tsx
@@ -67,7 +67,14 @@ const EnabledCohortsView = () => {
   return (
     <>
       <div className="d-flex mt-4.5">
-        <FormControl placeholder={intl.formatMessage(messages.selectCohortPlaceholder)} name="cohort" as="select" onChange={handleSelectCohort} value={selectedCohort?.id?.toString() ?? 'null'} disabled={displayAddForm}>
+        <FormControl
+          as="select"
+          disabled={displayAddForm || cohortsList.length === 0}
+          name="cohort"
+          placeholder={intl.formatMessage(messages.selectCohortPlaceholder)}
+          value={selectedCohort?.id?.toString() ?? 'null'}
+          onChange={handleSelectCohort}
+        >
           {
             cohortsList.map((cohort) => (
               <option key={cohort.id} value={cohort.id}>

--- a/src/cohorts/components/ManageLearners.test.tsx
+++ b/src/cohorts/components/ManageLearners.test.tsx
@@ -1,0 +1,86 @@
+import { screen, fireEvent } from '@testing-library/react';
+import ManageLearners from './ManageLearners';
+import { useParams } from 'react-router-dom';
+import { useAddLearnersToCohort } from '../data/apiHook';
+import { useCohortContext } from './CohortContext';
+import messages from '../messages';
+import { renderWithIntl } from '../../testUtils';
+
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useAddLearnersToCohort: jest.fn(),
+}));
+
+jest.mock('./CohortContext', () => ({
+  useCohortContext: jest.fn(),
+}));
+
+describe('ManageLearners', () => {
+  const mutateMock = jest.fn();
+
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue({ courseId: 'course-v1:edX+Test+2024' });
+    (useCohortContext as jest.Mock).mockReturnValue({ selectedCohort: { id: 123 } });
+    (useAddLearnersToCohort as jest.Mock).mockReturnValue({ mutate: mutateMock });
+    mutateMock.mockReset();
+  });
+
+  it('render all static texts', () => {
+    renderWithIntl(<ManageLearners />);
+    expect(screen.getByRole('heading', { name: messages.addLearnersTitle.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByText(messages.addLearnersSubtitle.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.addLearnersInstructions.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(messages.learnersExample.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.addLearnersFootnote.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /\+ Add Learners/i })).toBeInTheDocument();
+  });
+
+  it('updates textarea value and calls mutate on button click', () => {
+    renderWithIntl(<ManageLearners />);
+    const textarea = screen.getByPlaceholderText(messages.learnersExample.defaultMessage);
+    fireEvent.change(textarea, { target: { value: 'user1@example.com,user2@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /\+ Add Learners/i }));
+    expect(mutateMock).toHaveBeenCalledWith(
+      ['user1@example.com', 'user2@example.com'],
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it('handles empty input gracefully', () => {
+    renderWithIntl(<ManageLearners />);
+    fireEvent.click(screen.getByRole('button', { name: /\+ Add Learners/i }));
+    expect(mutateMock).toHaveBeenCalledWith(
+      [''],
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it('calls onError if mutate fails', () => {
+    renderWithIntl(<ManageLearners />);
+    const textarea = screen.getByPlaceholderText(messages.learnersExample.defaultMessage);
+    fireEvent.change(textarea, { target: { value: 'user@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /\+ Add Learners/i }));
+
+    const callArgs = mutateMock.mock.calls[0][1];
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    callArgs.onError('error!');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('error!');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('uses default cohort id 0 if selectedCohort is missing', () => {
+    (useCohortContext as jest.Mock).mockReturnValue({ selectedCohort: undefined });
+    renderWithIntl(<ManageLearners />);
+    fireEvent.click(screen.getByRole('button', { name: /\+ Add Learners/i }));
+    expect(mutateMock).toHaveBeenCalled();
+  });
+});

--- a/src/cohorts/components/ManageLearners.test.tsx
+++ b/src/cohorts/components/ManageLearners.test.tsx
@@ -1,20 +1,20 @@
 import { screen, fireEvent } from '@testing-library/react';
-import ManageLearners from './ManageLearners';
 import { useParams } from 'react-router-dom';
-import { useAddLearnersToCohort } from '../data/apiHook';
-import { useCohortContext } from './CohortContext';
-import messages from '../messages';
-import { renderWithIntl } from '../../testUtils';
+import { useAddLearnersToCohort } from '@src/cohorts/data/apiHook';
+import { useCohortContext } from '@src/cohorts/components/CohortContext';
+import ManageLearners from '@src/cohorts/components/ManageLearners';
+import messages from '@src/cohorts/messages';
+import { renderWithIntl } from '@src/testUtils';
 
 jest.mock('react-router-dom', () => ({
   useParams: jest.fn(),
 }));
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/cohorts/data/apiHook', () => ({
   useAddLearnersToCohort: jest.fn(),
 }));
 
-jest.mock('./CohortContext', () => ({
+jest.mock('@src/cohorts/components/CohortContext', () => ({
   useCohortContext: jest.fn(),
 }));
 

--- a/src/cohorts/components/ManageLearners.tsx
+++ b/src/cohorts/components/ManageLearners.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, FormControl } from '@openedx/paragon';
-import { useParams } from 'react-router-dom';
-import { useAddLearnersToCohort } from '../data/apiHook';
-import messages from '../messages';
-import { useCohortContext } from './CohortContext';
+import { useCohortContext } from '@src/cohorts/components/CohortContext';
+import { useAddLearnersToCohort } from '@src/cohorts/data/apiHook';
+import messages from '@src/cohorts/messages';
 
 const ManageLearners = () => {
   const { courseId = '' } = useParams();

--- a/src/cohorts/components/ManageLearners.tsx
+++ b/src/cohorts/components/ManageLearners.tsx
@@ -29,7 +29,13 @@ const ManageLearners = () => {
       <h3 className="text-primary-700">{intl.formatMessage(messages.addLearnersTitle)}</h3>
       <p className="x-small mb-2.5">{intl.formatMessage(messages.addLearnersSubtitle)}</p>
       <p className="mb-2 text-primary-500">{intl.formatMessage(messages.addLearnersInstructions)}</p>
-      <FormControl as="textarea" className="mb-2" placeholder={intl.formatMessage(messages.learnersExample)} onChange={(e) => setUsers(e.target.value)} />
+      <FormControl
+        as="textarea"
+        className="mb-2"
+        rows={4}
+        placeholder={intl.formatMessage(messages.learnersExample)}
+        onChange={(e) => setUsers(e.target.value)}
+      />
       <p className="x-small mb-2.5">{intl.formatMessage(messages.addLearnersFootnote)}</p>
       <Button variant="primary" className="mt-2" onClick={handleAddLearners}>+ {intl.formatMessage(messages.addLearnersLabel)}</Button>
     </div>

--- a/src/cohorts/components/ManageLearners.tsx
+++ b/src/cohorts/components/ManageLearners.tsx
@@ -1,5 +1,39 @@
+import { useState } from 'react';
+import { useIntl } from '@openedx/frontend-base';
+import { Button, FormControl } from '@openedx/paragon';
+import { useParams } from 'react-router-dom';
+import { useAddLearnersToCohort } from '../data/apiHook';
+import messages from '../messages';
+import { useCohortContext } from './CohortContext';
+
 const ManageLearners = () => {
-  return <div>Manage Learners Component</div>;
+  const { courseId = '' } = useParams();
+  const intl = useIntl();
+  const { selectedCohort } = useCohortContext();
+  const { mutate: addLearnersToCohort } = useAddLearnersToCohort(courseId, selectedCohort?.id ? Number(selectedCohort.id) : 0);
+  const [users, setUsers] = useState('');
+
+  const handleAddLearners = () => {
+    addLearnersToCohort(users.split(','), {
+      onSuccess: () => {
+        // Handle success (e.g., show a success message)
+      },
+      onError: (error) => {
+        console.error(error);
+      }
+    });
+  };
+
+  return (
+    <div className="mx-4 my-3.5">
+      <h3 className="text-primary-700">{intl.formatMessage(messages.addLearnersTitle)}</h3>
+      <p className="x-small mb-2.5">{intl.formatMessage(messages.addLearnersSubtitle)}</p>
+      <p className="mb-2 text-primary-500">{intl.formatMessage(messages.addLearnersInstructions)}</p>
+      <FormControl as="textarea" className="mb-2" placeholder={intl.formatMessage(messages.learnersExample)} onChange={(e) => setUsers(e.target.value)} />
+      <p className="x-small mb-2.5">{intl.formatMessage(messages.addLearnersFootnote)}</p>
+      <Button variant="primary" className="mt-2" onClick={handleAddLearners}>+ {intl.formatMessage(messages.addLearnersLabel)}</Button>
+    </div>
+  );
 };
 
 export default ManageLearners;

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
-import { CohortData, BasicCohortData } from '../types';
+import { CohortData, BasicCohortData } from '@src/cohorts/types';
 
 export const getCohortStatus = async (courseId: string) => {
   const url = `${getApiBaseUrl()}/api/cohorts/v1/settings/${courseId}`;

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -28,7 +28,7 @@ export const createCohort = async (courseId: string, cohortDetails: BasicCohortD
 };
 
 export const getContentGroups = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/content_groups`;
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/group_configurations`;
   const { data } = await getAuthenticatedHttpClient().get(url);
   return camelCaseObject(data);
 };
@@ -41,7 +41,7 @@ export const patchCohort = async (courseId: string, cohortId: number, cohortDeta
 };
 
 export const addLearnersToCohort = async (courseId: string, cohortId: number, users: string[]) => {
-  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/${cohortId}/users`;
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/${cohortId}/users/`;
   const { data } = await getAuthenticatedHttpClient().post(url, { users });
   return camelCaseObject(data);
 };

--- a/src/cohorts/data/api.ts
+++ b/src/cohorts/data/api.ts
@@ -28,7 +28,7 @@ export const createCohort = async (courseId: string, cohortDetails: BasicCohortD
 };
 
 export const getContentGroups = async (courseId: string) => {
-  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/content_groups/`;
+  const url = `${getApiBaseUrl()}/api/instructor/v1/courses/${courseId}/content_groups`;
   const { data } = await getAuthenticatedHttpClient().get(url);
   return camelCaseObject(data);
 };
@@ -37,5 +37,11 @@ export const patchCohort = async (courseId: string, cohortId: number, cohortDeta
   const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/${cohortId}`;
   const cohortDetailsSnakeCase = snakeCaseObject(cohortDetails);
   const { data } = await getAuthenticatedHttpClient().patch(url, cohortDetailsSnakeCase);
+  return camelCaseObject(data);
+};
+
+export const addLearnersToCohort = async (courseId: string, cohortId: number, users: string[]) => {
+  const url = `${getApiBaseUrl()}/api/cohorts/v1/courses/${courseId}/cohorts/${cohortId}/users`;
+  const { data } = await getAuthenticatedHttpClient().post(url, { users });
   return camelCaseObject(data);
 };

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort, patchCohort, addLearnersToCohort } from './api';
-import { cohortsQueryKeys } from './queryKeys';
-import { CohortData, BasicCohortData } from '../types';
+import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort, patchCohort, addLearnersToCohort } from '@src/cohorts/data/api';
+import { cohortsQueryKeys } from '@src/cohorts/data/queryKeys';
+import { CohortData, BasicCohortData } from '@src/cohorts/types';
 
 export const useCohortStatus = (courseId: string) => (
   useQuery({

--- a/src/cohorts/data/apiHook.ts
+++ b/src/cohorts/data/apiHook.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort, patchCohort } from './api';
+import { getCohorts, getCohortStatus, getContentGroups, toggleCohorts, createCohort, patchCohort, addLearnersToCohort } from './api';
 import { cohortsQueryKeys } from './queryKeys';
 import { CohortData, BasicCohortData } from '../types';
 
@@ -53,6 +53,16 @@ export const usePatchCohort = (courseId: string) => {
       patchCohort(courseId, cohortId, cohortInfo),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.byCourse(courseId) });
+    },
+  });
+};
+
+export const useAddLearnersToCohort = (courseId: string, cohortId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (users: string[]) => addLearnersToCohort(courseId, cohortId, users),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: cohortsQueryKeys.list(courseId) });
     },
   });
 };

--- a/src/cohorts/messages.ts
+++ b/src/cohorts/messages.ts
@@ -155,7 +155,37 @@ const messages = defineMessages({
     id: 'instruct.cohorts.cohortUpdateSuccessMessage',
     defaultMessage: 'Settings have been saved.',
     description: 'Success message displayed when a cohort is updated'
-  }
+  },
+  addLearnersTitle: {
+    id: 'instruct.cohorts.addLearnersTitle',
+    defaultMessage: 'Add Learners to this cohort',
+    description: 'Title for the add learners section'
+  },
+  addLearnersSubtitle: {
+    id: 'instruct.cohorts.addLearnersSubtitle',
+    defaultMessage: 'Note: Learners can be in only one cohort. Adding learners to this group overrides any previous group assignment.',
+    description: 'Subtitle for the add learners section'
+  },
+  addLearnersInstructions: {
+    id: 'instruct.cohorts.addLearnersInstructions',
+    defaultMessage: 'Enter email addresses and/or usernames, separated by new lines or commas, for the learners you want to add.*',
+    description: 'Instructions for adding learners to a cohort'
+  },
+  addLearnersFootnote: {
+    id: 'instruct.cohorts.addLearnersFootnote',
+    defaultMessage: 'You will not receive notification for emails that bounce, so double-check your spelling.',
+    description: 'Footnote for adding learners to a cohort'
+  },
+  learnersExample: {
+    id: 'instruct.cohorts.learnersExample',
+    defaultMessage: 'e.g. johndoe@example.com, JaneDoe, Joeydoe@example.com',
+    description: 'Placeholder for the learners example'
+  },
+  addLearnersLabel: {
+    id: 'instruct.cohorts.addLearnersLabel',
+    defaultMessage: 'Add Learners',
+    description: 'Label for the add learners button'
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description
This PR covers the tab Manage Learners, in which you can add learners and see the count of current students, in other PR will be handled csv functionality

## Screenshot
<img width="1661" height="930" alt="Screenshot 2026-01-23 at 2 50 48 p m" src="https://github.com/user-attachments/assets/1c6e627c-f44a-4967-9e89-103263bee880" />

## Supporting information
Closes #65 

## Testing instructions
- npm run dev
- go to a valid url in cohorts like: http://apps.local.openedx.io:8080/instructor/course-v1:OpenedX+DemoX+DemoCourse/cohorts
- enable cohorts, if its already enable: select an existing cohort from dropdown
- Add a new email on the text area
- Click on add learners

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
