### PR TITLE
feat: added code spliting on main module

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,7 +1,6 @@
 import CohortsPage from '@src/cohorts/CohortsPage';
 import CourseInfoPage from '@src/courseInfo/CourseInfoPage';
 import OpenResponsesPage from '@src/openResponses/OpenResponsesPage';
-import Main from '@src/Main';
 
 const routes = [
   {
@@ -10,7 +9,10 @@ const routes = [
     handle: {
       role: 'org.openedx.frontend.role.instructor'
     },
-    Component: Main,
+    async lazy() {
+      const module = await import('./Main');
+      return { Component: module.default };
+    },
     children: [
       {
         path: 'course_info',


### PR DESCRIPTION
## Description

This adds the Main path of auth as a lazy loaded component so any app consuming this (as frontend-template-site) will have the related routes with code splitting

fixes https://github.com/openedx/frontend-base/issues/163

## Testing instructions

- Run this in dev mode and look for extra chunks in the networ requests 

OR 

- Add this repo as part of a parent aggregator project (use frontend-template-site as a quick headstart)
- Run the the frontent-base app and see that while accessing the related routes extra chunks of code are being fetch
- Pull any other route of this frontend-app if any work it should be the same for any other

## Other information

Include anything else that will help reviewers and consumers understand the change.
- This doesn't depend on any other change
- No special concern

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
