### PR TITLE
Grading single learner

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -12,3 +12,7 @@
 .username .form-control::placeholder {
     font-size: var(--pgn-typography-form-input-font-size-sm);
 }
+
+.info-tooltip .tooltip-inner {
+    max-width: none;
+}

--- a/src/components/ActionCard.test.tsx
+++ b/src/components/ActionCard.test.tsx
@@ -8,6 +8,7 @@ describe('ActionCard', () => {
     title: 'Test Card Title',
     description: 'This is a test card description',
     buttonLabel: 'Click Me',
+    onButtonClick: jest.fn(),
   };
 
   beforeEach(() => {
@@ -62,12 +63,5 @@ describe('ActionCard', () => {
     expect(screen.getByText('Custom Button 1')).toBeInTheDocument();
     expect(screen.getByText('Custom Button 2')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Click Me' })).not.toBeInTheDocument();
-  });
-
-  it('should handle missing onButtonClick prop gracefully', async () => {
-    render(<ActionCard {...defaultProps} />);
-    const button = screen.getByRole('button', { name: 'Click Me' });
-    await user.click(button);
-    expect(button).toBeInTheDocument();
   });
 });

--- a/src/components/ActionCard.tsx
+++ b/src/components/ActionCard.tsx
@@ -1,7 +1,7 @@
 import { Button, Card } from '@openedx/paragon';
 
-interface ActionCardProps {
-  buttonLabel: string,
+export interface ActionCardProps {
+  buttonLabel?: string,
   customAction?: React.ReactNode,
   description: string,
   hasBorderBottom?: boolean,
@@ -20,15 +20,15 @@ const ActionCard = ({
   onButtonClick,
 }: ActionCardProps) => {
   return (
-    <Card className={`bg-light-200 py-2 border-gray-500 rounded-0 shadow-none ${hasBorderBottom ? 'border-bottom' : ''}`} orientation="horizontal">
+    <Card className={`bg-light-200 pb-2 mt-2 border-gray-500 rounded-0 shadow-none ${hasBorderBottom ? 'border-bottom' : ''}`} orientation="horizontal">
       <Card.Body className="flex-grow-1">
-        <Card.Section>
-          <h4 className="mb-2">{title}</h4>
-          <p className="text-muted mb-0">{description}</p>
+        <Card.Section className="pl-0">
+          <h4 className="text-primary-700 mb-2">{title}</h4>
+          <p className="text-primary-500 mb-0">{description}</p>
         </Card.Section>
       </Card.Body>
       <Card.Footer className="d-flex align-items-center justify-content-end">
-        {customAction ?? (
+        {customAction ?? (buttonLabel && onButtonClick && (
           <Button
             onClick={onButtonClick}
             disabled={isLoading}
@@ -36,7 +36,7 @@ const ActionCard = ({
           >
             {buttonLabel}
           </Button>
-        )}
+        ))}
       </Card.Footer>
     </Card>
   );

--- a/src/components/PendingTasks.test.tsx
+++ b/src/components/PendingTasks.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
-import { PendingTasks } from './PendingTasks';
+import { PendingTasks } from '@src/components/PendingTasks';
+import messages from '@src/components/messages';
 import { usePendingTasks } from '@src/data/apiHook';
 import { renderWithQueryClient } from '@src/testUtils';
 
@@ -12,14 +13,14 @@ describe('PendingTasks', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should render the collapsible pending tasks section', () => {
     mockUsePendingTasks.mockReturnValue({
       data: undefined,
       isPending: false,
       isLoading: false,
     } as any);
-  });
-
-  it('should render the collapsible pending tasks section', () => {
     renderWithQueryClient(<PendingTasks />);
 
     expect(screen.getByText('Pending Tasks')).toBeInTheDocument();
@@ -37,9 +38,9 @@ describe('PendingTasks', () => {
     const toggleButton = screen.getByRole('button');
     await toggleButton.click();
 
-    expect(screen.queryByText('No tasks currently running.')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.noTasksMessage.defaultMessage)).not.toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
-    expect(screen.queryByText('Task Type')).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.taskTypeColumnName.defaultMessage)).not.toBeInTheDocument();
 
     const skeletons = container.querySelectorAll('.react-loading-skeleton');
     expect(skeletons).toHaveLength(3);
@@ -56,7 +57,7 @@ describe('PendingTasks', () => {
     const toggleButton = screen.getByRole('button');
     await toggleButton.click();
 
-    expect(screen.getByText('No tasks currently running.')).toBeInTheDocument();
+    expect(screen.getByText(messages.noTasksMessage.defaultMessage)).toBeInTheDocument();
   });
 
   it('should render data table with tasks when data is available', async () => {
@@ -85,13 +86,18 @@ describe('PendingTasks', () => {
     const toggleButton = screen.getByRole('button');
     await toggleButton.click();
 
-    expect(screen.getByText('Task Type')).toBeInTheDocument();
-    expect(screen.getByText('Task ID')).toBeInTheDocument();
+    expect(screen.getByText(messages.taskTypeColumnName.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.taskIdColumnName.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText('grade_course')).toBeInTheDocument();
     expect(screen.getByText('12345')).toBeInTheDocument();
   });
 
   it('should fetch tasks on component mount', async () => {
+    mockUsePendingTasks.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isLoading: false,
+    } as any);
     renderWithQueryClient(<PendingTasks />);
     expect(mockUsePendingTasks).toHaveBeenCalledTimes(1);
   });

--- a/src/components/PendingTasks.tsx
+++ b/src/components/PendingTasks.tsx
@@ -10,9 +10,11 @@ import { PendingTask, TableCellValue } from '@src/types';
 
 interface PendingTasksProps {
   isPolling?: boolean,
+  isOpen?: boolean,
+  onToggle?: () => void,
 }
 
-const PendingTasks = ({ isPolling = false }: PendingTasksProps) => {
+const PendingTasks = ({ isPolling = false, isOpen = false, onToggle }: PendingTasksProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
   const { data: tasks, isLoading } = usePendingTasks(courseId, { enablePolling: isPolling });
@@ -48,10 +50,13 @@ const PendingTasks = ({ isPolling = false }: PendingTasksProps) => {
     );
   };
 
+  const collapsibleProps = onToggle ? { open: isOpen, onToggle } : {};
+
   return (
     <Collapsible.Advanced
       className="mt-4 pt-4 border-top"
       styling="basic"
+      {...collapsibleProps}
     >
       <Collapsible.Trigger
         className="collapsible-trigger d-flex border-0 align-items-center text-decoration-none"

--- a/src/components/SpecifyLearnerField.test.tsx
+++ b/src/components/SpecifyLearnerField.test.tsx
@@ -23,7 +23,7 @@ describe('SpecifyLearnerField', () => {
       (useCourseInfo as jest.Mock).mockReturnValue({ data: { permissions: { admin: true, dataResearcher: false } } });
       (useLearner as jest.Mock).mockReturnValue({
         data: mockLearnerData,
-        refetch: jest.fn(),
+        refetch: jest.fn().mockResolvedValue({ data: mockLearnerData }),
         error: null,
       });
     });
@@ -76,7 +76,7 @@ describe('SpecifyLearnerField', () => {
       (useCourseInfo as jest.Mock).mockReturnValue({ data: { permissions: { admin: true, dataResearcher: false } } });
       (useLearner as jest.Mock).mockReturnValue({
         data: {},
-        refetch: jest.fn(),
+        refetch: jest.fn().mockResolvedValue({ data: {} }),
         error: { isAxiosError: true, response: { status: 404 } },
       });
     });

--- a/src/components/SpecifyLearnerField.tsx
+++ b/src/components/SpecifyLearnerField.tsx
@@ -39,9 +39,13 @@ const SpecifyLearnerField = ({ learner, onClickSelect }: SpecifyLearnerFieldProp
 
   const handleClickSelect = () => {
     if (inputValue) {
-      onClickSelect(inputValue);
-      refetch();
-      enableShowLearner();
+      refetch().then((result) => {
+        // Need to pass empty value if learner is not valid to clear out any previously selected learner
+        // We could have other conditions/fields depending on valid learner
+        const formValue = !result.error ? inputValue : '';
+        onClickSelect(formValue);
+        enableShowLearner();
+      });
     }
   };
 

--- a/src/components/SpecifyLearnerField.tsx
+++ b/src/components/SpecifyLearnerField.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent } from 'react';
+import { useState, ChangeEvent, useImperativeHandle, forwardRef } from 'react';
 import { isAxiosError } from 'axios';
 import { useParams } from 'react-router-dom';
 import { Avatar, Button, FormControl, FormGroup, FormLabel, useToggle } from '@openedx/paragon';
@@ -14,18 +14,29 @@ interface SpecifyLearnerFieldProps {
   onClickSelect: (emailOrUsername: string) => void,
 }
 
-const SpecifyLearnerField = ({ learner, onClickSelect }: SpecifyLearnerFieldProps) => {
+interface SpecifyLearnerFieldRef {
+  reset: () => void,
+}
+
+const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFieldProps>(({ learner, onClickSelect }, ref) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [identifier, setIdentifier] = useState('');
   const [showLearner, enableShowLearner, disableShowLearner] = useToggle(false);
   const { data: courseInfo } = useCourseInfo(courseId);
   const permissions = courseInfo?.permissions || { admin: false, dataResearcher: false };
-  const { inputValue, handleChange } = useDebouncedFilter({
+  const { inputValue, handleChange, resetFilter } = useDebouncedFilter({
     filterValue: identifier,
     setFilter: setIdentifier,
   });
   const { data = { email: '', fullName: '', username: '' }, refetch, error } = useLearner(courseId, inputValue);
+
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      resetFilter();
+      disableShowLearner();
+    }
+  }));
 
   const selectedLearner = learner || data;
 
@@ -90,6 +101,8 @@ const SpecifyLearnerField = ({ learner, onClickSelect }: SpecifyLearnerFieldProp
       )}
     </FormGroup>
   );
-};
+});
+
+SpecifyLearnerField.displayName = 'SpecifyLearnerField';
 
 export default SpecifyLearnerField;

--- a/src/components/SpecifyProblem.tsx
+++ b/src/components/SpecifyProblem.tsx
@@ -1,5 +1,0 @@
-const SpecifyProblem = () => {
-  return <div>Specify Problem</div>;
-};
-
-export default SpecifyProblem;

--- a/src/components/SpecifyProblemField.test.tsx
+++ b/src/components/SpecifyProblemField.test.tsx
@@ -42,6 +42,7 @@ describe('SpecifyProblemField', () => {
     mockUseDebouncedFilter.mockReturnValue({
       inputValue: '',
       handleChange: jest.fn(),
+      resetFilter: jest.fn(),
     });
 
     mockUseProblemDetails.mockReturnValue({
@@ -73,11 +74,12 @@ describe('SpecifyProblemField', () => {
   it('calls onClickSelect when select button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnClickSelect = jest.fn();
-    const mockRefetch = jest.fn();
+    const mockRefetch = jest.fn().mockResolvedValue({ data: mockProblemData });
 
     mockUseDebouncedFilter.mockReturnValue({
       inputValue: 'test-problem-id',
       handleChange: jest.fn(),
+      resetFilter: jest.fn(),
     });
 
     mockUseProblemDetails.mockReturnValue({
@@ -103,6 +105,7 @@ describe('SpecifyProblemField', () => {
     mockUseDebouncedFilter.mockReturnValue({
       inputValue: '',
       handleChange: jest.fn(),
+      resetFilter: jest.fn(),
     });
 
     renderWithIntl(<SpecifyProblemField {...defaultProps} />);
@@ -115,6 +118,7 @@ describe('SpecifyProblemField', () => {
     mockUseDebouncedFilter.mockReturnValue({
       inputValue: 'test-problem-id',
       handleChange: jest.fn(),
+      resetFilter: jest.fn(),
     });
 
     renderWithIntl(
@@ -148,6 +152,7 @@ describe('SpecifyProblemField', () => {
     mockUseDebouncedFilter.mockReturnValue({
       inputValue: 'test',
       handleChange: mockHandleChange,
+      resetFilter: jest.fn(),
     });
 
     renderWithIntl(<SpecifyProblemField {...defaultProps} />);

--- a/src/components/SpecifyProblemField.test.tsx
+++ b/src/components/SpecifyProblemField.test.tsx
@@ -1,0 +1,216 @@
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SpecifyProblemField from '@src/components/SpecifyProblemField';
+import messages from '@src/components/messages';
+import { useProblemDetails } from '@src/data/apiHook';
+import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
+import { renderWithIntl } from '@src/testUtils';
+
+// Mock dependencies
+jest.mock('@src/data/apiHook');
+jest.mock('@src/hooks/useDebouncedFilter');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'test-course-id' }),
+}));
+
+const mockUseProblemDetails = useProblemDetails as jest.MockedFunction<typeof useProblemDetails>;
+const mockUseDebouncedFilter = useDebouncedFilter as jest.MockedFunction<typeof useDebouncedFilter>;
+
+const defaultProps = {
+  buttonLabel: 'Select Problem',
+  fieldLabel: 'Problem Location:',
+  usernameOrEmail: 'testuser@example.com',
+  onClickSelect: jest.fn(),
+};
+
+const mockProblemData = {
+  breadcrumbs: [
+    { displayName: 'Course' },
+    { displayName: 'Chapter 1' },
+    { displayName: 'Section A' },
+    { displayName: 'Problem 1' },
+  ],
+  name: 'Math Problem',
+  id: 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+};
+
+describe('SpecifyProblemField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseDebouncedFilter.mockReturnValue({
+      inputValue: '',
+      handleChange: jest.fn(),
+    });
+
+    mockUseProblemDetails.mockReturnValue({
+      data: { breadcrumbs: [], name: '', id: '' },
+      refetch: jest.fn(),
+    } as any);
+  });
+
+  it('renders correctly with required props', () => {
+    renderWithIntl(<SpecifyProblemField {...defaultProps} />);
+
+    expect(screen.getByText('Problem Location:')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select Problem' })).toBeInTheDocument();
+  });
+
+  it('displays tooltip when hovering over info icon', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<SpecifyProblemField {...defaultProps} />);
+
+    const infoIcon = screen.getByLabelText('Example format for problem location');
+    await user.hover(infoIcon);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.problemLocationTooltip.defaultMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClickSelect when select button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnClickSelect = jest.fn();
+    const mockRefetch = jest.fn();
+
+    mockUseDebouncedFilter.mockReturnValue({
+      inputValue: 'test-problem-id',
+      handleChange: jest.fn(),
+    });
+
+    mockUseProblemDetails.mockReturnValue({
+      data: mockProblemData,
+      refetch: mockRefetch,
+    } as any);
+
+    renderWithIntl(
+      <SpecifyProblemField
+        {...defaultProps}
+        onClickSelect={mockOnClickSelect}
+      />
+    );
+
+    const selectButton = screen.getByRole('button', { name: 'Select Problem' });
+    await user.click(selectButton);
+
+    expect(mockRefetch).toHaveBeenCalled();
+    expect(mockOnClickSelect).toHaveBeenCalledWith('test-problem-id', expect.any(Object));
+  });
+
+  it('disables select button when inputValue is empty', () => {
+    mockUseDebouncedFilter.mockReturnValue({
+      inputValue: '',
+      handleChange: jest.fn(),
+    });
+
+    renderWithIntl(<SpecifyProblemField {...defaultProps} />);
+
+    const selectButton = screen.getByRole('button', { name: 'Select Problem' });
+    expect(selectButton).toBeDisabled();
+  });
+
+  it('disables select button when disabled prop is true', () => {
+    mockUseDebouncedFilter.mockReturnValue({
+      inputValue: 'test-problem-id',
+      handleChange: jest.fn(),
+    });
+
+    renderWithIntl(
+      <SpecifyProblemField
+        {...defaultProps}
+        disabled={true}
+      />
+    );
+
+    const selectButton = screen.getByRole('button', { name: 'Select Problem' });
+    expect(selectButton).toBeDisabled();
+  });
+
+  it('displays error message when problemResponsesError is provided', () => {
+    const errorMessage = 'Invalid problem location';
+
+    renderWithIntl(
+      <SpecifyProblemField
+        {...defaultProps}
+        problemResponsesError={errorMessage}
+      />
+    );
+
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it('calls handleChange when input value changes', async () => {
+    const user = userEvent.setup();
+    const mockHandleChange = jest.fn();
+
+    mockUseDebouncedFilter.mockReturnValue({
+      inputValue: 'test',
+      handleChange: mockHandleChange,
+    });
+
+    renderWithIntl(<SpecifyProblemField {...defaultProps} />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'new-value');
+
+    // Note: Due to mocking, we can't test the actual onChange handler directly,
+    // but we can verify that the input receives user input
+    expect(input).toBeInTheDocument();
+  });
+
+  it('displays breadcrumbs correctly in selected state', () => {
+    mockUseProblemDetails.mockReturnValue({
+      data: mockProblemData,
+      refetch: jest.fn(),
+    } as any);
+
+    // Mock the component in selected state
+    const SelectedStateComponent = () => {
+      const data = mockProblemData;
+      return (
+        <div>
+          <p>
+            {data.breadcrumbs
+              .slice(1, -1)
+              .map(breadcrumb => breadcrumb.displayName)
+              .join(' > ')}
+          </p>
+          <p>{data.name}</p>
+          <p>{data.id}</p>
+        </div>
+      );
+    };
+
+    render(<SelectedStateComponent />);
+
+    expect(screen.getByText('Chapter 1 > Section A')).toBeInTheDocument();
+    expect(screen.getByText('Math Problem')).toBeInTheDocument();
+    expect(screen.getByText(mockProblemData.id)).toBeInTheDocument();
+  });
+
+  it('uses correct placeholder text', () => {
+    renderWithIntl(<SpecifyProblemField {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(messages.problemLocationPlaceholder.defaultMessage);
+    expect(input).toBeInTheDocument();
+  });
+
+  it('passes usernameOrEmail to useProblemDetails hook', () => {
+    const testUsername = 'testuser@example.com';
+
+    renderWithIntl(
+      <SpecifyProblemField
+        {...defaultProps}
+        usernameOrEmail={testUsername}
+      />
+    );
+
+    expect(mockUseProblemDetails).toHaveBeenCalledWith(
+      'test-course-id',
+      '',
+      testUsername
+    );
+  });
+});

--- a/src/components/SpecifyProblemField.tsx
+++ b/src/components/SpecifyProblemField.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useImperativeHandle, forwardRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button, Form, Icon, OverlayTrigger, Tooltip, useToggle } from '@openedx/paragon';
 import { InfoOutline, SpinnerIcon } from '@openedx/paragon/icons';
@@ -16,24 +16,35 @@ interface SpecifyProblemFieldProps {
   onClickSelect: (problemLocation: string, event: React.MouseEvent<HTMLButtonElement>) => void,
 }
 
-const SpecifyProblemField = ({
+interface SpecifyProblemFieldRef {
+  reset: () => void,
+}
+
+const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFieldProps>(({
   buttonLabel,
   disabled,
   fieldLabel,
   problemResponsesError,
   usernameOrEmail = '',
   onClickSelect,
-}: SpecifyProblemFieldProps) => {
+}, ref) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [problemLocation, setProblemLocation] = useState('');
   const [showSelectedLocation, enableShowSelectedLocation, disableShowSelectedLocation] = useToggle(false);
 
-  const { inputValue, handleChange } = useDebouncedFilter({
+  const { inputValue, handleChange, resetFilter } = useDebouncedFilter({
     filterValue: problemLocation,
     setFilter: setProblemLocation,
   });
   const { data = { breadcrumbs: [], name: '', id: '' }, refetch } = useProblemDetails(courseId, inputValue, usernameOrEmail);
+
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      resetFilter();
+      disableShowSelectedLocation();
+    }
+  }));
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     handleChange(e.target.value);
@@ -112,6 +123,8 @@ const SpecifyProblemField = ({
       </div>
     </Form.Group>
   );
-};
+});
+
+SpecifyProblemField.displayName = 'SpecifyProblemField';
 
 export default SpecifyProblemField;

--- a/src/components/SpecifyProblemField.tsx
+++ b/src/components/SpecifyProblemField.tsx
@@ -55,9 +55,10 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
   };
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    refetch();
-    onClickSelect(inputValue, event);
-    enableShowSelectedLocation();
+    refetch().then(() => {
+      onClickSelect(inputValue, event);
+      enableShowSelectedLocation();
+    });
   };
 
   return (

--- a/src/components/SpecifyProblemField.tsx
+++ b/src/components/SpecifyProblemField.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Button, Form, Icon, OverlayTrigger, Tooltip, useToggle } from '@openedx/paragon';
+import { InfoOutline, SpinnerIcon } from '@openedx/paragon/icons';
+import { useIntl } from '@openedx/frontend-base';
+import messages from './messages';
+import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
+import { useProblemDetails } from '@src/data/apiHook';
+
+interface SpecifyProblemFieldProps {
+  buttonLabel: string,
+  disabled?: boolean,
+  fieldLabel: string,
+  problemResponsesError?: string,
+  usernameOrEmail?: string,
+  onClickSelect: (problemLocation: string, event: React.MouseEvent<HTMLButtonElement>) => void,
+}
+
+const SpecifyProblemField = ({
+  buttonLabel,
+  disabled,
+  fieldLabel,
+  problemResponsesError,
+  usernameOrEmail = '',
+  onClickSelect,
+}: SpecifyProblemFieldProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const [problemLocation, setProblemLocation] = useState('');
+  const [showSelectedLocation, enableShowSelectedLocation, disableShowSelectedLocation] = useToggle(false);
+
+  const { inputValue, handleChange } = useDebouncedFilter({
+    filterValue: problemLocation,
+    setFilter: setProblemLocation,
+  });
+  const { data = { breadcrumbs: [], name: '', id: '' }, refetch } = useProblemDetails(courseId, inputValue, usernameOrEmail);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleChange(e.target.value);
+
+    if (showSelectedLocation) {
+      disableShowSelectedLocation();
+    }
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    refetch();
+    onClickSelect(inputValue, event);
+    enableShowSelectedLocation();
+  };
+
+  return (
+    <Form.Group className="mb-0" isInvalid={!!problemResponsesError} size="sm">
+      <Form.Label className="d-flex align-content-end align-items-center gap-2 text-primary-500">
+        {showSelectedLocation ? intl.formatMessage(messages.selectedProblem)
+          : (
+              <>
+                {fieldLabel}
+                <OverlayTrigger
+                  placement="top"
+                  overlay={(
+                    <Tooltip id="problem-location-tooltip" className="info-tooltip">
+                      {intl.formatMessage(messages.problemLocationTooltip)}
+                    </Tooltip>
+                  )}
+                >
+                  <Icon src={InfoOutline} size="sm" aria-label={intl.formatMessage(messages.problemLocationInfoIconLabel)} />
+                </OverlayTrigger>
+              </>
+            )}
+      </Form.Label>
+      <div className="d-flex align-items-center">
+        {showSelectedLocation && data ? (
+          <div className="d-flex gap-3 align-items-center col-8 p-0">
+            <div className="d-block w-100">
+              <p className="x-small mb-0 text-primary-500 text-truncate">
+                {data.breadcrumbs
+                  .slice(1, -1)
+                  .map(breadcrumb => breadcrumb.displayName)
+                  .join(' > ')}
+              </p>
+              <p className="text-primary-500 mb-0">{data.name}</p>
+              <p className="x-small text-gray-700 text-truncate mb-0">{data.id}</p>
+            </div>
+            <Button iconBefore={SpinnerIcon} onClick={disableShowSelectedLocation}>{intl.formatMessage(messages.change)}</Button>
+          </div>
+        ) : (
+          <>
+            <Form.Control
+              type="text"
+              placeholder={intl.formatMessage(messages.problemLocationPlaceholder)}
+              value={inputValue}
+              onChange={handleInputChange}
+              className="flex-grow-1"
+              size="md"
+            />
+            {problemResponsesError && (
+              <Form.Control.Feedback type="invalid">
+                {problemResponsesError}
+              </Form.Control.Feedback>
+            )}
+            <Button
+              variant="primary"
+              onClick={handleClick}
+              disabled={disabled || !inputValue}
+              className="text-nowrap"
+            >
+              {buttonLabel}
+            </Button>
+          </>
+        )}
+      </div>
+    </Form.Group>
+  );
+};
+
+export default SpecifyProblemField;

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -120,6 +120,26 @@ const messages = defineMessages({
     id: 'instruct.usernameFilter.searchPlaceholder',
     defaultMessage: 'Search By Username or Email',
     description: 'Placeholder text for the username filter input',
+  },
+  problemLocationPlaceholder: {
+    id: 'instruct.specifyProblemField.locationPlaceholder',
+    defaultMessage: 'Problem location',
+    description: 'Placeholder text for problem location input',
+  },
+  problemLocationInfoIconLabel: {
+    id: 'instruct.specifyProblemField.infoIconLabel',
+    defaultMessage: 'Example format for problem location',
+    description: 'Aria label for the info icon next to the problem location input',
+  },
+  problemLocationTooltip: {
+    id: 'instruct.specifyProblemField.locationTooltip',
+    defaultMessage: 'Example: block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+    description: 'Tooltip text showing an example problem location format',
+  },
+  selectedProblem: {
+    id: 'instruct.specifyProblemField.selectedProblem',
+    defaultMessage: 'Selected Problem:',
+    description: 'Label for specify problem field when a problem has been selected',
   }
 });
 

--- a/src/data/api.test.ts
+++ b/src/data/api.test.ts
@@ -1,4 +1,4 @@
-import { getCourseInfo, getLearner } from './api';
+import { getCourseInfo, getLearner, getProblemDetails } from './api';
 import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { fetchPendingTasks } from './api';
 
@@ -13,15 +13,17 @@ const mockGetSiteConfig = getSiteConfig as jest.MockedFunction<typeof getSiteCon
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
+const mockHttpClient = {
+  get: jest.fn(),
+  post: jest.fn(),
+};
+
 describe('base api', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   describe('getCourseInfo', () => {
-    const mockHttpClient = {
-      get: jest.fn(),
-    };
     const mockCourseData = { course_name: 'Test Course' };
     const mockCamelCaseData = { courseName: 'Test Course' };
 
@@ -50,10 +52,6 @@ describe('base api', () => {
   });
 
   describe('fetchPendingTasks', () => {
-    const mockHttpClient = {
-      post: jest.fn(),
-    };
-
     beforeEach(() => {
       mockCamelCaseObject.mockImplementation((obj) => obj);
       (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://example.com' });
@@ -85,9 +83,6 @@ describe('base api', () => {
   });
 
   describe('getLearner', () => {
-    const mockHttpClient = {
-      get: jest.fn(),
-    };
     const mockLearnerData = { username: 'testuser', email: 'test@example.com', full_name: 'Test User' };
     const mockCamelCaseData = { username: 'testuser', email: 'test@example.com', fullName: 'Test User' };
 
@@ -112,6 +107,99 @@ describe('base api', () => {
       const error = new Error('Network error');
       mockHttpClient.get.mockRejectedValue(error);
       await expect(getLearner('course-v1:Test+Course+2025', 'testuser')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getProblemDetails', () => {
+    const mockProblemData = {
+      breadcrumbs: [
+        { display_name: 'Course' },
+        { display_name: 'Chapter 1' },
+        { display_name: 'Section A' },
+        { display_name: 'Problem 1' },
+      ],
+      name: 'Math Problem',
+      id: 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+    };
+    const mockCamelCaseData = {
+      breadcrumbs: [
+        { displayName: 'Course' },
+        { displayName: 'Chapter 1' },
+        { displayName: 'Section A' },
+        { displayName: 'Problem 1' },
+      ],
+      name: 'Math Problem',
+      id: 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+    };
+
+    beforeEach(() => {
+      (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
+      mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+      mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+      mockHttpClient.get.mockResolvedValue({ data: mockProblemData });
+    });
+
+    it('fetches problem details successfully with emailOrUsername parameter', async () => {
+      const courseId = 'course-v1:Test+Course+2025';
+      const blockId = 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378';
+      const emailOrUsername = 'testuser';
+
+      const result = await getProblemDetails(courseId, blockId, emailOrUsername);
+
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:Test+Course+2025/problems/block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+        { params: { email_or_username: emailOrUsername } }
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockProblemData);
+      expect(result).toBe(mockCamelCaseData);
+    });
+
+    it('fetches problem details successfully without emailOrUsername parameter', async () => {
+      const courseId = 'course-v1:Test+Course+2025';
+      const blockId = 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378';
+
+      const result = await getProblemDetails(courseId, blockId);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:Test+Course+2025/problems/block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378',
+        { params: { email_or_username: undefined } }
+      );
+      expect(result).toBe(mockCamelCaseData);
+    });
+
+    it('handles empty emailOrUsername parameter', async () => {
+      const courseId = 'course-v1:Test+Course+2025';
+      const blockId = 'block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378';
+
+      const result = await getProblemDetails(courseId, blockId, '');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        expect.any(String),
+        { params: { email_or_username: '' } }
+      );
+      expect(result).toBe(mockCamelCaseData);
+    });
+
+    it('throws error when API call fails', async () => {
+      const error = new Error('Problem not found');
+      mockHttpClient.get.mockRejectedValue(error);
+
+      await expect(
+        getProblemDetails('course-v1:Test+Course+2025', 'invalid-block-id')
+      ).rejects.toThrow('Problem not found');
+    });
+
+    it('handles special characters in blockId correctly', async () => {
+      const courseId = 'course-v1:Test+Course+2025';
+      const blockId = 'block-v1:edX+DemoX+2015+type@problem+block@special%20chars&symbols';
+
+      await getProblemDetails(courseId, blockId);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        `https://test-lms.com/api/instructor/v2/courses/${courseId}/problems/${blockId}`,
+        { params: { email_or_username: undefined } }
+      );
     });
   });
 });

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -38,3 +38,11 @@ export const getLearner = async (courseId: string, emailOrUsername: string): Pro
     .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/learners/${emailOrUsername}`);
   return camelCaseObject(data);
 };
+
+export const getProblemDetails = async (courseId: string, blockId: string, emailOrUsername?: string) => {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/problems/${blockId}`, {
+      params: { email_or_username: emailOrUsername },
+    });
+  return camelCaseObject(data);
+};

--- a/src/data/apiHook.ts
+++ b/src/data/apiHook.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchPendingTasks, getCourseInfo, getLearner } from './api';
-import { courseInfoQueryKeys, learnerQueryKeys, pendingTasksQueryKey } from './queryKeys';
+import { fetchPendingTasks, getCourseInfo, getLearner, getProblemDetails } from './api';
+import { courseInfoQueryKeys, learnerQueryKeys, pendingTasksQueryKey, problemQueryKeys } from './queryKeys';
 
 export const useCourseInfo = (courseId: string) => (
   useQuery({
@@ -25,6 +25,16 @@ export const useLearner = (courseId: string, emailOrUsername: string) => (
   useQuery({
     queryKey: learnerQueryKeys.byCourseAndLearner(courseId, emailOrUsername),
     queryFn: () => getLearner(courseId, emailOrUsername),
+    enabled: false,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  }));
+
+export const useProblemDetails = (courseId: string, blockId: string, emailOrUsername: string) => (
+  useQuery({
+    queryKey: problemQueryKeys.byCourseAndLearner(courseId, blockId, emailOrUsername),
+    queryFn: () => getProblemDetails(courseId, blockId, emailOrUsername),
     enabled: false,
     retry: false,
     refetchOnWindowFocus: false,

--- a/src/data/queryKeys.ts
+++ b/src/data/queryKeys.ts
@@ -14,3 +14,8 @@ export const learnerQueryKeys = {
   all: [appId, 'learner'] as const,
   byCourseAndLearner: (courseId: string, emailOrUsername: string) => [appId, 'learner', courseId, emailOrUsername] as const,
 };
+
+export const problemQueryKeys = {
+  all: [appId, 'problemDetails'] as const,
+  byCourseAndLearner: (courseId: string, blockId: string, emailOrUsername: string) => [appId, 'problemDetails', courseId, blockId, emailOrUsername] as const,
+};

--- a/src/dateExtensions/components/AddExtensionModal.test.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.test.tsx
@@ -73,7 +73,6 @@ describe('AddExtensionModal', () => {
     await user.type(learnerInput, 'testuser');
     const selectButton = screen.getByRole('button', { name: /select/i });
     await waitFor(() => expect(selectButton).not.toBeDisabled());
-    screen.debug();
     await user.click(selectButton);
     await user.selectOptions(blockInput, 'sub1');
     await user.type(dueDateInput, '2024-12-31');

--- a/src/dateExtensions/components/AddExtensionModal.test.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import AddExtensionModal from './AddExtensionModal';
 import { renderWithQueryClient } from '@src/testUtils';
 import messages from '../messages';
+import { useLearner } from '@src/data/apiHook';
 
 const mockProps = {
   isOpen: true,
@@ -16,13 +17,29 @@ const items = [
   { displayName: 'Quiz 2', subsectionId: 'sub2' },
 ];
 
-jest.mock('../data/apiHook', () => ({
+const mockLearnerData = {
+  username: 'testuser',
+  fullName: 'Test User',
+  email: 'test@email.com',
+};
+
+jest.mock('@src/data/apiHook', () => ({
+  useLearner: jest.fn(),
+  useCourseInfo: jest.fn().mockReturnValue({ data: { permissions: { admin: true, dataResearcher: false } } }),
+}));
+
+jest.mock('@src/dateExtensions/data/apiHook', () => ({
   useGradedSubsections: jest.fn().mockReturnValue({ data: { items } }),
 }));
 
 describe('AddExtensionModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useLearner as jest.Mock).mockReturnValue({
+      data: mockLearnerData,
+      refetch: jest.fn().mockResolvedValue({ data: mockLearnerData }),
+      error: null,
+    });
   });
 
   it('renders modal when isOpen is true', () => {
@@ -47,20 +64,24 @@ describe('AddExtensionModal', () => {
     const user = userEvent.setup();
 
     const learnerInput = screen.getByLabelText(/Specify Learner/i);
-    const blockInput = screen.getByRole('combobox');
+    const blockInput = screen.getByRole('combobox', { name: /Select Graded Subsection/i });
     const dueDateInput = screen.getByLabelText(messages.extensionDate.defaultMessage + ':');
     const dueTimeInput = document.querySelector('input[type="time"]') as HTMLInputElement;
     const reasonInput = screen.getByPlaceholderText(messages.reasonForExtension.defaultMessage);
 
+    await user.clear(learnerInput);
     await user.type(learnerInput, 'testuser');
-    await user.click(screen.getByRole('button', { name: /select/i }));
+    const selectButton = screen.getByRole('button', { name: /select/i });
+    await waitFor(() => expect(selectButton).not.toBeDisabled());
+    screen.debug();
+    await user.click(selectButton);
     await user.selectOptions(blockInput, 'sub1');
     await user.type(dueDateInput, '2024-12-31');
     await user.type(dueTimeInput, '23:59');
     await user.type(reasonInput, 'Medical emergency');
 
     const submitButton = screen.getByRole('button', { name: messages.addExtension.defaultMessage });
-    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    await waitFor(() => expect(submitButton).not.toBeDisabled(), { timeout: 2000 });
 
     await user.click(submitButton);
 

--- a/src/grading/GradingPage.tsx
+++ b/src/grading/GradingPage.tsx
@@ -10,6 +10,11 @@ import { GradingToolsType } from '@src/grading/types';
 const GradingPage = () => {
   const intl = useIntl();
   const [selectedTools, setSelectedTools] = useState<GradingToolsType>('single');
+  const [isPendingTasksOpen, setIsPendingTasksOpen] = useState(false);
+
+  const handleOpenPendingTasks = () => {
+    setIsPendingTasksOpen(true);
+  };
 
   return (
     <>
@@ -32,9 +37,9 @@ const GradingPage = () => {
             {intl.formatMessage(messages.allLearners)}
           </Button>
         </ButtonGroup>
-        <GradingLearnerContent toolType={selectedTools} />
+        <GradingLearnerContent toolType={selectedTools} onShowTasks={handleOpenPendingTasks} />
       </Card>
-      <PendingTasks />
+      <PendingTasks isOpen={isPendingTasksOpen} onToggle={() => setIsPendingTasksOpen(prev => !prev)} />
     </>
   );
 };

--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -1,0 +1,307 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GradingLearnerContent from '@src/grading/components/GradingLearnerContent';
+import { useChangeScore, useDeleteHistory, useRescoreSubmission, useResetAttempts } from '@src/grading/data/apiHook';
+import { usePendingTasks } from '@src/data/apiHook';
+import messages from '@src/grading/messages';
+import { renderWithIntl } from '@src/testUtils';
+
+// Mock dependencies
+jest.mock('@src/grading/data/apiHook');
+jest.mock('@src/data/apiHook');
+jest.mock('@src/components/SpecifyLearnerField', () => ({
+  __esModule: true,
+  default: ({ onClickSelect }: { onClickSelect: (value: string) => void }) => (
+    <div data-testid="specify-learner-field">
+      <button onClick={() => onClickSelect('testuser@example.com')}>
+        Select Learner
+      </button>
+    </div>
+  ),
+}));
+jest.mock('@src/components/SpecifyProblemField', () => ({
+  __esModule: true,
+  default: ({ onClickSelect, disabled }: { onClickSelect: (value: string, event: React.MouseEvent<HTMLButtonElement>) => void, disabled?: boolean }) => (
+    <div data-testid="specify-problem-field">
+      <button
+        onClick={(event) => onClickSelect('block-v1:test+problem', event)}
+        disabled={disabled}
+      >
+        Select Problem
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'test-course-id' }),
+}));
+
+const mockUseResetAttempts = useResetAttempts as jest.MockedFunction<typeof useResetAttempts>;
+const mockUseDeleteHistory = useDeleteHistory as jest.MockedFunction<typeof useDeleteHistory>;
+const mockUseChangeScore = useChangeScore as jest.MockedFunction<typeof useChangeScore>;
+const mockUseRescoreSubmission = useRescoreSubmission as jest.MockedFunction<typeof useRescoreSubmission>;
+const mockUsePendingTasks = usePendingTasks as jest.MockedFunction<typeof usePendingTasks>;
+
+const defaultProps = {
+  toolType: 'single' as const,
+  onShowTasks: jest.fn(),
+};
+
+describe('GradingLearnerContent', () => {
+  const mockMutateReset = jest.fn();
+  const mockMutateDelete = jest.fn();
+  const mockMutateChangeScore = jest.fn();
+  const mockMutateRescore = jest.fn();
+  const mockRefetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseResetAttempts.mockReturnValue({ mutate: mockMutateReset } as any);
+    mockUseDeleteHistory.mockReturnValue({ mutate: mockMutateDelete } as any);
+    mockUseChangeScore.mockReturnValue({ mutate: mockMutateChangeScore } as any);
+    mockUseRescoreSubmission.mockReturnValue({ mutate: mockMutateRescore } as any);
+    mockUsePendingTasks.mockReturnValue({ refetch: mockRefetch } as any);
+  });
+
+  it('renders correctly for single learner mode', () => {
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    expect(screen.getByText(messages.descriptionSingleLearner.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByTestId('specify-learner-field')).toBeInTheDocument();
+    expect(screen.getByTestId('specify-problem-field')).toBeInTheDocument();
+
+    // Check that all action cards are rendered
+    expect(screen.getByText(messages.resetAttempts.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.rescoreSubmission.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.overrideScore.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.deleteHistory.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.taskStatus.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders correctly for all learners mode', () => {
+    renderWithIntl(
+      <GradingLearnerContent
+        {...defaultProps}
+        toolType="all"
+      />
+    );
+
+    expect(screen.getByText(messages.descriptionAllLearners.defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByTestId('specify-learner-field')).not.toBeInTheDocument();
+    expect(screen.getByTestId('specify-problem-field')).toBeInTheDocument();
+  });
+
+  it('handles learner selection correctly', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    const selectLearnerButton = screen.getByText('Select Learner');
+    await user.click(selectLearnerButton);
+
+    // The problem field should now be enabled
+    const selectProblemButton = screen.getByText('Select Problem');
+    expect(selectProblemButton).not.toBeDisabled();
+  });
+
+  it('handles problem selection correctly', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // First select learner
+    const selectLearnerButton = screen.getByText('Select Learner');
+    await user.click(selectLearnerButton);
+
+    // Then select problem
+    const selectProblemButton = screen.getByText('Select Problem');
+    await user.click(selectProblemButton);
+
+    // Action buttons should now be enabled
+    const resetButton = screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0];
+    expect(resetButton).not.toBeDisabled();
+  });
+
+  it('calls reset attempts when button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Click reset attempts button
+    const resetButton = screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0];
+    await user.click(resetButton);
+
+    expect(mockMutateReset).toHaveBeenCalledWith({
+      learner: 'testuser@example.com',
+      problem: 'block-v1:test+problem',
+    });
+  });
+
+  it('calls rescore submission when button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Click rescore submission button
+    const rescoreButton = screen.getByText(messages.rescoreSubmissionButtonLabel.defaultMessage);
+    await user.click(rescoreButton);
+
+    expect(mockMutateRescore).toHaveBeenCalledWith({
+      learner: 'testuser@example.com',
+      problem: 'block-v1:test+problem',
+      onlyIfHigher: false,
+    });
+  });
+
+  it('calls rescore submission with onlyIfHigher when "only if improves" button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Click rescore if improves button
+    const rescoreIfImprovesButton = screen.getByText(messages.rescoreIfImprovesScoreButtonLabel.defaultMessage);
+    await user.click(rescoreIfImprovesButton);
+
+    expect(mockMutateRescore).toHaveBeenCalledWith({
+      learner: 'testuser@example.com',
+      problem: 'block-v1:test+problem',
+      onlyIfHigher: true,
+    });
+  });
+
+  it('handles score input correctly', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Find the score input field
+    const scoreInput = screen.getByPlaceholderText(messages.overrideScorePlaceholder.defaultMessage);
+    expect(scoreInput).toBeInTheDocument();
+
+    // Type a valid score
+    await user.type(scoreInput, '85.5');
+
+    // Click override score button
+    const overrideButton = screen.getByText(messages.overrideScoreButtonLabel.defaultMessage);
+    await user.click(overrideButton);
+
+    expect(mockMutateChangeScore).toHaveBeenCalledWith({
+      learner: 'testuser@example.com',
+      problem: 'block-v1:test+problem',
+      newScore: 85.5,
+    });
+  });
+
+  it('validates score input to only allow numeric values', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Find the score input field using placeholder text
+    const scoreInput = screen.getByPlaceholderText(messages.overrideScorePlaceholder.defaultMessage) as HTMLInputElement;
+    screen.debug(scoreInput);
+    // Try to type invalid characters
+    await user.type(scoreInput, 'abc');
+    expect(scoreInput.value).toBe('');
+
+    // Try valid numeric input
+    await user.type(scoreInput, '123.45');
+    expect(scoreInput).toHaveValue(123.45);
+
+    // Try negative number
+    await user.clear(scoreInput);
+    await user.type(scoreInput, '-10.5');
+    expect(scoreInput).toHaveValue(-10.5);
+  });
+
+  it('calls delete history when button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Click delete history button
+    const deleteButton = screen.getByText(messages.deleteHistoryButtonLabel.defaultMessage);
+    await user.click(deleteButton);
+
+    expect(mockMutateDelete).toHaveBeenCalledWith({
+      learner: 'testuser@example.com',
+      problem: 'block-v1:test+problem',
+    });
+  });
+
+  it('calls onShowTasks and refetches when task status button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnShowTasks = jest.fn();
+
+    renderWithIntl(
+      <GradingLearnerContent
+        {...defaultProps}
+        onShowTasks={mockOnShowTasks}
+      />
+    );
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    // Click task status button
+    const taskStatusButton = screen.getByText(messages.taskStatusButtonLabel.defaultMessage);
+    await user.click(taskStatusButton);
+
+    expect(mockRefetch).toHaveBeenCalled();
+    expect(mockOnShowTasks).toHaveBeenCalled();
+  });
+
+  it('disables problem selection when no learner is selected in single mode', () => {
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    const selectProblemButton = screen.getByText('Select Problem');
+    expect(selectProblemButton).toBeDisabled();
+  });
+
+  it('disables action buttons when learner or problem is not selected', () => {
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    const resetButtons = screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
+    const rescoreButton = screen.getByRole('button', { name: messages.rescoreSubmissionButtonLabel.defaultMessage });
+    const deleteButton = screen.getByRole('button', { name: messages.deleteHistoryButtonLabel.defaultMessage });
+    const taskStatusButton = screen.getByRole('button', { name: messages.taskStatusButtonLabel.defaultMessage });
+
+    expect(resetButtons[0]).toBeDisabled();
+    expect(resetButtons[1]).toBeDisabled();
+    expect(rescoreButton).toBeDisabled();
+    expect(deleteButton).toBeDisabled();
+    expect(taskStatusButton).toBeDisabled();
+  });
+
+  it('disables override score button when no score is entered', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+
+    // Select learner and problem first
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+
+    const overrideButton = screen.getByText(messages.overrideScoreButtonLabel.defaultMessage);
+    expect(overrideButton).toBeDisabled();
+  });
+});

--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -215,7 +215,7 @@ describe('GradingLearnerContent', () => {
 
     // Find the score input field using placeholder text
     const scoreInput = screen.getByPlaceholderText(messages.overrideScorePlaceholder.defaultMessage) as HTMLInputElement;
-    screen.debug(scoreInput);
+
     // Try to type invalid characters
     await user.type(scoreInput, 'abc');
     expect(scoreInput.value).toBe('');

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -91,6 +91,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       customAction: (
         <div className="d-flex align-items-center gap-2">
           <FormControl
+            name={intl.formatMessage(messages.overrideScorePlaceholder)}
             type="number"
             placeholder={intl.formatMessage(messages.overrideScorePlaceholder)}
             value={score}

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -1,14 +1,137 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
-import SpecifyProblem from '@src/components/SpecifyProblem';
+import { Button, FormControl } from '@openedx/paragon';
+import ActionCard, { ActionCardProps } from '@src/components/ActionCard';
+import SpecifyLearnerField from '@src/components/SpecifyLearnerField';
+import SpecifyProblemField from '@src/components/SpecifyProblemField';
+import { useChangeScore, useDeleteHistory, useRescoreSubmission, useResetAttempts } from '@src/grading/data/apiHook';
 import messages from '@src/grading/messages';
 import { GradingToolsType } from '@src/grading/types';
+import { usePendingTasks } from '@src/data/apiHook';
 
 interface GradingLearnerContentProps {
   toolType: GradingToolsType,
+  onShowTasks: () => void,
 }
 
-const GradingLearnerContent = ({ toolType }: GradingLearnerContentProps) => {
+const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentProps) => {
   const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const [usernameOrEmail, setUsernameOrEmail] = useState('');
+  const [blockId, setBlockId] = useState('');
+  const [score, setScore] = useState('');
+  const { mutate: resetAttempts } = useResetAttempts(courseId);
+  const { mutate: deleteHistory } = useDeleteHistory(courseId);
+  const { mutate: changeScore } = useChangeScore(courseId);
+  const { mutate: rescoreSubmission } = useRescoreSubmission(courseId);
+  const { refetch: refetchTasks } = usePendingTasks(courseId);
+
+  const handleResetAttempts = (): void => {
+    resetAttempts({ learner: usernameOrEmail, problem: blockId });
+  };
+
+  const handleRescoreSubmission = (onlyIfHigher = false): void => {
+    rescoreSubmission({ learner: usernameOrEmail, problem: blockId, onlyIfHigher });
+  };
+
+  const handleDeleteHistory = (): void => {
+    deleteHistory({ learner: usernameOrEmail, problem: blockId });
+  };
+
+  const handleOverrideScore = (): void => {
+    changeScore({ learner: usernameOrEmail, problem: blockId, newScore: Number(score) });
+  };
+
+  const handleScoreChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const value = e.target.value;
+    const numericRegex = /^-?\d*\.?\d*$/;
+
+    if (numericRegex.test(value) || value === '') {
+      setScore(value);
+    }
+  };
+
+  const handleTaskStatusClick = (): void => {
+    refetchTasks();
+    onShowTasks();
+  };
+
+  useEffect(() => {
+    if (toolType === 'all') {
+      setUsernameOrEmail('');
+    }
+    setBlockId('');
+  }, [toolType]);
+
+  const singleLearnerActionRows: ActionCardProps[] = [
+    {
+      title: intl.formatMessage(messages.resetAttempts),
+      description: intl.formatMessage(messages.resetAttemptsDescription),
+      customAction: (
+        <Button disabled={!usernameOrEmail || !blockId} onClick={handleResetAttempts}>
+          {intl.formatMessage(messages.resetAttemptsButtonLabel)}
+        </Button>
+      )
+    },
+    {
+      title: intl.formatMessage(messages.rescoreSubmission),
+      description: intl.formatMessage(messages.rescoreSubmissionDescription),
+      customAction: (
+        <div className="d-flex flex-column gap-3">
+          <Button disabled={!usernameOrEmail || !blockId} onClick={() => handleRescoreSubmission()}>{intl.formatMessage(messages.rescoreSubmissionButtonLabel)}</Button>
+          <Button disabled={!usernameOrEmail || !blockId} onClick={() => handleRescoreSubmission(true)}>{intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}</Button>
+        </div>
+      ),
+    },
+    {
+      title: intl.formatMessage(messages.overrideScore),
+      description: intl.formatMessage(messages.overrideScoreDescription),
+      buttonLabel: intl.formatMessage(messages.overrideScoreButtonLabel),
+      customAction: (
+        <div className="d-flex align-items-center gap-2">
+          <FormControl
+            type="number"
+            placeholder={intl.formatMessage(messages.overrideScorePlaceholder)}
+            value={score}
+            onChange={handleScoreChange}
+          />
+          <Button disabled={!usernameOrEmail || !blockId || !score} onClick={handleOverrideScore}>{intl.formatMessage(messages.overrideScoreButtonLabel)}</Button>
+        </div>
+      )
+    },
+    {
+      title: intl.formatMessage(messages.deleteHistory),
+      description: intl.formatMessage(messages.deleteHistoryDescription),
+      customAction: (
+        <div className="d-flex flex-column gap-3">
+          <Button disabled={!usernameOrEmail || !blockId} onClick={handleResetAttempts}>{intl.formatMessage(messages.resetAttemptsButtonLabel)}</Button>
+          <Button disabled={!usernameOrEmail || !blockId} onClick={handleDeleteHistory}>{intl.formatMessage(messages.deleteHistoryButtonLabel)}</Button>
+        </div>
+      ),
+    },
+    {
+      title: intl.formatMessage(messages.taskStatus),
+      description: intl.formatMessage(messages.taskStatusDescription),
+      customAction: (
+        <Button disabled={!usernameOrEmail || !blockId} onClick={handleTaskStatusClick}>
+          {intl.formatMessage(messages.taskStatusButtonLabel)}
+        </Button>
+      )
+    }
+  ];
+
+  const allLearnersActionRows = [];
+
+  const rows = toolType === 'single' ? singleLearnerActionRows : allLearnersActionRows;
+
+  const handleProblemChange = (location: string): void => {
+    setBlockId(location);
+  };
+
+  const handleLearnerChange = (usernameOrEmail: string): void => {
+    setUsernameOrEmail(usernameOrEmail);
+  };
 
   return (
     <>
@@ -19,7 +142,27 @@ const GradingLearnerContent = ({ toolType }: GradingLearnerContentProps) => {
             : intl.formatMessage(messages.descriptionAllLearners)
         }
       </p>
-      <SpecifyProblem />
+      <div className="d-flex justify-content-between gap-4">
+        {toolType === 'single' && (
+          <div className="w-50">
+            <SpecifyLearnerField onClickSelect={handleLearnerChange} />
+          </div>
+        )}
+        <div className="w-50">
+          <SpecifyProblemField
+            fieldLabel={intl.formatMessage(messages.specifyProblem)}
+            buttonLabel={intl.formatMessage(messages.select)}
+            disabled={!usernameOrEmail && toolType === 'single'}
+            usernameOrEmail={usernameOrEmail}
+            onClickSelect={handleProblemChange}
+          />
+        </div>
+      </div>
+      {
+        rows.map(({ title, description, buttonLabel, customAction, onButtonClick }, index) => (
+          <ActionCard key={title} buttonLabel={buttonLabel} description={description} title={title} hasBorderBottom={index !== rows.length - 1} customAction={customAction} onButtonClick={onButtonClick} />
+        ))
+      }
     </>
   );
 };

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, FormControl } from '@openedx/paragon';
 import ActionCard, { ActionCardProps } from '@src/components/ActionCard';
@@ -21,6 +21,9 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const [usernameOrEmail, setUsernameOrEmail] = useState('');
   const [blockId, setBlockId] = useState('');
   const [score, setScore] = useState('');
+  const learnerFieldRef = useRef<{ reset: () => void }>(null);
+  const problemFieldRef = useRef<{ reset: () => void }>(null);
+
   const { mutate: resetAttempts } = useResetAttempts(courseId);
   const { mutate: deleteHistory } = useDeleteHistory(courseId);
   const { mutate: changeScore } = useChangeScore(courseId);
@@ -58,10 +61,11 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   };
 
   useEffect(() => {
-    if (toolType === 'all') {
-      setUsernameOrEmail('');
-    }
+    setUsernameOrEmail('');
     setBlockId('');
+    setScore('');
+    learnerFieldRef.current?.reset();
+    problemFieldRef.current?.reset();
   }, [toolType]);
 
   const singleLearnerActionRows: ActionCardProps[] = [
@@ -146,11 +150,12 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       <div className="d-flex justify-content-between gap-4">
         {toolType === 'single' && (
           <div className="w-50">
-            <SpecifyLearnerField onClickSelect={handleLearnerChange} />
+            <SpecifyLearnerField ref={learnerFieldRef} onClickSelect={handleLearnerChange} />
           </div>
         )}
         <div className="w-50">
           <SpecifyProblemField
+            ref={problemFieldRef}
             fieldLabel={intl.formatMessage(messages.specifyProblem)}
             buttonLabel={intl.formatMessage(messages.select)}
             disabled={!usernameOrEmail && toolType === 'single'}

--- a/src/grading/data/api.test.ts
+++ b/src/grading/data/api.test.ts
@@ -1,5 +1,11 @@
 import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { getGradingConfiguration } from '@src/grading/data/api';
+import {
+  getGradingConfiguration,
+  postResetAttempts,
+  postRescoreSubmission,
+  deleteState,
+  changeScore
+} from '@src/grading/data/api';
 
 jest.mock('@openedx/frontend-base', () => ({
   ...jest.requireActual('@openedx/frontend-base'),
@@ -12,10 +18,14 @@ const mockGetSiteConfig = getSiteConfig as jest.MockedFunction<typeof getSiteCon
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
+const mockHttpClient = {
+  get: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  put: jest.fn(),
+};
+
 describe('getGradingConfiguration', () => {
-  const mockHttpClient = {
-    get: jest.fn(),
-  };
   const mockConfigData = { grading_policy: 'test_policy' };
   const mockCamelCaseData = { gradingPolicy: 'test_policy' };
 
@@ -44,5 +54,195 @@ describe('getGradingConfiguration', () => {
     const error = new Error('Network error');
     mockHttpClient.get.mockRejectedValue(error);
     await expect(getGradingConfiguration('test-course')).rejects.toThrow('Network error');
+  });
+});
+
+describe('postResetAttempts', () => {
+  const mockResponseData = { status: 'success' };
+  const mockCamelCaseData = { status: 'success' };
+
+  beforeEach(() => {
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+    mockHttpClient.post.mockResolvedValue({ data: mockResponseData });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('resets attempts with learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+
+    const result = await postResetAttempts(courseId, params);
+
+    const expectedUrl = 'https://test-lms.com/api/instructor/v2/courses/test-course-123/block-v1:test+problem/grading/attempts/reset';
+    expect(mockHttpClient.post).toHaveBeenCalledWith(expectedUrl, expect.any(URLSearchParams));
+    expect(mockCamelCaseObject).toHaveBeenCalledWith(mockResponseData);
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('resets attempts without learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { problem: 'block-v1:test+problem' };
+
+    const result = await postResetAttempts(courseId, params);
+
+    const expectedUrl = 'https://test-lms.com/api/instructor/v2/courses/test-course-123/block-v1:test+problem/grading/attempts/reset';
+    expect(mockHttpClient.post).toHaveBeenCalledWith(expectedUrl, expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('handles error in reset attempts', async () => {
+    const error = new Error('Reset failed');
+    mockHttpClient.post.mockRejectedValue(error);
+
+    await expect(postResetAttempts('test-course', { problem: 'test' })).rejects.toThrow('Reset failed');
+  });
+});
+
+describe('postRescoreSubmission', () => {
+  const mockResponseData = { status: 'success' };
+  const mockCamelCaseData = { status: 'success' };
+
+  beforeEach(() => {
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+    mockHttpClient.post.mockResolvedValue({ data: mockResponseData });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('rescores submission with onlyIfHigher true', async () => {
+    const courseId = 'test-course-123';
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', onlyIfHigher: true };
+
+    const result = await postRescoreSubmission(courseId, params);
+
+    const expectedUrl = 'https://test-lms.com/api/instructor/v2/courses/test-course-123/block-v1:test+problem/grading/scores/rescore';
+    expect(mockHttpClient.post).toHaveBeenCalledWith(expectedUrl, expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('rescores submission with onlyIfHigher false', async () => {
+    const courseId = 'test-course-123';
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', onlyIfHigher: false };
+
+    const result = await postRescoreSubmission(courseId, params);
+
+    expect(mockHttpClient.post).toHaveBeenCalledWith(expect.any(String), expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('handles error in rescore submission', async () => {
+    const error = new Error('Rescore failed');
+    mockHttpClient.post.mockRejectedValue(error);
+
+    await expect(postRescoreSubmission('test-course', { problem: 'test', onlyIfHigher: false })).rejects.toThrow('Rescore failed');
+  });
+});
+
+describe('deleteState', () => {
+  const mockResponseData = { status: 'deleted' };
+  const mockCamelCaseData = { status: 'deleted' };
+
+  beforeEach(() => {
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+    mockHttpClient.delete.mockResolvedValue({ data: mockResponseData });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('deletes state with learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+
+    const result = await deleteState(courseId, params);
+
+    const expectedUrl = 'https://test-lms.com/api/instructor/v2/courses/test-course-123/block-v1:test+problem/grading/state';
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({
+      data: expect.any(URLSearchParams),
+    }));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('deletes state without learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { problem: 'block-v1:test+problem' };
+
+    const result = await deleteState(courseId, params);
+
+    expect(mockHttpClient.delete).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('handles error in delete state', async () => {
+    const error = new Error('Delete failed');
+    mockHttpClient.delete.mockRejectedValue(error);
+
+    await expect(deleteState('test-course', { problem: 'test' })).rejects.toThrow('Delete failed');
+  });
+});
+
+describe('changeScore', () => {
+  const mockResponseData = { status: 'updated' };
+  const mockCamelCaseData = { status: 'updated' };
+
+  beforeEach(() => {
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+    mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+    mockHttpClient.put.mockResolvedValue({ data: mockResponseData });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('changes score with learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', newScore: 85.5 };
+
+    const result = await changeScore(courseId, params);
+
+    const expectedUrl = 'https://test-lms.com/api/instructor/v2/courses/test-course-123/block-v1:test+problem/grading/scores';
+    expect(mockHttpClient.put).toHaveBeenCalledWith(expectedUrl, expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('changes score without learner parameter', async () => {
+    const courseId = 'test-course-123';
+    const params = { problem: 'block-v1:test+problem', newScore: 90 };
+
+    const result = await changeScore(courseId, params);
+
+    expect(mockHttpClient.put).toHaveBeenCalledWith(expect.any(String), expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('handles negative scores', async () => {
+    const courseId = 'test-course-123';
+    const params = { problem: 'block-v1:test+problem', newScore: -5 };
+
+    const result = await changeScore(courseId, params);
+
+    expect(mockHttpClient.put).toHaveBeenCalledWith(expect.any(String), expect.any(URLSearchParams));
+    expect(result).toBe(mockCamelCaseData);
+  });
+
+  it('handles error in change score', async () => {
+    const error = new Error('Score change failed');
+    mockHttpClient.put.mockRejectedValue(error);
+
+    await expect(changeScore('test-course', { problem: 'test', newScore: 100 })).rejects.toThrow('Score change failed');
   });
 });

--- a/src/grading/data/api.ts
+++ b/src/grading/data/api.ts
@@ -1,8 +1,87 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
+import { RescoreParams, GradingParams, ScoreParams } from '../types';
 
 export const getGradingConfiguration = async (courseId: string) => {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/grading-config`);
+  return camelCaseObject(data);
+};
+
+export const postResetAttempts = async (
+  courseId: string,
+  params: GradingParams
+): Promise<any> => {
+  const queryParams = new URLSearchParams();
+
+  if (params.learner) {
+    queryParams.append('learner', params.learner);
+  }
+
+  const problem = encodeURI(params.problem);
+
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/${problem}/grading/attempts/reset`, queryParams
+  );
+  return camelCaseObject(data);
+};
+
+export const postRescoreSubmission = async (
+  courseId: string,
+  params: RescoreParams
+): Promise<any> => {
+  const queryParams = new URLSearchParams({
+    only_if_higher: params.onlyIfHigher.toString(),
+  });
+
+  if (params.learner) {
+    queryParams.append('learner', params.learner);
+  }
+
+  const problem = encodeURI(params.problem);
+
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/${problem}/grading/scores/rescore`, queryParams
+  );
+  return camelCaseObject(data);
+};
+
+export const deleteState = async (
+  courseId: string,
+  params: GradingParams
+): Promise<any> => {
+  const queryParams = new URLSearchParams();
+
+  if (params.learner) {
+    queryParams.append('learner', params.learner);
+  }
+
+  const problem = encodeURI(params.problem);
+
+  const { data } = await getAuthenticatedHttpClient().delete(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/${problem}/grading/state`, {
+      data: queryParams,
+    }
+  );
+  return camelCaseObject(data);
+};
+
+export const changeScore = async (
+  courseId: string,
+  params: ScoreParams
+): Promise<any> => {
+  const queryParams = new URLSearchParams({
+    new_score: params.newScore.toString(),
+  });
+
+  if (params.learner) {
+    queryParams.append('learner', params.learner);
+  }
+
+  const problem = encodeURI(params.problem);
+
+  const { data } = await getAuthenticatedHttpClient().put(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/${problem}/grading/scores`, queryParams
+  );
   return camelCaseObject(data);
 };

--- a/src/grading/data/apiHook.test.tsx
+++ b/src/grading/data/apiHook.test.tsx
@@ -1,7 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as api from '@src/grading/data/api';
-import { useGradingConfiguration } from '@src/grading/data/apiHook';
+import {
+  useGradingConfiguration,
+  useResetAttempts,
+  useRescoreSubmission,
+  useDeleteHistory,
+  useChangeScore
+} from '@src/grading/data/apiHook';
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -46,5 +52,184 @@ describe('useGradingConfiguration', () => {
     const spy = jest.spyOn(api, 'getGradingConfiguration');
     renderHook(() => useGradingConfiguration(''), { wrapper });
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useResetAttempts', () => {
+  const wrapper = createWrapper();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls postResetAttempts when mutate is triggered', async () => {
+    const mockData = { status: 'success' };
+    const spy = jest.spyOn(api, 'postResetAttempts').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useResetAttempts('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it('handles error when postResetAttempts rejects', async () => {
+    const error = new Error('Reset failed');
+    jest.spyOn(api, 'postResetAttempts').mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useResetAttempts('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useRescoreSubmission', () => {
+  const wrapper = createWrapper();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls postRescoreSubmission when mutate is triggered', async () => {
+    const mockData = { status: 'success' };
+    const spy = jest.spyOn(api, 'postRescoreSubmission').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useRescoreSubmission('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', onlyIfHigher: false };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it('handles onlyIfHigher parameter correctly', async () => {
+    const mockData = { status: 'success' };
+    const spy = jest.spyOn(api, 'postRescoreSubmission').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useRescoreSubmission('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', onlyIfHigher: true };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+  });
+
+  it('handles error when postRescoreSubmission rejects', async () => {
+    const error = new Error('Rescore failed');
+    jest.spyOn(api, 'postRescoreSubmission').mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useRescoreSubmission('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', onlyIfHigher: false };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useDeleteHistory', () => {
+  const wrapper = createWrapper();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls deleteState when mutate is triggered', async () => {
+    const mockData = { status: 'deleted' };
+    const spy = jest.spyOn(api, 'deleteState').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useDeleteHistory('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it('handles error when deleteState rejects', async () => {
+    const error = new Error('Delete failed');
+    jest.spyOn(api, 'deleteState').mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useDeleteHistory('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem' };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
+  });
+});
+
+describe('useChangeScore', () => {
+  const wrapper = createWrapper();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls changeScore when mutate is triggered', async () => {
+    const mockData = { status: 'updated' };
+    const spy = jest.spyOn(api, 'changeScore').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useChangeScore('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', newScore: 85.5 };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it('handles integer scores correctly', async () => {
+    const mockData = { status: 'updated' };
+    const spy = jest.spyOn(api, 'changeScore').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useChangeScore('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', newScore: 100 };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+  });
+
+  it('handles negative scores correctly', async () => {
+    const mockData = { status: 'updated' };
+    const spy = jest.spyOn(api, 'changeScore').mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useChangeScore('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', newScore: -5 };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('course-v1:abc123', params);
+  });
+
+  it('handles error when changeScore rejects', async () => {
+    const error = new Error('Score change failed');
+    jest.spyOn(api, 'changeScore').mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useChangeScore('course-v1:abc123'), { wrapper });
+
+    const params = { learner: 'testuser', problem: 'block-v1:test+problem', newScore: 85.5 };
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(error);
   });
 });

--- a/src/grading/data/apiHook.ts
+++ b/src/grading/data/apiHook.ts
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
-import { getGradingConfiguration } from '@src/grading/data/api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { changeScore, deleteState, getGradingConfiguration, postRescoreSubmission, postResetAttempts } from '@src/grading/data/api';
 import { gradingQueryKeys } from '@src/grading/data/queryKeys';
+import { GradingParams, RescoreParams, ScoreParams } from '@src/grading/types';
 
 export const useGradingConfiguration = (courseId: string) => (
   useQuery({
@@ -9,3 +10,31 @@ export const useGradingConfiguration = (courseId: string) => (
     enabled: !!courseId,
   })
 );
+
+export const useResetAttempts = (courseId: string) => {
+  return useMutation({
+    mutationFn: (params: GradingParams) =>
+      postResetAttempts(courseId, params),
+  });
+};
+
+export const useRescoreSubmission = (courseId: string) => {
+  return useMutation({
+    mutationFn: (params: RescoreParams) =>
+      postRescoreSubmission(courseId, params),
+  });
+};
+
+export const useDeleteHistory = (courseId: string) => {
+  return useMutation({
+    mutationFn: (params: GradingParams) =>
+      deleteState(courseId, params),
+  });
+};
+
+export const useChangeScore = (courseId: string) => {
+  return useMutation({
+    mutationFn: (params: ScoreParams) =>
+      changeScore(courseId, params),
+  });
+};

--- a/src/grading/data/queryKeys.ts
+++ b/src/grading/data/queryKeys.ts
@@ -4,4 +4,5 @@ export const gradingQueryKeys = {
   all: [appId, 'grading'] as const,
   byCourse: (courseId: string) => [...gradingQueryKeys.all, courseId] as const,
   gradingConfiguration: (courseId: string) => [...gradingQueryKeys.byCourse(courseId), 'gradingConfiguration'] as const,
+  resetAttempts: (courseId: string, params: { learner: string, problem: string }) => [...gradingQueryKeys.byCourse(courseId), 'resetAttempts', params.learner, params.problem] as const,
 };

--- a/src/grading/messages.ts
+++ b/src/grading/messages.ts
@@ -60,6 +60,101 @@ const messages = defineMessages({
     id: 'instruct.grading.noGradingConfiguration',
     defaultMessage: 'No grading configuration found for this course.',
     description: 'Message to display when there is no grading configuration for the course'
+  },
+  resetAttempts: {
+    id: 'instruct.grading.resetAttempts',
+    defaultMessage: 'Reset Attempts',
+    description: 'Title for the reset attempts action card'
+  },
+  resetAttemptsDescription: {
+    id: 'instruct.grading.resetAttemptsDescription',
+    defaultMessage: 'Allow a learner who has used up all attempts to work on the problem again.',
+    description: 'Description for the reset attempts action card'
+  },
+  resetAttemptsButtonLabel: {
+    id: 'instruct.grading.resetAttemptsButtonLabel',
+    defaultMessage: 'Reset Attempts to Zero',
+    description: 'Button label for the reset attempts action card'
+  },
+  rescoreSubmission: {
+    id: 'instruct.grading.rescoreSubmission',
+    defaultMessage: 'Rescore Submission',
+    description: 'Title for the rescore submission action card'
+  },
+  rescoreSubmissionDescription: {
+    id: 'instruct.grading.rescoreSubmissionDescription',
+    defaultMessage: 'For the specified problem, two tools exist for rescoring learner responses.',
+    description: 'Description for the rescore submission action card'
+  },
+  rescoreSubmissionButtonLabel: {
+    id: 'instruct.grading.rescoreSubmissionButtonLabel',
+    defaultMessage: 'Rescore Learner\'s Submission',
+    description: 'Button label for the rescore submission action card'
+  },
+  rescoreIfImprovesScoreButtonLabel: {
+    id: 'instruct.grading.rescoreIfImprovesScoreButtonLabel',
+    defaultMessage: 'Rescore Only if Score Improves',
+    description: 'Button label for the rescore if improves score action in the rescore submission'
+  },
+  overrideScore: {
+    id: 'instruct.grading.overrideScore',
+    defaultMessage: 'Override Score',
+    description: 'Title for the override score action card'
+  },
+  overrideScoreDescription: {
+    id: 'instruct.grading.overrideScoreDescription',
+    defaultMessage: 'For the specified problem, override the learner\'s score. Input the new score, out of the total points available for this problem.',
+    description: 'Description for the override score action card'
+  },
+  overrideScoreButtonLabel: {
+    id: 'instruct.grading.overrideScoreButtonLabel',
+    defaultMessage: 'Override Learner\'s Score',
+    description: 'Button label for the override score action card'
+  },
+  deleteHistory: {
+    id: 'instruct.grading.deleteHistory',
+    defaultMessage: 'Delete History',
+    description: 'Title for the delete history action card'
+  },
+  deleteHistoryDescription: {
+    id: 'instruct.grading.deleteHistoryDescription',
+    defaultMessage: 'For the specified problem, permanently and completely delete the learner\'s answers and scores from the database.',
+    description: 'Description for the delete history action card'
+  },
+  deleteHistoryButtonLabel: {
+    id: 'instruct.grading.deleteHistoryButtonLabel',
+    defaultMessage: 'Delete Learner\'s State',
+    description: 'Button label for the delete history action card'
+  },
+  taskStatus: {
+    id: 'instruct.grading.taskStatus',
+    defaultMessage: 'Task Status',
+    description: 'Title for the task status action card'
+  },
+  taskStatusDescription: {
+    id: 'instruct.grading.taskStatusDescription',
+    defaultMessage: 'Show the status for the tasks that you submitted for this problem.',
+    description: 'Description for the task status action card'
+  },
+  taskStatusButtonLabel: {
+    id: 'instruct.grading.taskStatusButtonLabel',
+    defaultMessage: 'Show Task Status',
+    description: 'Button label for the task status action card'
+  },
+  specifyProblem: {
+    id: 'instruct.grading.specifyProblem',
+    defaultMessage: 'Specify Problem:',
+    description: 'Label for the specify problem input field'
+  },
+  select: {
+    id: 'instruct.grading.select',
+    defaultMessage: 'Select',
+    description: 'Label for the select button in the specify problem field'
+  },
+  overrideScorePlaceholder: {
+    id: 'instruct.grading.overrideScorePlaceholder',
+    defaultMessage: 'Score',
+    description: 'Placeholder text for the override score input field'
   }
 });
 

--- a/src/grading/types.ts
+++ b/src/grading/types.ts
@@ -1,1 +1,14 @@
 export type GradingToolsType = 'single' | 'all';
+
+export interface GradingParams {
+  learner?: string,
+  problem: string,
+}
+
+export interface RescoreParams extends GradingParams {
+  onlyIfHigher: boolean,
+}
+
+export interface ScoreParams extends GradingParams {
+  newScore: number,
+}

--- a/src/hooks/useDebouncedFilter.ts
+++ b/src/hooks/useDebouncedFilter.ts
@@ -37,8 +37,14 @@ export const useDebouncedFilter = ({
     debouncedSetFilter(value);
   };
 
+  const resetFilter = () => {
+    setInputValue('');
+    setFilter('');
+  };
+
   return {
     inputValue,
     handleChange,
+    resetFilter,
   };
 };


### PR DESCRIPTION
## Description
Add Single learner tab content, and functionality to every button on the view.

## Supporting information
Closes #46 

Tests Co-authored-by: Claude Sonnet 4 <claude@anthropic.com>

## Testing instructions

Please provide detailed step-by-step instructions for manually testing this change.

## Other information
<img width="1421" height="853" alt="Screenshot 2026-04-17 at 6 32 12 p m" src="https://github.com/user-attachments/assets/681fe3f3-01c3-4993-8ce1-01a74d122ba3" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
