### PR TITLE
Grading all learners

### DIFF
--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -50,7 +50,7 @@ const defaultProps = {
 };
 
 describe('GradingLearnerContent', () => {
-  const mockMutateReset = jest.fn();
+  const mockMutateReset = jest.fn().mockResolvedValue({ success: true });
   const mockMutateDelete = jest.fn();
   const mockMutateChangeScore = jest.fn();
   const mockMutateRescore = jest.fn();
@@ -303,5 +303,170 @@ describe('GradingLearnerContent', () => {
 
     const overrideButton = screen.getByText(messages.overrideScoreButtonLabel.defaultMessage);
     expect(overrideButton).toBeDisabled();
+  });
+
+  // Tests for "all learners" mode functionality
+  describe('All Learners Mode', () => {
+    it('renders all learners specific action cards', () => {
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Check that all action cards for all learners mode are rendered
+      expect(screen.getByText(messages.resetAttempts.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.rescoreSubmission.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.taskStatus.defaultMessage)).toBeInTheDocument();
+
+      // Check specific button labels for all learners mode
+      expect(screen.getByText(messages.rescoreAllSubmissionButtonLabel.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.rescoreIfImprovesScoreButtonLabel.defaultMessage)).toBeInTheDocument();
+    });
+
+    it('calls reset attempts for all learners when button is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Select problem first
+      await user.click(screen.getByText('Select Problem'));
+
+      // Click reset attempts button for all learners
+      const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
+      await user.click(resetButton);
+
+      expect(mockMutateReset).toHaveBeenCalledWith({
+        problem: 'block-v1:test+problem',
+        learner: '',
+      });
+    });
+
+    it('calls rescore all submissions when button is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Select problem first
+      await user.click(screen.getByText('Select Problem'));
+
+      // Click rescore all submissions button
+      const rescoreAllButton = screen.getByRole('button', { name: messages.rescoreAllSubmissionButtonLabel.defaultMessage });
+      await user.click(rescoreAllButton);
+
+      expect(mockMutateRescore).toHaveBeenCalledWith({
+        problem: 'block-v1:test+problem',
+        onlyIfHigher: false,
+        learner: '',
+      });
+    });
+
+    it('calls rescore submissions with onlyIfHigher when "if improves" button is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Select problem first
+      await user.click(screen.getByText('Select Problem'));
+
+      // Click rescore if improves button
+      const rescoreIfImprovesButton = screen.getByRole('button', { name: messages.rescoreIfImprovesScoreButtonLabel.defaultMessage });
+      await user.click(rescoreIfImprovesButton);
+
+      expect(mockMutateRescore).toHaveBeenCalledWith({
+        problem: 'block-v1:test+problem',
+        onlyIfHigher: true,
+        learner: '',
+      });
+    });
+
+    it('calls onShowTasks and refetches when task status button is clicked in all learners mode', async () => {
+      const user = userEvent.setup();
+      const mockOnShowTasks = jest.fn();
+
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+          onShowTasks={mockOnShowTasks}
+        />
+      );
+
+      // Select problem first
+      await user.click(screen.getByText('Select Problem'));
+
+      // Click task status button
+      const taskStatusButton = screen.getByText(messages.taskStatusButtonLabel.defaultMessage);
+      await user.click(taskStatusButton);
+
+      expect(mockRefetch).toHaveBeenCalled();
+      expect(mockOnShowTasks).toHaveBeenCalled();
+    });
+
+    it('disables action buttons when problem is not selected in all learners mode', () => {
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
+      const rescoreAllButton = screen.getByRole('button', { name: messages.rescoreAllSubmissionButtonLabel.defaultMessage });
+      const rescoreIfImprovesButton = screen.getByRole('button', { name: messages.rescoreIfImprovesScoreButtonLabel.defaultMessage });
+
+      expect(resetButton).toBeDisabled();
+      expect(rescoreAllButton).toBeDisabled();
+      expect(rescoreIfImprovesButton).toBeDisabled();
+    });
+
+    it('enables action buttons when problem is selected in all learners mode', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Select problem
+      await user.click(screen.getByText('Select Problem'));
+
+      const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
+      const rescoreAllButton = screen.getByRole('button', { name: messages.rescoreAllSubmissionButtonLabel.defaultMessage });
+      const rescoreIfImprovesButton = screen.getByRole('button', { name: messages.rescoreIfImprovesScoreButtonLabel.defaultMessage });
+      const taskStatusButton = screen.getByRole('button', { name: messages.taskStatusButtonLabel.defaultMessage });
+
+      expect(resetButton).not.toBeDisabled();
+      expect(rescoreAllButton).not.toBeDisabled();
+      expect(rescoreIfImprovesButton).not.toBeDisabled();
+      expect(taskStatusButton).not.toBeDisabled();
+    });
+
+    it('task status button is always enabled in all learners mode (does not depend on problem selection)', () => {
+      renderWithIntl(
+        <GradingLearnerContent
+          {...defaultProps}
+          toolType="all"
+        />
+      );
+
+      // Task status button should be enabled even without selecting a problem
+      const taskStatusButton = screen.getByRole('button', { name: messages.taskStatusButtonLabel.defaultMessage });
+      expect(taskStatusButton).not.toBeDisabled();
+    });
   });
 });

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -126,7 +126,37 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
     }
   ];
 
-  const allLearnersActionRows = [];
+  const allLearnersActionRows = [
+    {
+      title: intl.formatMessage(messages.resetAttempts),
+      description: intl.formatMessage(messages.resetAllLearnersAttemptsDescription),
+      buttonLabel: intl.formatMessage(messages.resetAttemptsButtonLabel),
+      customAction: (
+        <Button disabled={!blockId} onClick={handleResetAttempts}>
+          {intl.formatMessage(messages.resetAttemptsButtonLabel)}
+        </Button>
+      )
+    },
+    {
+      title: intl.formatMessage(messages.rescoreSubmission),
+      description: intl.formatMessage(messages.rescoreSubmissionAllLearnersDescription),
+      customAction: (
+        <div className="d-flex flex-column gap-3">
+          <Button disabled={!blockId} onClick={() => handleRescoreSubmission()}>{intl.formatMessage(messages.rescoreAllSubmissionButtonLabel)}</Button>
+          <Button disabled={!blockId} onClick={() => handleRescoreSubmission(true)}>{intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}</Button>
+        </div>
+      ),
+    },
+    {
+      title: intl.formatMessage(messages.taskStatus),
+      description: intl.formatMessage(messages.taskStatusDescription),
+      customAction: (
+        <Button onClick={handleTaskStatusClick}>
+          {intl.formatMessage(messages.taskStatusButtonLabel)}
+        </Button>
+      )
+    }
+  ];
 
   const rows = toolType === 'single' ? singleLearnerActionRows : allLearnersActionRows;
 

--- a/src/grading/messages.ts
+++ b/src/grading/messages.ts
@@ -155,6 +155,21 @@ const messages = defineMessages({
     id: 'instruct.grading.overrideScorePlaceholder',
     defaultMessage: 'Score',
     description: 'Placeholder text for the override score input field'
+  },
+  resetAllLearnersAttemptsDescription: {
+    id: 'instruct.grading.resetAllLearnersAttemptsDescription',
+    defaultMessage: 'Allows all learners to work on the problem again.',
+    description: 'Description for the reset attempts action card in the all learners view'
+  },
+  rescoreSubmissionAllLearnersDescription: {
+    id: 'instruct.grading.rescoreSubmissionAllLearnersDescription',
+    defaultMessage: 'For the specified problem, rescore all learners\' responses.',
+    description: 'Description for the rescore submission action card in the all learners view'
+  },
+  rescoreAllSubmissionButtonLabel: {
+    id: 'instruct.grading.rescoreAllSubmissionButtonLabel',
+    defaultMessage: 'Rescore All Learners\' Submissions',
+    description: 'Button label for the rescore submission action card in the all learners view'
   }
 });
 


### PR DESCRIPTION
## Description
Add All learners tab content, and functionality to every button on the view.

## Supporting information
Closes #47 

## Testing instructions
- Go to grading tab with a valid course Id
- Click on all learners tab
- provide a valid problem block id
- test on buttons

## Other information
<img width="1529" height="935" alt="Screenshot 2026-04-21 at 1 08 54 p m" src="https://github.com/user-attachments/assets/d16d4aa8-f878-4163-a5e5-c7d70dcc3fb5" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
