### PR TITLE
Remove status component from data table on open responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "make build",
     "clean": "make clean",
-    "dev": "PORT=8080 PUBLIC_PATH=/instructor openedx dev",
+    "dev": "PORT=2003 PUBLIC_PATH=/instructor openedx dev",
     "i18n_extract": "openedx formatjs extract",
     "lint": "openedx lint .",
     "lint:fix": "openedx lint --fix .",

--- a/src/openResponses/components/DetailAssessmentsList.test.tsx
+++ b/src/openResponses/components/DetailAssessmentsList.test.tsx
@@ -2,6 +2,7 @@ import { screen, fireEvent, waitFor } from '@testing-library/react';
 import DetailAssessmentsList from './DetailAssessmentsList';
 import { useDetailAssessmentsData } from '../data/apiHook';
 import { renderWithIntl } from '../../testUtils';
+import messages from '../messages';
 
 jest.mock('react-router-dom', () => ({
   useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
@@ -77,7 +78,7 @@ describe('DetailAssessmentsList', () => {
     });
     renderWithIntl(<DetailAssessmentsList />);
     expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(screen.getByText(messages.noAssessmentsFoundMessage.defaultMessage)).toBeInTheDocument();
     expect(screen.queryByText('View and Grade Responses')).not.toBeInTheDocument();
   });
 });

--- a/src/openResponses/components/DetailAssessmentsList.tsx
+++ b/src/openResponses/components/DetailAssessmentsList.tsx
@@ -64,7 +64,11 @@ const DetailAssessmentsList = () => {
         manualPagination
         pageCount={data.numPages}
         pageSize={DETAILS_PAGE_SIZE}
-      />
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content={intl.formatMessage(messages.noAssessmentsFoundMessage)} />
+        <DataTable.TableFooter />
+      </DataTable>
     </div>
   );
 };

--- a/src/openResponses/messages.ts
+++ b/src/openResponses/messages.ts
@@ -76,6 +76,11 @@ const messages = defineMessages({
     defaultMessage: 'View and Grade Responses',
     description: 'Label for the link to view and grade responses'
   },
+  noAssessmentsFoundMessage: {
+    id: 'instruct.openResponses.noAssessmentsFoundMessage',
+    defaultMessage: 'No assessments found.',
+    description: 'Message displayed when no assessments are found in the details table'
+  }
 });
 
 export default messages;


### PR DESCRIPTION
## Description
After AC testing status bar default from data table is not required so i added manually just data table, empty state and pagination so we don't have undesired features

## Supporting information
Closes #123 

## Testing instructions
- Go on open_responses route with a valid course. Example: http://apps.local.openedx.io:2003/instructor/course-v1:OpenedX+DemoX+DemoCourse/open_responses
- The table should look like this and doesn't have status bar at top  
<img width="1701" height="337" alt="Screenshot 2026-02-18 at 5 25 00 p m" src="https://github.com/user-attachments/assets/b58b92d7-0ee7-45ad-82ea-ddb7fc28093f" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
