### PR TITLE
Add/Unenroll learners

### DIFF
--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
-import { render, screen, within } from '@testing-library/react';
-import { IntlProvider } from '@openedx/frontend-base';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import EnrollmentsPage from './EnrollmentsPage';
 import { EnrolledLearner } from './types';
-import userEvent from '@testing-library/user-event';
 import messages from './messages';
+import { useEnrollmentByUserId, useEnrollments, useEnrollLearners, useUnenrollLearners } from './data/apiHook';
+import { renderWithAlertAndIntl } from '@src/testUtils';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'test-course-id' }),
+}));
+
+jest.mock('./data/apiHook', () => ({
+  useEnrollments: jest.fn(),
+  useEnrollmentByUserId: jest.fn(),
+  useEnrollLearners: jest.fn(),
+  useUnenrollLearners: jest.fn(),
+}));
 
 jest.mock('./components/EnrollmentsList', () => {
   return function MockEnrollmentsList({ onUnenroll }: { onUnenroll: (learner: EnrolledLearner) => void }) {
@@ -25,55 +37,46 @@ jest.mock('./components/EnrollmentsList', () => {
   };
 });
 
-jest.mock('./components/EnrollmentStatusModal', () => {
-  return function MockEnrollmentStatusModal({ isOpen, onClose }: { isOpen: boolean, onClose: () => void }) {
-    return isOpen ? (
-      <div role="dialog">
-        <button onClick={onClose}>Close Modal</button>
-      </div>
-    ) : null;
-  };
-});
-
-jest.mock('./components/UnenrollModal', () => {
-  return function MockUnenrollModal({ isOpen, learner, onClose }: { isOpen: boolean, learner: EnrolledLearner | null, onClose: () => void }) {
-    return isOpen ? (
-      <div role="dialog">
-        <span>Unenroll {learner?.fullName}</span>
-        <button onClick={onClose}>Close Unenroll Modal</button>
-      </div>
-    ) : null;
-  };
-});
-
-const renderWithIntl = (component: React.ReactElement) => {
-  return render(
-    <IntlProvider locale="en">
-      {component}
-    </IntlProvider>
-  );
-};
-
 describe('EnrollmentsPage', () => {
+  beforeAll(() => {
+    (useEnrollments as jest.Mock).mockReturnValue({
+      data: { count: 1, numPages: 1, results: [{ username: 'testuser', fullName: 'Test User', email: 'test@example.com', mode: 'audit', isBetaTester: false }] },
+      isLoading: false,
+    });
+    (useEnrollmentByUserId as jest.Mock).mockReturnValue({
+      data: { enrollmentStatus: 'enrolled' },
+      refetch: jest.fn(),
+    });
+    (useEnrollLearners as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
+      isLoading: false,
+      error: null,
+    });
+    (useUnenrollLearners as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
+      isPending: false,
+    });
+  });
+
   it('renders the page title', () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
     expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
   });
 
   it('renders action buttons', () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
     expect(screen.getByRole('button', { name: messages.checkEnrollmentStatus.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: new RegExp(messages.addBetaTesters.defaultMessage) })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: new RegExp(messages.enrollLearners.defaultMessage) })).toBeInTheDocument();
   });
 
   it('renders EnrollmentsList component', () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('opens enrollment status modal when more button is clicked', async () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
 
     const moreButton = screen.getByRole('button', { name: messages.checkEnrollmentStatus.defaultMessage });
     const user = userEvent.setup();
@@ -83,20 +86,20 @@ describe('EnrollmentsPage', () => {
   });
 
   it('closes enrollment status modal', async () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
 
     const moreButton = screen.getByRole('button', { name: messages.checkEnrollmentStatus.defaultMessage });
     const user = userEvent.setup();
     await user.click(moreButton);
 
-    const closeButton = screen.getByText('Close Modal');
+    const closeButton = screen.getByText('Close');
     await user.click(closeButton);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('opens unenroll modal when unenroll is triggered', async () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
 
     const unenrollButton = screen.getByText('Unenroll Test Learner');
     const user = userEvent.setup();
@@ -109,20 +112,20 @@ describe('EnrollmentsPage', () => {
   });
 
   it('closes unenroll modal and clears selected learner', async () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
 
     const unenrollButton = screen.getByText('Unenroll Test Learner');
     const user = userEvent.setup();
     await user.click(unenrollButton);
 
-    const closeUnenrollButton = screen.getByText('Close Unenroll Modal');
+    const closeUnenrollButton = screen.getByText('Cancel');
     await user.click(closeUnenrollButton);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('modals are closed by default', () => {
-    renderWithIntl(<EnrollmentsPage />);
+    renderWithAlertAndIntl(<EnrollmentsPage />);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });

--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -37,7 +37,8 @@ jest.mock('./components/EnrollmentsList', () => {
 });
 
 describe('EnrollmentsPage', () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     (useEnrollments as jest.Mock).mockReturnValue({
       data: { count: 1, numPages: 1, results: [{ username: 'testuser', fullName: 'Test User', email: 'test@example.com', mode: 'audit', isBetaTester: false }] },
       isLoading: false,

--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -1,9 +1,9 @@
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EnrollmentsPage from './EnrollmentsPage';
-import { EnrolledLearner } from './types';
-import messages from './messages';
-import { useEnrollmentByUserId, useEnrollments, useUpdateEnrollments } from './data/apiHook';
+import { EnrolledLearner } from '@src/enrollments/types';
+import messages from '@src/enrollments/messages';
+import { useEnrollmentByUserId, useEnrollments, useUpdateEnrollments } from '@src/enrollments/data/apiHook';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 
 jest.mock('react-router-dom', () => ({

--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import EnrollmentsPage from './EnrollmentsPage';
 import { EnrolledLearner } from './types';
 import messages from './messages';
-import { useEnrollmentByUserId, useEnrollments, useEnrollLearners, useUnenrollLearners } from './data/apiHook';
+import { useEnrollmentByUserId, useEnrollments, useUpdateEnrollments } from './data/apiHook';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 
 jest.mock('react-router-dom', () => ({
@@ -14,8 +14,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('./data/apiHook', () => ({
   useEnrollments: jest.fn(),
   useEnrollmentByUserId: jest.fn(),
-  useEnrollLearners: jest.fn(),
-  useUnenrollLearners: jest.fn(),
+  useUpdateEnrollments: jest.fn(),
 }));
 
 jest.mock('./components/EnrollmentsList', () => {
@@ -47,14 +46,10 @@ describe('EnrollmentsPage', () => {
       data: { enrollmentStatus: 'enrolled' },
       refetch: jest.fn(),
     });
-    (useEnrollLearners as jest.Mock).mockReturnValue({
+    (useUpdateEnrollments as jest.Mock).mockReturnValue({
       mutate: jest.fn(),
       isLoading: false,
       error: null,
-    });
-    (useUnenrollLearners as jest.Mock).mockReturnValue({
-      mutate: jest.fn(),
-      isPending: false,
     });
   });
 

--- a/src/enrollments/EnrollmentsPage.tsx
+++ b/src/enrollments/EnrollmentsPage.tsx
@@ -6,11 +6,13 @@ import messages from './messages';
 import EnrollmentsList from './components/EnrollmentsList';
 import EnrollmentStatusModal from './components/EnrollmentStatusModal';
 import UnenrollModal from './components/UnenrollModal';
+import EnrollLearnersModal from './components/EnrollLearnersModal';
 import { EnrolledLearner } from './types';
 
 const EnrollmentsPage = () => {
   const intl = useIntl();
   const [isEnrollmentStatusModalOpen, setIsEnrollmentStatusModalOpen] = useState(false);
+  const [isEnrollLearnersModalOpen, setIsEnrollLearnersModalOpen] = useState(false);
   const [isUnenrollModalOpen, setIsUnenrollModalOpen] = useState(false);
   const [selectedLearner, setSelectedLearner] = useState<EnrolledLearner | null>(null);
 
@@ -32,6 +34,10 @@ const EnrollmentsPage = () => {
     setIsEnrollmentStatusModalOpen(false);
   };
 
+  const handleEnrollLearners = () => {
+    setIsEnrollLearnersModalOpen(true);
+  };
+
   return (
     <>
       <div className="d-flex justify-content-between align-items-center">
@@ -44,12 +50,13 @@ const EnrollmentsPage = () => {
             onClick={handleMoreButton}
           />
           <Button variant="outline-primary">+ {intl.formatMessage(messages.addBetaTesters)}</Button>
-          <Button>+ {intl.formatMessage(messages.enrollLearners)}</Button>
+          <Button onClick={handleEnrollLearners}>+ {intl.formatMessage(messages.enrollLearners)}</Button>
         </ActionRow>
       </div>
       <EnrollmentsList onUnenroll={handleUnenroll} />
       <EnrollmentStatusModal isOpen={isEnrollmentStatusModalOpen} onClose={handleCloseEnrollmentStatusModal} />
-      {selectedLearner && <UnenrollModal isOpen={isUnenrollModalOpen} learner={selectedLearner} onClose={handleUnenrollModalClose} />}
+      {selectedLearner && <UnenrollModal isOpen={isUnenrollModalOpen} learner={selectedLearner} onClose={handleUnenrollModalClose} onSuccess={() => {}} />}
+      <EnrollLearnersModal isOpen={isEnrollLearnersModalOpen} onClose={() => setIsEnrollLearnersModalOpen(false)} onSuccess={() => {}} />
     </>
   );
 };

--- a/src/enrollments/EnrollmentsPage.tsx
+++ b/src/enrollments/EnrollmentsPage.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
 import { ActionRow, Button, IconButton } from '@openedx/paragon';
 import { MoreVert } from '@openedx/paragon/icons';
-import messages from './messages';
-import EnrollmentsList from './components/EnrollmentsList';
-import EnrollmentStatusModal from './components/EnrollmentStatusModal';
-import UnenrollModal from './components/UnenrollModal';
-import EnrollLearnersModal from './components/EnrollLearnersModal';
-import { EnrolledLearner } from './types';
+import messages from '@src/enrollments/messages';
+import EnrollmentsList from '@src/enrollments/components/EnrollmentsList';
+import EnrollmentStatusModal from '@src/enrollments/components/EnrollmentStatusModal';
+import UnenrollModal from '@src/enrollments/components/UnenrollModal';
+import EnrollLearnersModal from '@src/enrollments/components/EnrollLearnersModal';
+import { EnrolledLearner } from '@src/enrollments/types';
 
 const EnrollmentsPage = () => {
   const intl = useIntl();

--- a/src/enrollments/EnrollmentsPage.tsx
+++ b/src/enrollments/EnrollmentsPage.tsx
@@ -38,6 +38,10 @@ const EnrollmentsPage = () => {
     setIsEnrollLearnersModalOpen(true);
   };
 
+  const handleCloseEnrollLearnersModal = () => {
+    setIsEnrollLearnersModalOpen(false);
+  };
+
   return (
     <>
       <div className="d-flex justify-content-between align-items-center">
@@ -55,8 +59,8 @@ const EnrollmentsPage = () => {
       </div>
       <EnrollmentsList onUnenroll={handleUnenroll} />
       <EnrollmentStatusModal isOpen={isEnrollmentStatusModalOpen} onClose={handleCloseEnrollmentStatusModal} />
-      {selectedLearner && <UnenrollModal isOpen={isUnenrollModalOpen} learner={selectedLearner} onClose={handleUnenrollModalClose} onSuccess={() => {}} />}
-      <EnrollLearnersModal isOpen={isEnrollLearnersModalOpen} onClose={() => setIsEnrollLearnersModalOpen(false)} onSuccess={() => {}} />
+      {selectedLearner && <UnenrollModal isOpen={isUnenrollModalOpen} learner={selectedLearner} onClose={handleUnenrollModalClose} onSuccess={handleUnenrollModalClose} />}
+      <EnrollLearnersModal isOpen={isEnrollLearnersModalOpen} onClose={handleCloseEnrollLearnersModal} onSuccess={handleCloseEnrollLearnersModal} />
     </>
   );
 };

--- a/src/enrollments/components/EnrollLearnersModal.test.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import EnrollLearnersModal, { EnrollLearnersModalProps } from './EnrollLearnersModal';
 import messages from '../messages';
 import { renderWithAlertAndIntl } from '@src/testUtils';
-import { useEnrollLearners } from '../data/apiHook';
+import { useUpdateEnrollments } from '../data/apiHook';
 
 const defaultProps: EnrollLearnersModalProps = {
   isOpen: true,
@@ -19,7 +19,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('../data/apiHook', () => ({
-  useEnrollLearners: jest.fn(),
+  useUpdateEnrollments: jest.fn(),
 }));
 
 jest.mock('@src/providers/AlertProvider', () => ({
@@ -36,7 +36,7 @@ describe('EnrollLearnersModal', () => {
   const mutateMock = jest.fn();
 
   beforeEach(() => {
-    (useEnrollLearners as jest.Mock).mockReturnValue({ mutate: mutateMock });
+    (useUpdateEnrollments as jest.Mock).mockReturnValue({ mutate: mutateMock });
     mockShowModal.mockClear();
   });
 
@@ -109,10 +109,15 @@ describe('EnrollLearnersModal', () => {
       name: messages.saveButton.defaultMessage,
     });
     await user.click(saveBtn);
-    expect(mutateMock).toHaveBeenCalledWith([
-      'alice@example.com',
-      'bob@example.com',
-    ], {
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [
+        'alice@example.com',
+        'bob@example.com',
+      ],
+      action: 'enroll',
+      autoEnroll: true,
+      emailStudents: true,
+    }, {
       onSuccess: expect.any(Function),
       onError: expect.any(Function),
     });
@@ -129,11 +134,16 @@ describe('EnrollLearnersModal', () => {
       name: messages.saveButton.defaultMessage,
     });
     await user.click(saveBtn);
-    expect(mutateMock).toHaveBeenCalledWith([
-      'a@a.com',
-      'b@b.com',
-      'c@c.com',
-    ], {
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [
+        'a@a.com',
+        'b@b.com',
+        'c@c.com',
+      ],
+      action: 'enroll',
+      autoEnroll: true,
+      emailStudents: true,
+    }, {
       onSuccess: expect.any(Function),
       onError: expect.any(Function),
     });
@@ -198,6 +208,7 @@ describe('EnrollLearnersModal', () => {
     expect(mockShowModal).toHaveBeenCalledWith({
       message: errorMessage,
       variant: 'danger',
+      confirmText: messages.closeButton.defaultMessage,
     });
   });
 
@@ -221,6 +232,7 @@ describe('EnrollLearnersModal', () => {
     expect(mockShowModal).toHaveBeenCalledWith({
       message: messages.enrollLearnerError.defaultMessage,
       variant: 'danger',
+      confirmText: messages.closeButton.defaultMessage,
     });
   });
 
@@ -236,10 +248,15 @@ describe('EnrollLearnersModal', () => {
     });
     await user.click(saveBtn);
 
-    expect(mutateMock).toHaveBeenCalledWith([
-      'alice@example.com',
-      'bob@example.com',
-    ], {
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [
+        'alice@example.com',
+        'bob@example.com',
+      ],
+      action: 'enroll',
+      autoEnroll: true,
+      emailStudents: true,
+    }, {
       onSuccess: expect.any(Function),
       onError: expect.any(Function),
     });

--- a/src/enrollments/components/EnrollLearnersModal.test.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.test.tsx
@@ -1,9 +1,9 @@
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
-import EnrollLearnersModal, { EnrollLearnersModalProps } from './EnrollLearnersModal';
-import messages from '../messages';
+import EnrollLearnersModal, { EnrollLearnersModalProps } from '@src/enrollments/components/EnrollLearnersModal';
+import { useUpdateEnrollments } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
 import { renderWithAlertAndIntl } from '@src/testUtils';
-import { useUpdateEnrollments } from '../data/apiHook';
 
 const defaultProps: EnrollLearnersModalProps = {
   isOpen: true,
@@ -18,7 +18,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'test-course-id' }),
 }));
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/enrollments/data/apiHook', () => ({
   useUpdateEnrollments: jest.fn(),
 }));
 
@@ -184,7 +184,6 @@ describe('EnrollLearnersModal', () => {
     await user.click(saveBtn);
 
     expect(defaultProps.onSuccess).toHaveBeenCalled();
-    expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
   it('shows error alert when mutation fails', async () => {

--- a/src/enrollments/components/EnrollLearnersModal.test.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.test.tsx
@@ -1,0 +1,247 @@
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import EnrollLearnersModal, { EnrollLearnersModalProps } from './EnrollLearnersModal';
+import messages from '../messages';
+import { renderWithAlertAndIntl } from '@src/testUtils';
+import { useEnrollLearners } from '../data/apiHook';
+
+const defaultProps: EnrollLearnersModalProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+const mockShowModal = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'test-course-id' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useEnrollLearners: jest.fn(),
+}));
+
+jest.mock('@src/providers/AlertProvider', () => ({
+  useAlert: () => ({
+    showModal: mockShowModal,
+  }),
+  AlertProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const renderComponent = (props = {}) =>
+  renderWithAlertAndIntl(<EnrollLearnersModal {...defaultProps} {...props} />);
+
+describe('EnrollLearnersModal', () => {
+  const mutateMock = jest.fn();
+
+  beforeEach(() => {
+    (useEnrollLearners as jest.Mock).mockReturnValue({ mutate: mutateMock });
+    mockShowModal.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal with title and instructions', () => {
+    renderComponent();
+    expect(screen.getByText(messages.enrollLearners.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.addLearnerInstructions.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders textarea with placeholder', () => {
+    renderComponent();
+    expect(
+      screen.getByPlaceholderText(messages.userIdentifierPlaceholder.defaultMessage)
+    ).toBeInTheDocument();
+  });
+
+  it('renders checkboxes with correct labels', () => {
+    renderComponent();
+    expect(
+      screen.getByLabelText(messages.autoEnrollCheckbox.defaultMessage)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(messages.notifyUsersCheckbox.defaultMessage)
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel button is clicked', async () => {
+    renderComponent();
+    const cancelBtn = screen.getByRole('button', {
+      name: messages.cancelButton.defaultMessage,
+    });
+    const user = userEvent.setup();
+    await user.click(cancelBtn);
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('Save button is disabled when textarea is empty', () => {
+    renderComponent();
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('Save button is enabled when textarea has input', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'test@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    expect(saveBtn).toBeEnabled();
+  });
+
+  it('calls onSave with trimmed email list when Save is clicked', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, '  alice@example.com, bob@example.com  ');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+    expect(mutateMock).toHaveBeenCalledWith([
+      'alice@example.com',
+      'bob@example.com',
+    ], {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+
+  it('splits emails by comma and trims whitespace', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'a@a.com,   b@b.com ,c@c.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+    expect(mutateMock).toHaveBeenCalledWith([
+      'a@a.com',
+      'b@b.com',
+      'c@c.com',
+    ], {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+
+  it('does not call onSuccess if textarea is empty', async () => {
+    renderComponent();
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    const user = userEvent.setup();
+    expect(saveBtn).toBeDisabled();
+    await user.click(saveBtn);
+    expect(defaultProps.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not render modal when isOpen is false', () => {
+    renderComponent({ isOpen: false });
+    expect(screen.queryByText(messages.enrollLearners.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('calls onSuccess and onClose when mutation succeeds', async () => {
+    const mutateWithCallback = (_users: string[], callbacks: any) => {
+      // Call onSuccess for the success scenario
+      callbacks.onSuccess();
+    };
+    mutateMock.mockImplementation(mutateWithCallback);
+
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'test@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+
+    expect(defaultProps.onSuccess).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('shows error alert when mutation fails', async () => {
+    const errorMessage = 'Enrollment failed';
+    const mutateWithError = (_users: string[], callbacks: any) => {
+      callbacks.onError({ message: errorMessage });
+    };
+    mutateMock.mockImplementation(mutateWithError);
+
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'test@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+
+    expect(mockShowModal).toHaveBeenCalledWith({
+      message: errorMessage,
+      variant: 'danger',
+    });
+  });
+
+  it('shows default error message when error has no message', async () => {
+    const mutateWithError = (_users: string[], callbacks: any) => {
+      callbacks.onError({});
+    };
+    mutateMock.mockImplementation(mutateWithError);
+
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'test@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+
+    expect(mockShowModal).toHaveBeenCalledWith({
+      message: messages.enrollLearnerError.defaultMessage,
+      variant: 'danger',
+    });
+  });
+
+  it('filters out empty emails from the list', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'alice@example.com,,, ,bob@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+
+    expect(mutateMock).toHaveBeenCalledWith([
+      'alice@example.com',
+      'bob@example.com',
+    ], {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+});

--- a/src/enrollments/components/EnrollLearnersModal.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, FormControl, ModalDialog } from '@openedx/paragon';
-import { FormCheckbox, FormCheckboxSet } from '@openedx/paragon/dist/Form';
+import { Button, FormControl, ModalDialog, Form } from '@openedx/paragon';
 import { useAlert } from '@src/providers/AlertProvider';
 import messages from '../messages';
-import { useEnrollLearners } from '../data/apiHook';
+import { useUpdateEnrollments } from '../data/apiHook';
+import { isAxiosError } from 'axios';
 
 export interface EnrollLearnersModalProps {
   isOpen: boolean,
@@ -21,20 +21,27 @@ const EnrollLearnersModal = ({
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [emails, setEmails] = useState('');
-  const { mutate: enrollLearners } = useEnrollLearners(courseId);
+  const [autoEnroll, setAutoEnroll] = useState(true);
+  const [emailStudents, setEmailStudents] = useState(true);
+  const { mutate: enrollLearners } = useUpdateEnrollments(courseId);
   const { showModal } = useAlert();
 
   const handleSave = () => {
-    const emailList = emails.split(',').map(email => email.trim()).filter(email => email);
-    enrollLearners(emailList, {
+    const identifier = emails.split(',').map(email => email.trim()).filter(email => email);
+    enrollLearners({ identifier, action: 'enroll', autoEnroll, emailStudents }, {
       onSuccess: () => {
         onSuccess();
         onClose();
       },
       onError: (error) => {
+        const notFound = isAxiosError(error) && error.response?.status === 404;
+        const errorMessage = notFound
+          ? intl.formatMessage(messages.enrollLearnerNotFoundError)
+          : error.message || intl.formatMessage(messages.enrollLearnerError);
         showModal({
-          message: error.message || intl.formatMessage(messages.enrollLearnerError),
+          message: errorMessage,
           variant: 'danger',
+          confirmText: intl.formatMessage(messages.closeButton),
         });
       }
     });
@@ -45,26 +52,33 @@ const EnrollLearnersModal = ({
       <ModalDialog.Header className="border-light-700 border-bottom">
         <h3 className="text-primary-500">{intl.formatMessage(messages.enrollLearners)}</h3>
       </ModalDialog.Header>
-      <ModalDialog.Body className="py-4">
-        {/* TABS will be added as a follow up */}
-        {/* <Tabs id={`${title.replace(/\s+/g, '-')}-tabs`} className="mt-0 mb-2" onSelect={() => {}}>
-          <Tab key={`${title.replace(/\s+/g, '-')}`} eventKey={`${title.replace(/\s+/g, '-')}`} title={title}> */}
-        <p className="text-gray-700 x-small mb-2">{intl.formatMessage(messages.addLearnerInstructions)}</p>
-        <FormControl
-          as="textarea"
-          rows={4}
-          placeholder={intl.formatMessage(messages.userIdentifierPlaceholder)}
-          onChange={(e) => setEmails(e.target.value)}
-        />
-        <FormCheckboxSet name="enrollment-options" isInline className="mt-3 text-primary-500">
-          <FormCheckbox controlClassName="border-primary-500">{intl.formatMessage(messages.autoEnrollCheckbox)}</FormCheckbox>
-          <FormCheckbox controlClassName="border-primary-500" className="ml-4">{intl.formatMessage(messages.notifyUsersCheckbox)}</FormCheckbox>
-        </FormCheckboxSet>
-        {/* </Tab>
-          <Tab key="upload-csv" eventKey="upload-csv" title={intl.formatMessage(messages.uploadCSV)}>
-          </Tab>
-        </Tabs> */}
-      </ModalDialog.Body>
+      <div className="position-relative overflow-auto">
+        <ModalDialog.Body className="py-4">
+          <p className="text-gray-700 x-small mb-2">{intl.formatMessage(messages.addLearnerInstructions)}</p>
+          <FormControl
+            name="identifier"
+            as="textarea"
+            rows={4}
+            placeholder={intl.formatMessage(messages.userIdentifierPlaceholder)}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setEmails(e.target.value)}
+          />
+          <div className="d-flex mt-3 text-primary-500">
+            <Form.Checkbox
+              controlClassName="border-primary-500"
+              checked={autoEnroll}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAutoEnroll(e.target.checked)}
+            >{intl.formatMessage(messages.autoEnrollCheckbox)}
+            </Form.Checkbox>
+            <Form.Checkbox
+              controlClassName="border-primary-500"
+              className="ml-4"
+              checked={emailStudents}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmailStudents(e.target.checked)}
+            >{intl.formatMessage(messages.notifyUsersCheckbox)}
+            </Form.Checkbox>
+          </div>
+        </ModalDialog.Body>
+      </div>
       <ModalDialog.Footer className="border-light-700 border-top">
         <Button variant="tertiary" onClick={onClose}>
           {intl.formatMessage(messages.cancelButton)}

--- a/src/enrollments/components/EnrollLearnersModal.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { isAxiosError } from 'axios';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, FormControl, ModalDialog, Form } from '@openedx/paragon';
+import { useUpdateEnrollments } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
 import { useAlert } from '@src/providers/AlertProvider';
-import messages from '../messages';
-import { useUpdateEnrollments } from '../data/apiHook';
-import { isAxiosError } from 'axios';
 
 export interface EnrollLearnersModalProps {
   isOpen: boolean,

--- a/src/enrollments/components/EnrollLearnersModal.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.tsx
@@ -30,8 +30,10 @@ const EnrollLearnersModal = ({
     const identifier = emails.split(',').map(email => email.trim()).filter(email => email);
     enrollLearners({ identifier, action: 'enroll', autoEnroll, emailStudents }, {
       onSuccess: () => {
+        setEmails('');
+        setAutoEnroll(true);
+        setEmailStudents(true);
         onSuccess();
-        onClose();
       },
       onError: (error) => {
         const notFound = isAxiosError(error) && error.response?.status === 404;

--- a/src/enrollments/components/EnrollLearnersModal.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { Button, FormControl, ModalDialog } from '@openedx/paragon';
+import { FormCheckbox, FormCheckboxSet } from '@openedx/paragon/dist/Form';
+import { useAlert } from '@src/providers/AlertProvider';
+import messages from '../messages';
+import { useEnrollLearners } from '../data/apiHook';
+
+export interface EnrollLearnersModalProps {
+  isOpen: boolean,
+  onClose: () => void,
+  onSuccess: () => void,
+}
+
+const EnrollLearnersModal = ({
+  isOpen,
+  onClose,
+  onSuccess
+}: EnrollLearnersModalProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const [emails, setEmails] = useState('');
+  const { mutate: enrollLearners } = useEnrollLearners(courseId);
+  const { showModal } = useAlert();
+
+  const handleSave = () => {
+    const emailList = emails.split(',').map(email => email.trim()).filter(email => email);
+    enrollLearners(emailList, {
+      onSuccess: () => {
+        onSuccess();
+        onClose();
+      },
+      onError: (error) => {
+        showModal({
+          message: error.message || intl.formatMessage(messages.enrollLearnerError),
+          variant: 'danger',
+        });
+      }
+    });
+  };
+
+  return (
+    <ModalDialog isOpen={isOpen} onClose={onClose} isOverflowVisible={false} title={intl.formatMessage(messages.enrollLearners)}>
+      <ModalDialog.Header className="border-light-700 border-bottom">
+        <h3 className="text-primary-500">{intl.formatMessage(messages.enrollLearners)}</h3>
+      </ModalDialog.Header>
+      <ModalDialog.Body className="py-4">
+        {/* TABS will be added as a follow up */}
+        {/* <Tabs id={`${title.replace(/\s+/g, '-')}-tabs`} className="mt-0 mb-2" onSelect={() => {}}>
+          <Tab key={`${title.replace(/\s+/g, '-')}`} eventKey={`${title.replace(/\s+/g, '-')}`} title={title}> */}
+        <p className="text-gray-700 x-small mb-2">{intl.formatMessage(messages.addLearnerInstructions)}</p>
+        <FormControl
+          as="textarea"
+          rows={4}
+          placeholder={intl.formatMessage(messages.userIdentifierPlaceholder)}
+          onChange={(e) => setEmails(e.target.value)}
+        />
+        <FormCheckboxSet name="enrollment-options" isInline className="mt-3 text-primary-500">
+          <FormCheckbox controlClassName="border-primary-500">{intl.formatMessage(messages.autoEnrollCheckbox)}</FormCheckbox>
+          <FormCheckbox controlClassName="border-primary-500" className="ml-4">{intl.formatMessage(messages.notifyUsersCheckbox)}</FormCheckbox>
+        </FormCheckboxSet>
+        {/* </Tab>
+          <Tab key="upload-csv" eventKey="upload-csv" title={intl.formatMessage(messages.uploadCSV)}>
+          </Tab>
+        </Tabs> */}
+      </ModalDialog.Body>
+      <ModalDialog.Footer className="border-light-700 border-top">
+        <Button variant="tertiary" onClick={onClose}>
+          {intl.formatMessage(messages.cancelButton)}
+        </Button>
+        <Button className="ml-2" variant="primary" onClick={handleSave} disabled={emails.trim().length === 0}>
+          {intl.formatMessage(messages.saveButton)}
+        </Button>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default EnrollLearnersModal;

--- a/src/enrollments/components/EnrollmentStatusModal.test.tsx
+++ b/src/enrollments/components/EnrollmentStatusModal.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import EnrollmentStatusModal from './EnrollmentStatusModal';
-import { useEnrollmentByUserId } from '../data/apiHook';
+import { useEnrollmentByUserId } from '@src/enrollments/data/apiHook';
 import { renderWithIntl } from '@src/testUtils';
 import userEvent from '@testing-library/user-event';
 

--- a/src/enrollments/components/EnrollmentStatusModal.tsx
+++ b/src/enrollments/components/EnrollmentStatusModal.tsx
@@ -2,8 +2,8 @@ import { useState, ChangeEvent } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, FormControl, ModalDialog } from '@openedx/paragon';
-import { useEnrollmentByUserId } from '../data/apiHook';
-import messages from '../messages';
+import { useEnrollmentByUserId } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
 
 interface EnrollmentStatusModalProps {
   isOpen: boolean,

--- a/src/enrollments/components/EnrollmentStatusModal.tsx
+++ b/src/enrollments/components/EnrollmentStatusModal.tsx
@@ -34,7 +34,7 @@ const EnrollmentStatusModal = ({ isOpen, onClose }: EnrollmentStatusModalProps) 
         <div className="my-2">
           <p>{intl.formatMessage(messages.addLearnerInstructions)}</p>
           <FormControl
-            placeholder={intl.formatMessage(messages.enrollLearnersPlaceholder)}
+            placeholder={intl.formatMessage(messages.enrollmentStatusPlaceholder)}
             value={learnerIdentifier}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setLearnerIdentifier(e.target.value)}
           />

--- a/src/enrollments/components/EnrollmentsList.test.tsx
+++ b/src/enrollments/components/EnrollmentsList.test.tsx
@@ -1,11 +1,11 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import EnrollmentsList from './EnrollmentsList';
-import { useEnrollments } from '../data/apiHook';
+import EnrollmentsList from '@src/enrollments/components/EnrollmentsList';
+import { useEnrollments } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
 import { renderWithIntl } from '@src/testUtils';
-import messages from '../messages';
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/enrollments/data/apiHook', () => ({
   useEnrollments: jest.fn(),
 }));
 

--- a/src/enrollments/components/EnrollmentsList.tsx
+++ b/src/enrollments/components/EnrollmentsList.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { ActionRow, Button, DataTable, FormControl, Icon, IconButton } from '@openedx/paragon';
 import { useIntl } from '@openedx/frontend-base';
-import { MoreVert, Search } from '@openedx/paragon/icons';
-import messages from '../messages';
-import { useEnrollments } from '../data/apiHook';
-import { EnrolledLearner } from '../types';
-import { DataTableFetchDataProps, TableCellValue } from '@src/types';
+import { ActionRow, Button, DataTable, FormControl, Icon, IconButton } from '@openedx/paragon';
+import { FilterList, MoreVert, Search } from '@openedx/paragon/icons';
+import messages from '@src/enrollments/messages';
+import { useEnrollments } from '@src/enrollments/data/apiHook';
+import { EnrolledLearner } from '@src/enrollments/types';
 import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
+import { DataTableFetchDataProps, TableCellValue } from '@src/types';
 
 const ENROLLMENTS_PAGE_SIZE = 25;
 
@@ -58,6 +58,7 @@ const BetaTesterFilter = ({ column: { filterValue, setFilter } }: { column: { fi
       size="md"
       value={filterValue}
       onChange={handleSelectChange}
+      leadingElement={<Icon src={FilterList} />}
     >
       {
         betaTesterOptions.map((option) => (

--- a/src/enrollments/components/UnenrollModal.test.tsx
+++ b/src/enrollments/components/UnenrollModal.test.tsx
@@ -2,8 +2,9 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UnenrollModal from './UnenrollModal';
 import { renderWithAlertAndIntl } from '@src/testUtils';
-import { useUnenrollLearners } from '../data/apiHook';
+import { useUpdateEnrollments } from '../data/apiHook';
 import messages from '../messages';
+import { UpdateEnrollmentsParams } from '../types';
 
 const learner = {
   fullName: 'Jane Doe',
@@ -28,7 +29,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('../data/apiHook', () => ({
-  useUnenrollLearners: jest.fn(),
+  useUpdateEnrollments: jest.fn(),
 }));
 
 jest.mock('@src/providers/AlertProvider', () => ({
@@ -42,7 +43,7 @@ describe('UnenrollModal', () => {
   const mutateMock = jest.fn();
 
   beforeEach(() => {
-    (useUnenrollLearners as jest.Mock).mockReturnValue({
+    (useUpdateEnrollments as jest.Mock).mockReturnValue({
       mutate: mutateMock,
       isPending: false
     });
@@ -83,14 +84,17 @@ describe('UnenrollModal', () => {
       <UnenrollModal {...defaultProps} />
     );
     await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
-    expect(mutateMock).toHaveBeenCalledWith([learner.email], {
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [learner.email],
+      action: 'unenroll',
+    }, {
       onSuccess: expect.any(Function),
       onError: expect.any(Function),
     });
   });
 
   it('calls onSuccess and onClose when unenrollment succeeds', async () => {
-    const mutateWithCallback = (_users: string[], callbacks: any) => {
+    const mutateWithCallback = (_params: UpdateEnrollmentsParams, callbacks: any) => {
       callbacks.onSuccess();
     };
     mutateMock.mockImplementation(mutateWithCallback);
@@ -106,7 +110,7 @@ describe('UnenrollModal', () => {
 
   it('shows error alert when unenrollment fails', async () => {
     const errorMessage = 'Unenrollment failed';
-    const mutateWithError = (_users: string[], callbacks: any) => {
+    const mutateWithError = (_params: UpdateEnrollmentsParams, callbacks: any) => {
       callbacks.onError({ message: errorMessage });
     };
     mutateMock.mockImplementation(mutateWithError);
@@ -119,11 +123,12 @@ describe('UnenrollModal', () => {
     expect(mockShowModal).toHaveBeenCalledWith({
       message: errorMessage,
       variant: 'danger',
+      confirmText: messages.closeButton.defaultMessage,
     });
   });
 
   it('shows default error message when error has no message', async () => {
-    const mutateWithError = (_users: string[], callbacks: any) => {
+    const mutateWithError = (_params: UpdateEnrollmentsParams, callbacks: any) => {
       callbacks.onError({});
     };
     mutateMock.mockImplementation(mutateWithError);
@@ -136,11 +141,12 @@ describe('UnenrollModal', () => {
     expect(mockShowModal).toHaveBeenCalledWith({
       message: messages.unenrollLearnerError.defaultMessage,
       variant: 'danger',
+      confirmText: messages.closeButton.defaultMessage,
     });
   });
 
   it('disables unenroll button when pending', () => {
-    (useUnenrollLearners as jest.Mock).mockReturnValue({
+    (useUpdateEnrollments as jest.Mock).mockReturnValue({
       mutate: mutateMock,
       isPending: true
     });

--- a/src/enrollments/components/UnenrollModal.test.tsx
+++ b/src/enrollments/components/UnenrollModal.test.tsx
@@ -1,10 +1,10 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import UnenrollModal from './UnenrollModal';
+import UnenrollModal from '@src/enrollments/components/UnenrollModal';
+import { useUpdateEnrollments } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
+import { UpdateEnrollmentsParams } from '@src/enrollments/types';
 import { renderWithAlertAndIntl } from '@src/testUtils';
-import { useUpdateEnrollments } from '../data/apiHook';
-import messages from '../messages';
-import { UpdateEnrollmentsParams } from '../types';
 
 const learner = {
   fullName: 'Jane Doe',
@@ -28,7 +28,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'test-course-id' }),
 }));
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/enrollments/data/apiHook', () => ({
   useUpdateEnrollments: jest.fn(),
 }));
 
@@ -85,7 +85,7 @@ describe('UnenrollModal', () => {
     );
     await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
     expect(mutateMock).toHaveBeenCalledWith({
-      identifier: [learner.email],
+      identifier: [learner.username],
       action: 'unenroll',
     }, {
       onSuccess: expect.any(Function),

--- a/src/enrollments/components/UnenrollModal.test.tsx
+++ b/src/enrollments/components/UnenrollModal.test.tsx
@@ -1,0 +1,173 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UnenrollModal from './UnenrollModal';
+import { renderWithAlertAndIntl } from '@src/testUtils';
+import { useUnenrollLearners } from '../data/apiHook';
+import messages from '../messages';
+
+const learner = {
+  fullName: 'Jane Doe',
+  email: 'jane@example.com',
+  isBetaTester: false,
+  username: 'jane.doe',
+  mode: 'verified',
+};
+
+const defaultProps = {
+  learner,
+  isOpen: true,
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+const mockShowModal = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'test-course-id' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useUnenrollLearners: jest.fn(),
+}));
+
+jest.mock('@src/providers/AlertProvider', () => ({
+  useAlert: () => ({
+    showModal: mockShowModal,
+  }),
+  AlertProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('UnenrollModal', () => {
+  const mutateMock = jest.fn();
+
+  beforeEach(() => {
+    (useUnenrollLearners as jest.Mock).mockReturnValue({
+      mutate: mutateMock,
+      isPending: false
+    });
+    mockShowModal.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal with correct title and confirmation message', () => {
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    expect(screen.getByRole('heading', { name: /unenroll learner/i })).toBeInTheDocument();
+    expect(screen.getByText(messages.unenrollLearnersConfirmation.defaultMessage.replace('{name}', learner.fullName))).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Unenroll buttons', () => {
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^unenroll$/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel button is clicked', async () => {
+    const onClose = jest.fn();
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} onClose={onClose} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls unenrollLearners when Unenroll button is clicked', async () => {
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
+    expect(mutateMock).toHaveBeenCalledWith([learner.email], {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+
+  it('calls onSuccess and onClose when unenrollment succeeds', async () => {
+    const mutateWithCallback = (_users: string[], callbacks: any) => {
+      callbacks.onSuccess();
+    };
+    mutateMock.mockImplementation(mutateWithCallback);
+
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
+
+    expect(defaultProps.onSuccess).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('shows error alert when unenrollment fails', async () => {
+    const errorMessage = 'Unenrollment failed';
+    const mutateWithError = (_users: string[], callbacks: any) => {
+      callbacks.onError({ message: errorMessage });
+    };
+    mutateMock.mockImplementation(mutateWithError);
+
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
+
+    expect(mockShowModal).toHaveBeenCalledWith({
+      message: errorMessage,
+      variant: 'danger',
+    });
+  });
+
+  it('shows default error message when error has no message', async () => {
+    const mutateWithError = (_users: string[], callbacks: any) => {
+      callbacks.onError({});
+    };
+    mutateMock.mockImplementation(mutateWithError);
+
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^unenroll$/i }));
+
+    expect(mockShowModal).toHaveBeenCalledWith({
+      message: messages.unenrollLearnerError.defaultMessage,
+      variant: 'danger',
+    });
+  });
+
+  it('disables unenroll button when pending', () => {
+    (useUnenrollLearners as jest.Mock).mockReturnValue({
+      mutate: mutateMock,
+      isPending: true
+    });
+
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} />
+    );
+
+    const unenrollButton = screen.getByRole('button', { name: messages.unenrollButton.defaultMessage });
+    expect(unenrollButton).toBeDisabled();
+  });
+
+  it('does not render modal when isOpen is false', () => {
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} isOpen={false} />
+    );
+    expect(screen.queryByText(messages.unenrollLearners.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when modal close button is clicked', async () => {
+    const onClose = jest.fn();
+    renderWithAlertAndIntl(
+      <UnenrollModal {...defaultProps} onClose={onClose} />
+    );
+    // ModalDialog close button should have aria-label="Close"
+    const closeButton = screen.getByLabelText(/close/i);
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/enrollments/components/UnenrollModal.tsx
+++ b/src/enrollments/components/UnenrollModal.tsx
@@ -1,14 +1,59 @@
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { Button, ModalDialog } from '@openedx/paragon';
+import { useAlert } from '@src/providers/AlertProvider';
+import { useUnenrollLearners } from '../data/apiHook';
+import messages from '../messages';
 import { EnrolledLearner } from '../types';
+
 interface UnenrollModalProps {
   learner: EnrolledLearner,
   isOpen: boolean,
   onClose: () => void,
+  onSuccess: () => void,
 }
 
-const UnenrollModal = ({ learner, isOpen, onClose }: UnenrollModalProps) => {
-  console.log(learner, isOpen, onClose);
+const UnenrollModal = ({ learner, isOpen, onClose, onSuccess }: UnenrollModalProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { mutate: unenrollLearners, isPending } = useUnenrollLearners(courseId);
+  const { showModal } = useAlert();
 
-  return <div>Unenroll Modal</div>;
+  const handleUnenroll = () => {
+    unenrollLearners([learner.email], {
+      onSuccess: () => {
+        onSuccess();
+        onClose();
+      },
+      onError: (error) => {
+        showModal({
+          message: error.message || intl.formatMessage(messages.unenrollLearnerError),
+          variant: 'danger',
+        });
+      }
+    });
+  };
+
+  return (
+    <ModalDialog isOpen={isOpen} onClose={onClose} title={intl.formatMessage(messages.unenrollLearners)} isOverflowVisible={false}>
+      <ModalDialog.Header>
+        <h3 className="text-primary-500">{intl.formatMessage(messages.unenrollLearnerTitle)}</h3>
+      </ModalDialog.Header>
+      <ModalDialog.Body className="py-4">
+        <p>{intl.formatMessage(messages.unenrollLearnersConfirmation, { name: learner.fullName })}</p>
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelButton)}</Button>
+        <Button
+          className="ml-2"
+          onClick={handleUnenroll}
+          disabled={isPending}
+        >
+          {intl.formatMessage(messages.unenrollButton)}
+        </Button>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
 };
 
 export default UnenrollModal;

--- a/src/enrollments/components/UnenrollModal.tsx
+++ b/src/enrollments/components/UnenrollModal.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, ModalDialog } from '@openedx/paragon';
 import { useAlert } from '@src/providers/AlertProvider';
-import { useUnenrollLearners } from '../data/apiHook';
+import { useUpdateEnrollments } from '../data/apiHook';
 import messages from '../messages';
 import { EnrolledLearner } from '../types';
 
@@ -16,11 +16,14 @@ interface UnenrollModalProps {
 const UnenrollModal = ({ learner, isOpen, onClose, onSuccess }: UnenrollModalProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const { mutate: unenrollLearners, isPending } = useUnenrollLearners(courseId);
+  const { mutate: unenrollLearners, isPending } = useUpdateEnrollments(courseId);
   const { showModal } = useAlert();
 
   const handleUnenroll = () => {
-    unenrollLearners([learner.email], {
+    unenrollLearners({
+      identifier: [learner.username],
+      action: 'unenroll',
+    }, {
       onSuccess: () => {
         onSuccess();
         onClose();
@@ -29,6 +32,7 @@ const UnenrollModal = ({ learner, isOpen, onClose, onSuccess }: UnenrollModalPro
         showModal({
           message: error.message || intl.formatMessage(messages.unenrollLearnerError),
           variant: 'danger',
+          confirmText: intl.formatMessage(messages.closeButton),
         });
       }
     });

--- a/src/enrollments/components/UnenrollModal.tsx
+++ b/src/enrollments/components/UnenrollModal.tsx
@@ -2,9 +2,9 @@ import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, ModalDialog } from '@openedx/paragon';
 import { useAlert } from '@src/providers/AlertProvider';
-import { useUpdateEnrollments } from '../data/apiHook';
-import messages from '../messages';
-import { EnrolledLearner } from '../types';
+import { useUpdateEnrollments } from '@src/enrollments/data/apiHook';
+import messages from '@src/enrollments/messages';
+import { EnrolledLearner } from '@src/enrollments/types';
 
 interface UnenrollModalProps {
   learner: EnrolledLearner,

--- a/src/enrollments/data/api.test.ts
+++ b/src/enrollments/data/api.test.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { getEnrollments, getEnrollmentStatus, enrollLearners, unenrollLearners } from './api';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
 import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner } from '../types';
 import { DataList } from '@src/types';
 
@@ -249,85 +249,85 @@ describe('enrollments api', () => {
     });
   });
 
-  describe('enrollLearners', () => {
+  describe('updateEnrollments', () => {
     beforeEach(() => {
       mockHttpClient.post.mockResolvedValue({});
     });
 
     it('enrolls multiple learners successfully', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student1@example.com', 'student2@example.com'];
+      const identifier = ['student1@example.com', 'student2@example.com'];
 
-      await enrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true });
 
       expect(mockGetApiBaseUrl).toHaveBeenCalled();
       expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
       expect(mockHttpClient.post).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { users }
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/modify',
+        { identifier, action: 'enroll', auto_enroll: true, email_students: true }
       );
     });
 
     it('enrolls a single learner successfully', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student@example.com'];
+      const identifier = ['student@example.com'];
 
-      await enrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { users }
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/modify',
+        { identifier, action: 'enroll', auto_enroll: true, email_students: true }
       );
     });
 
     it('handles empty users array', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users: string[] = [];
+      const identifier: string[] = [];
 
-      await enrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { users }
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/modify',
+        { identifier, action: 'enroll', auto_enroll: true, email_students: true }
       );
     });
 
     it('handles special characters in course ID', async () => {
       const courseId = 'course-v1:edX+Advanced+Course+2023';
-      const users = ['student@example.com'];
+      const identifier = ['student@example.com'];
 
-      await enrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Advanced+Course+2023/enrollments/',
-        { users }
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Advanced+Course+2023/enrollments/modify',
+        { identifier, action: 'enroll', auto_enroll: true, email_students: true }
       );
     });
 
     it('handles special characters in user emails', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['test+user@example.com', 'user.with+dots@domain.co.uk'];
+      const identifier = ['test+user@example.com', 'user.with+dots@domain.co.uk'];
 
-      await enrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { users }
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/modify',
+        { identifier, action: 'enroll', auto_enroll: true, email_students: true }
       );
     });
 
     it('throws error when API call fails', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student@example.com'];
+      const identifier = ['student@example.com'];
       const error = new Error('Enrollment failed');
       mockHttpClient.post.mockRejectedValue(error);
 
-      await expect(enrollLearners(courseId, users)).rejects.toThrow('Enrollment failed');
+      await expect(updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true })).rejects.toThrow('Enrollment failed');
     });
 
     it('handles enrollment validation errors', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['invalid-email'];
+      const identifier = ['invalid-email'];
       const error = {
         response: {
           status: 400,
@@ -336,112 +336,19 @@ describe('enrollments api', () => {
       };
       mockHttpClient.post.mockRejectedValue(error);
 
-      await expect(enrollLearners(courseId, users)).rejects.toEqual(error);
-    });
-  });
-
-  describe('unenrollLearners', () => {
-    beforeEach(() => {
-      mockHttpClient.delete.mockResolvedValue({});
+      await expect(updateEnrollments(courseId, { identifier, action: 'enroll', autoEnroll: true, emailStudents: true })).rejects.toEqual(error);
     });
 
     it('unenrolls multiple learners successfully', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student1@example.com', 'student2@example.com'];
+      const identifier = ['student1@example.com', 'student2@example.com'];
 
-      await unenrollLearners(courseId, users);
+      await updateEnrollments(courseId, { identifier, action: 'unenroll', autoEnroll: true, emailStudents: true });
 
-      expect(mockGetApiBaseUrl).toHaveBeenCalled();
-      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { data: { users } }
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/modify',
+        { identifier, action: 'unenroll', auto_enroll: true, email_students: true }
       );
-    });
-
-    it('unenrolls a single learner successfully', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student@example.com'];
-
-      await unenrollLearners(courseId, users);
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { data: { users } }
-      );
-    });
-
-    it('handles empty users array', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users: string[] = [];
-
-      await unenrollLearners(courseId, users);
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { data: { users } }
-      );
-    });
-
-    it('handles special characters in course ID', async () => {
-      const courseId = 'course-v1:edX+Advanced+Course+2023';
-      const users = ['student@example.com'];
-
-      await unenrollLearners(courseId, users);
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Advanced+Course+2023/enrollments/',
-        { data: { users } }
-      );
-    });
-
-    it('handles special characters in user emails', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users = ['test+user@example.com', 'user.with+dots@domain.co.uk'];
-
-      await unenrollLearners(courseId, users);
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
-        { data: { users } }
-      );
-    });
-
-    it('throws error when API call fails', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student@example.com'];
-      const error = new Error('Unenrollment failed');
-      mockHttpClient.delete.mockRejectedValue(error);
-
-      await expect(unenrollLearners(courseId, users)).rejects.toThrow('Unenrollment failed');
-    });
-
-    it('handles unenrollment authorization errors', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users = ['student@example.com'];
-      const error = {
-        response: {
-          status: 403,
-          data: { error: 'Permission denied' },
-        },
-      };
-      mockHttpClient.delete.mockRejectedValue(error);
-
-      await expect(unenrollLearners(courseId, users)).rejects.toEqual(error);
-    });
-
-    it('handles unenrollment of non-enrolled users', async () => {
-      const courseId = 'course-v1:edX+Test+2023';
-      const users = ['notenrolled@example.com'];
-      const error = {
-        response: {
-          status: 404,
-          data: { error: 'User not enrolled in course' },
-        },
-      };
-      mockHttpClient.delete.mockRejectedValue(error);
-
-      await expect(unenrollLearners(courseId, users)).rejects.toEqual(error);
     });
   });
 });

--- a/src/enrollments/data/api.test.ts
+++ b/src/enrollments/data/api.test.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { getApiBaseUrl } from '../../data/api';
-import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
-import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner } from '../types';
+import { getApiBaseUrl } from '@src/data/api';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from '@src/enrollments/data/api';
+import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner } from '@src/enrollments/types';
 import { DataList } from '@src/types';
 
 jest.mock('@openedx/frontend-base', () => ({
@@ -10,7 +10,7 @@ jest.mock('@openedx/frontend-base', () => ({
   getAuthenticatedHttpClient: jest.fn(),
 }));
 
-jest.mock('../../data/api', () => ({
+jest.mock('@src/data/api', () => ({
   getApiBaseUrl: jest.fn(),
 }));
 

--- a/src/enrollments/data/api.test.ts
+++ b/src/enrollments/data/api.test.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { getEnrollments, getEnrollmentStatus } from './api';
+import { getEnrollments, getEnrollmentStatus, enrollLearners, unenrollLearners } from './api';
 import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner } from '../types';
 import { DataList } from '@src/types';
 
@@ -22,6 +22,7 @@ describe('enrollments api', () => {
   const mockHttpClient = {
     get: jest.fn(),
     post: jest.fn(),
+    delete: jest.fn(),
   };
 
   beforeEach(() => {
@@ -245,6 +246,202 @@ describe('enrollments api', () => {
         expect(result.enrollmentStatus).toBe(status);
         expect(mockCamelCaseObject).toHaveBeenCalledWith(mockStatusData);
       }
+    });
+  });
+
+  describe('enrollLearners', () => {
+    beforeEach(() => {
+      mockHttpClient.post.mockResolvedValue({});
+    });
+
+    it('enrolls multiple learners successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student1@example.com', 'student2@example.com'];
+
+      await enrollLearners(courseId, users);
+
+      expect(mockGetApiBaseUrl).toHaveBeenCalled();
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { users }
+      );
+    });
+
+    it('enrolls a single learner successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student@example.com'];
+
+      await enrollLearners(courseId, users);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { users }
+      );
+    });
+
+    it('handles empty users array', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users: string[] = [];
+
+      await enrollLearners(courseId, users);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { users }
+      );
+    });
+
+    it('handles special characters in course ID', async () => {
+      const courseId = 'course-v1:edX+Advanced+Course+2023';
+      const users = ['student@example.com'];
+
+      await enrollLearners(courseId, users);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Advanced+Course+2023/enrollments/',
+        { users }
+      );
+    });
+
+    it('handles special characters in user emails', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['test+user@example.com', 'user.with+dots@domain.co.uk'];
+
+      await enrollLearners(courseId, users);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { users }
+      );
+    });
+
+    it('throws error when API call fails', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student@example.com'];
+      const error = new Error('Enrollment failed');
+      mockHttpClient.post.mockRejectedValue(error);
+
+      await expect(enrollLearners(courseId, users)).rejects.toThrow('Enrollment failed');
+    });
+
+    it('handles enrollment validation errors', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['invalid-email'];
+      const error = {
+        response: {
+          status: 400,
+          data: { error: 'Invalid email format' },
+        },
+      };
+      mockHttpClient.post.mockRejectedValue(error);
+
+      await expect(enrollLearners(courseId, users)).rejects.toEqual(error);
+    });
+  });
+
+  describe('unenrollLearners', () => {
+    beforeEach(() => {
+      mockHttpClient.delete.mockResolvedValue({});
+    });
+
+    it('unenrolls multiple learners successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student1@example.com', 'student2@example.com'];
+
+      await unenrollLearners(courseId, users);
+
+      expect(mockGetApiBaseUrl).toHaveBeenCalled();
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { data: { users } }
+      );
+    });
+
+    it('unenrolls a single learner successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student@example.com'];
+
+      await unenrollLearners(courseId, users);
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { data: { users } }
+      );
+    });
+
+    it('handles empty users array', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users: string[] = [];
+
+      await unenrollLearners(courseId, users);
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { data: { users } }
+      );
+    });
+
+    it('handles special characters in course ID', async () => {
+      const courseId = 'course-v1:edX+Advanced+Course+2023';
+      const users = ['student@example.com'];
+
+      await unenrollLearners(courseId, users);
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Advanced+Course+2023/enrollments/',
+        { data: { users } }
+      );
+    });
+
+    it('handles special characters in user emails', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['test+user@example.com', 'user.with+dots@domain.co.uk'];
+
+      await unenrollLearners(courseId, users);
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments/',
+        { data: { users } }
+      );
+    });
+
+    it('throws error when API call fails', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student@example.com'];
+      const error = new Error('Unenrollment failed');
+      mockHttpClient.delete.mockRejectedValue(error);
+
+      await expect(unenrollLearners(courseId, users)).rejects.toThrow('Unenrollment failed');
+    });
+
+    it('handles unenrollment authorization errors', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['student@example.com'];
+      const error = {
+        response: {
+          status: 403,
+          data: { error: 'Permission denied' },
+        },
+      };
+      mockHttpClient.delete.mockRejectedValue(error);
+
+      await expect(unenrollLearners(courseId, users)).rejects.toEqual(error);
+    });
+
+    it('handles unenrollment of non-enrolled users', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const users = ['notenrolled@example.com'];
+      const error = {
+        response: {
+          status: 404,
+          data: { error: 'User not enrolled in course' },
+        },
+      };
+      mockHttpClient.delete.mockRejectedValue(error);
+
+      await expect(unenrollLearners(courseId, users)).rejects.toEqual(error);
     });
   });
 });

--- a/src/enrollments/data/api.ts
+++ b/src/enrollments/data/api.ts
@@ -37,3 +37,23 @@ export const getEnrollmentStatus = async (
   );
   return camelCaseObject(data);
 };
+
+export const enrollLearners = async (
+  courseId: string,
+  users: string[]
+): Promise<void> => {
+  await getAuthenticatedHttpClient().post(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments/`,
+    { users }
+  );
+};
+
+export const unenrollLearners = async (
+  courseId: string,
+  users: string[]
+): Promise<void> => {
+  await getAuthenticatedHttpClient().delete(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments/`,
+    { data: { users } }
+  );
+};

--- a/src/enrollments/data/api.ts
+++ b/src/enrollments/data/api.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
-import { getApiBaseUrl } from '../../data/api';
-import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner, UpdateEnrollmentsParams } from '../types';
+import { getApiBaseUrl } from '@src/data/api';
+import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner, UpdateEnrollmentsParams } from '@src/enrollments/types';
 import { DataList } from '@src/types';
 
 export const getEnrollments = async (

--- a/src/enrollments/data/api.ts
+++ b/src/enrollments/data/api.ts
@@ -1,6 +1,6 @@
-import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner } from '../types';
+import { EnrollmentsParams, EnrollmentStatusResponse, EnrolledLearner, UpdateEnrollmentsParams } from '../types';
 import { DataList } from '@src/types';
 
 export const getEnrollments = async (
@@ -38,22 +38,13 @@ export const getEnrollmentStatus = async (
   return camelCaseObject(data);
 };
 
-export const enrollLearners = async (
+export const updateEnrollments = async (
   courseId: string,
-  users: string[]
+  params: UpdateEnrollmentsParams
 ): Promise<void> => {
+  const snakeCaseParams = snakeCaseObject(params);
   await getAuthenticatedHttpClient().post(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments/`,
-    { users }
-  );
-};
-
-export const unenrollLearners = async (
-  courseId: string,
-  users: string[]
-): Promise<void> => {
-  await getAuthenticatedHttpClient().delete(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments/`,
-    { data: { users } }
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments/modify`,
+    snakeCaseParams
   );
 };

--- a/src/enrollments/data/apiHook.test.tsx
+++ b/src/enrollments/data/apiHook.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useEnrollments, useEnrollmentByUserId, useUpdateEnrollments } from './apiHook';
-import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
-import { EnrollmentsParams } from '../types';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from '@src/enrollments/data/api';
+import { useEnrollments, useEnrollmentByUserId, useUpdateEnrollments } from '@src/enrollments/data/apiHook';
+import { EnrollmentsParams } from '@src/enrollments/types';
 
-jest.mock('./api');
+jest.mock('@src/enrollments/data/api');
 
 const mockGetEnrollments = getEnrollments as jest.MockedFunction<typeof getEnrollments>;
 const mockGetEnrollmentStatus = getEnrollmentStatus as jest.MockedFunction<typeof getEnrollmentStatus>;

--- a/src/enrollments/data/apiHook.test.tsx
+++ b/src/enrollments/data/apiHook.test.tsx
@@ -1,13 +1,14 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useEnrollments, useEnrollmentByUserId } from './apiHook';
-import { getEnrollments, getEnrollmentStatus } from './api';
+import { useEnrollments, useEnrollmentByUserId, useUpdateEnrollments } from './apiHook';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
 import { EnrollmentsParams } from '../types';
 
 jest.mock('./api');
 
 const mockGetEnrollments = getEnrollments as jest.MockedFunction<typeof getEnrollments>;
 const mockGetEnrollmentStatus = getEnrollmentStatus as jest.MockedFunction<typeof getEnrollmentStatus>;
+const mockPostUpdateEnrollments = updateEnrollments as jest.MockedFunction<typeof updateEnrollments>;
 
 const mockEnrollmentsData = {
   count: 2,
@@ -296,6 +297,45 @@ describe('enrollments api hooks', () => {
       });
 
       expect(result.current.error).toBe(httpError);
+    });
+  });
+
+  describe('useUpdateEnrollments', () => {
+    const courseId = 'course-v1:edX+Test+2023';
+
+    it('calls updateEnrollments and succeeds', async () => {
+      mockPostUpdateEnrollments.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useUpdateEnrollments(courseId), {
+        wrapper: createWrapper(),
+      });
+
+      const params = { identifier: ['student1'], action: 'enroll' as const };
+      result.current.mutate(params);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockPostUpdateEnrollments).toHaveBeenCalledWith(courseId, params);
+    });
+
+    it('handles mutation error', async () => {
+      const error = new Error('Failed to update');
+      mockPostUpdateEnrollments.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useUpdateEnrollments(courseId), {
+        wrapper: createWrapper(),
+      });
+
+      const params = { identifier: ['student2'], action: 'unenroll' as const };
+      result.current.mutate(params);
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(mockPostUpdateEnrollments).toHaveBeenCalledWith(courseId, params);
+      expect(result.current.error).toBe(error);
     });
   });
 });

--- a/src/enrollments/data/apiHook.ts
+++ b/src/enrollments/data/apiHook.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { getEnrollments, getEnrollmentStatus } from './api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { enrollLearners, getEnrollments, getEnrollmentStatus, unenrollLearners } from './api';
 import { enrollmentsQueryKeys } from './queryKeys';
 import { EnrollmentsParams } from '../types';
 
@@ -18,3 +18,23 @@ export const useEnrollmentByUserId = (courseId: string, userIdentifier: string) 
     enabled: false,
   })
 );
+
+export const useEnrollLearners = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return (useMutation({
+    mutationFn: (users: string[]) => enrollLearners(courseId, users),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: enrollmentsQueryKeys.byCourse(courseId) });
+    },
+  }));
+};
+
+export const useUnenrollLearners = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return (useMutation({
+    mutationFn: (users: string[]) => unenrollLearners(courseId, users),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: enrollmentsQueryKeys.byCourse(courseId) });
+    },
+  }));
+};

--- a/src/enrollments/data/apiHook.ts
+++ b/src/enrollments/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
-import { enrollmentsQueryKeys } from './queryKeys';
-import { EnrollmentsParams, UpdateEnrollmentsParams } from '../types';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from '@src/enrollments/data/api';
+import { enrollmentsQueryKeys } from '@src/enrollments/data/queryKeys';
+import { EnrollmentsParams, UpdateEnrollmentsParams } from '@src/enrollments/types';
 
 export const useEnrollments = (courseId: string, params: EnrollmentsParams) => (
   useQuery({

--- a/src/enrollments/data/apiHook.ts
+++ b/src/enrollments/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { enrollLearners, getEnrollments, getEnrollmentStatus, unenrollLearners } from './api';
+import { getEnrollments, getEnrollmentStatus, updateEnrollments } from './api';
 import { enrollmentsQueryKeys } from './queryKeys';
-import { EnrollmentsParams } from '../types';
+import { EnrollmentsParams, UpdateEnrollmentsParams } from '../types';
 
 export const useEnrollments = (courseId: string, params: EnrollmentsParams) => (
   useQuery({
@@ -19,20 +19,10 @@ export const useEnrollmentByUserId = (courseId: string, userIdentifier: string) 
   })
 );
 
-export const useEnrollLearners = (courseId: string) => {
+export const useUpdateEnrollments = (courseId: string) => {
   const queryClient = useQueryClient();
   return (useMutation({
-    mutationFn: (users: string[]) => enrollLearners(courseId, users),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: enrollmentsQueryKeys.byCourse(courseId) });
-    },
-  }));
-};
-
-export const useUnenrollLearners = (courseId: string) => {
-  const queryClient = useQueryClient();
-  return (useMutation({
-    mutationFn: (users: string[]) => unenrollLearners(courseId, users),
+    mutationFn: (params: UpdateEnrollmentsParams) => updateEnrollments(courseId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: enrollmentsQueryKeys.byCourse(courseId) });
     },

--- a/src/enrollments/data/queryKeys.ts
+++ b/src/enrollments/data/queryKeys.ts
@@ -1,5 +1,5 @@
-import { appId } from '../../constants';
-import { EnrollmentsParams } from '../types';
+import { appId } from '@src/constants';
+import { EnrollmentsParams } from '@src/enrollments/types';
 
 export const enrollmentsQueryKeys = {
   all: [appId, 'enrollments'] as const,

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -170,6 +170,11 @@ const messages = defineMessages({
     id: 'instruct.enrollments.modals.unenrollingButton',
     defaultMessage: 'Unenrolling...',
     description: 'Label for unenroll button when processing',
+  },
+  enrollLearnerNotFoundError: {
+    id: 'instruct.enrollments.modals.enrollLearnerNotFoundError',
+    defaultMessage: 'One or more learners were not found. Please check the email addresses or usernames and try again.',
+    description: 'Error message displayed when enrolling learners fails due to learner not found',
   }
 });
 

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -14,7 +14,7 @@ const messages = defineMessages({
   enrollLearners: {
     id: 'instruct.enrollments.enrollLearners',
     defaultMessage: 'Enroll Learners',
-    description: 'Button label for enrolling learners',
+    description: 'Button label and modal title for enrolling learners',
   },
   checkEnrollmentStatus: {
     id: 'instruct.enrollments.checkEnrollmentStatus',
@@ -62,17 +62,17 @@ const messages = defineMessages({
     description: 'Label for true boolean value',
   },
   addLearnerInstructions: {
-    id: 'instruct.enrollments.checkEnrollmentStatusModal.addLearnerInstructions',
-    defaultMessage: 'Learner’s My Open edX email address or username',
+    id: 'instruct.enrollments.modals.checkEnrollmentStatus.addLearnerInstructions',
+    defaultMessage: 'Learner\'s My Open edX email address or username',
     description: 'Instructions for enroll learners to the course',
   },
-  enrollLearnersPlaceholder: {
-    id: 'instruct.enrollments.checkEnrollmentStatusModal.enrollLearnersPlaceholder',
+  enrollmentStatusPlaceholder: {
+    id: 'instruct.enrollments.modals.checkEnrollmentStatus.enrollmentStatusPlaceholder',
     defaultMessage: 'Learner email address or username',
     description: 'Placeholder text for enrolling learners textarea',
   },
   closeButton: {
-    id: 'instruct.enrollments.checkEnrollmentStatusModal.closeButton',
+    id: 'instruct.enrollments.modals.closeButton',
     defaultMessage: 'Close',
     description: 'Label for close button in modals',
   },
@@ -106,6 +106,71 @@ const messages = defineMessages({
     defaultMessage: 'Non-Beta Testers',
     description: 'Option for showing only non-beta testers in beta tester filter',
   },
+  statusResponseMessage: {
+    id: 'instruct.enrollments.modals.checkEnrollmentStatus.statusResponseMessage',
+    defaultMessage: 'Enrollment status for {learnerIdentifier}: {status}',
+    description: 'Message displaying the enrollment status for a learner',
+  },
+  userIdentifierPlaceholder: {
+    id: 'instruct.enrollments.modals.enrollLearners.userIdentifierPlaceholder',
+    defaultMessage: 'Email addresses / Usernames',
+    description: 'Placeholder text for enrolling learners textarea',
+  },
+  enrollLearnerInstructions: {
+    id: 'instruct.enrollments.modals.enrollLearners.enrollLearnerInstructions',
+    defaultMessage: 'Enter email addresses and/or usernames separated by new lines or commas. You will not get notification for emails that bounce, so please double-check spelling.',
+    description: 'Instructions for enrolling learners to the course',
+  },
+  unenrollLearners: {
+    id: 'instruct.enrollments.modals.unenrollLearners',
+    defaultMessage: 'Unenroll Learners',
+    description: 'Title for unenroll learners modal',
+  },
+  unenrollLearnersConfirmation: {
+    id: 'instruct.enrollments.modals.unenrollLearnersConfirmation',
+    defaultMessage: 'Unenroll {name} from course?',
+    description: 'Confirmation message for unenrolling learners',
+  },
+  unenrollLearnerTitle: {
+    id: 'instruct.enrollments.modals.unenrollLearnerTitle',
+    defaultMessage: 'Unenroll Learner?',
+    description: 'Title for unenroll learner modal',
+  },
+  saveButton: {
+    id: 'instruct.enrollments.modals.saveButton',
+    defaultMessage: 'Save',
+    description: 'Label for save button in modals',
+  },
+  cancelButton: {
+    id: 'instruct.enrollments.modals.cancelButton',
+    defaultMessage: 'Cancel',
+    description: 'Label for cancel button in modals',
+  },
+  autoEnrollCheckbox: {
+    id: 'instruct.enrollments.modals.autoEnrollCheckbox',
+    defaultMessage: 'Auto Enroll',
+    description: 'Label for auto enroll checkbox in enroll learners modal',
+  },
+  notifyUsersCheckbox: {
+    id: 'instruct.enrollments.modals.notifyUsersCheckbox',
+    defaultMessage: 'Notify Users by Email',
+    description: 'Label for notify users by email checkbox in enroll learners modal',
+  },
+  enrollLearnerError: {
+    id: 'instruct.enrollments.modals.enrollLearnerError',
+    defaultMessage: 'An error occurred while enrolling learners. Please try again.',
+    description: 'Error message displayed when enrolling learners fails',
+  },
+  unenrollLearnerError: {
+    id: 'instruct.enrollments.modals.unenrollLearnerError',
+    defaultMessage: 'An error occurred while unenrolling learner. Please try again.',
+    description: 'Error message displayed when unenrolling learner fails',
+  },
+  unenrollingButton: {
+    id: 'instruct.enrollments.modals.unenrollingButton',
+    defaultMessage: 'Unenrolling...',
+    description: 'Label for unenroll button when processing',
+  }
 });
 
 export default messages;

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -166,11 +166,6 @@ const messages = defineMessages({
     defaultMessage: 'An error occurred while unenrolling learner. Please try again.',
     description: 'Error message displayed when unenrolling learner fails',
   },
-  unenrollingButton: {
-    id: 'instruct.enrollments.modals.unenrollingButton',
-    defaultMessage: 'Unenrolling...',
-    description: 'Label for unenroll button when processing',
-  },
   enrollLearnerNotFoundError: {
     id: 'instruct.enrollments.modals.enrollLearnerNotFoundError',
     defaultMessage: 'One or more learners were not found. Please check the email addresses or usernames and try again.',

--- a/src/enrollments/types.ts
+++ b/src/enrollments/types.ts
@@ -13,3 +13,10 @@ export interface EnrollmentsParams extends PaginationParams {
   emailOrUsername: string,
   isBetaTester: string,
 }
+
+export interface UpdateEnrollmentsParams {
+  identifier: string[],
+  action: 'enroll' | 'unenroll',
+  autoEnroll?: boolean,
+  emailStudents?: boolean,
+}


### PR DESCRIPTION
## Description
Functionality added:
- Enroll Learners
- Unenroll Learners

Note: Waiting for Eddie to confirm copy if we want success messages
## Supporting information
Closes #28 

## Testing instructions
- Click on add learners, open a modal that needs to be filled with username or emails and select if auto enroll and send emails.
- Click on save.
- Click on unenroll and opens a confirmation modal.

## Other information
Enroll
<img width="1319" height="750" alt="Screenshot 2026-04-14 at 1 06 32 p m" src="https://github.com/user-attachments/assets/1cb39bef-c95e-45e5-973e-8c6def081e77" />

Unenroll
<img width="1449" height="833" alt="Screenshot 2026-04-14 at 1 06 46 p m" src="https://github.com/user-attachments/assets/4947e766-8d60-4da9-b25c-e42940074caa" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
