### PR TITLE
Course team - roles tab

### DIFF
--- a/src/courseTeam/components/RolesContent.test.tsx
+++ b/src/courseTeam/components/RolesContent.test.tsx
@@ -1,0 +1,49 @@
+import { screen } from '@testing-library/react';
+import { renderWithIntl } from '@src/testUtils';
+import RolesContent, { rolesOrder } from './RolesContent';
+import messages from '../messages';
+import { useRoles } from '../data/apiHook';
+
+jest.mock('../data/apiHook', () => ({
+  useRoles: jest.fn(),
+}));
+
+const mockRoles = rolesOrder.map((role) => ({ role: role, displayName: messages[role].defaultMessage }));
+
+describe('RolesContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all roles in the correct order with their descriptions', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+    renderWithIntl(<RolesContent />);
+
+    rolesOrder.forEach((role) => {
+      expect(screen.getByText(messages[role].defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages[`${role}Description`].defaultMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('does not render CCX Coach role when isCCXCoachEnabled is false', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+    renderWithIntl(<RolesContent />);
+    expect(screen.queryByText(messages.ccxCoach.defaultMessage)).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.ccxCoachDescription.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  it('renders correct number of role sections', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+    renderWithIntl(<RolesContent />);
+    // There are 9 roles in rolesOrder
+    expect(screen.getAllByRole('heading', { level: 4 })).toHaveLength(9);
+  });
+
+  it('renders CCX Coach role when isCCXCoachEnabled is true', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: [...mockRoles, { role: 'ccx_coach', displayName: messages.ccxCoach.defaultMessage }] } });
+
+    renderWithIntl(<RolesContent />);
+    expect(screen.getByText(messages.ccxCoach.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.ccxCoachDescription.defaultMessage)).toBeInTheDocument();
+  });
+});

--- a/src/courseTeam/components/RolesContent.test.tsx
+++ b/src/courseTeam/components/RolesContent.test.tsx
@@ -1,10 +1,10 @@
 import { screen } from '@testing-library/react';
 import { renderWithIntl } from '@src/testUtils';
-import RolesContent, { rolesOrder } from './RolesContent';
-import messages from '../messages';
-import { useRoles } from '../data/apiHook';
+import RolesContent, { rolesOrder } from '@src/courseTeam/components/RolesContent';
+import { useRoles } from '@src/courseTeam/data/apiHook';
+import messages from '@src/courseTeam/messages';
 
-jest.mock('../data/apiHook', () => ({
+jest.mock('@src/courseTeam/data/apiHook', () => ({
   useRoles: jest.fn(),
 }));
 

--- a/src/courseTeam/components/RolesContent.tsx
+++ b/src/courseTeam/components/RolesContent.tsx
@@ -1,7 +1,45 @@
+import { useIntl } from '@openedx/frontend-base';
+import messages from '../messages';
+import { useParams } from 'react-router-dom';
+import { useRoles } from '../data/apiHook';
+import { Role } from '../types';
+
+export const rolesOrder = [
+  'staff',
+  'limitedStaff',
+  'admin',
+  'beta',
+  'courseDataResearchers',
+  'discussionAdmin',
+  'discussionModerator',
+  'groupCommunityTA',
+  'communityTA'
+];
+
 const RolesContent = () => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { data: { results } = { data: { results: [] } } } = useRoles(courseId);
+  const isCCXCoachEnabled = !!results?.find(({ role }: Role) => role === 'ccx_coach');
+
   return (
     <div className="mt-4">
-      Roles content goes here.
+      {
+        rolesOrder.map((role) => (
+          <div key={role} className="mb-4">
+            <h4 className="text-primary-500">{intl.formatMessage(messages[role])}</h4>
+            <p className="text-gray-700">{intl.formatMessage(messages[`${role}Description`])}</p>
+          </div>
+        ))
+      }
+      {
+        isCCXCoachEnabled && (
+          <div className="mb-4">
+            <h4 className="text-primary-500">{intl.formatMessage(messages.ccxCoach)}</h4>
+            <p className="text-gray-700">{intl.formatMessage(messages.ccxCoachDescription)}</p>
+          </div>
+        )
+      }
     </div>
   );
 };

--- a/src/courseTeam/components/RolesContent.tsx
+++ b/src/courseTeam/components/RolesContent.tsx
@@ -1,8 +1,8 @@
-import { useIntl } from '@openedx/frontend-base';
-import messages from '../messages';
 import { useParams } from 'react-router-dom';
-import { useRoles } from '../data/apiHook';
-import { Role } from '../types';
+import { useIntl } from '@openedx/frontend-base';
+import messages from '@src/courseTeam/messages';
+import { useRoles } from '@src/courseTeam/data/apiHook';
+import { Role } from '@src/courseTeam/types';
 
 export const rolesOrder = [
   'staff',
@@ -14,12 +14,12 @@ export const rolesOrder = [
   'discussionModerator',
   'groupCommunityTA',
   'communityTA'
-];
+] as const;
 
 const RolesContent = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const { data: { results } = { data: { results: [] } } } = useRoles(courseId);
+  const { data: { results } = { results: [] } } = useRoles(courseId);
   const isCCXCoachEnabled = !!results?.find(({ role }: Role) => role === 'ccx_coach');
 
   return (

--- a/src/courseTeam/data/apiHook.test.tsx
+++ b/src/courseTeam/data/apiHook.test.tsx
@@ -95,7 +95,7 @@ describe('apiHook', () => {
 
   describe('useRoles', () => {
     it('should fetch course roles successfully', async () => {
-      const mockRoles = { count: 3, numPages: 1, results: [{ role: 'instructor', displayName: 'Instructor' }, { role: 'staff', displayName: 'Staff' }, { role: 'beta_testers', displayName: 'Beta Testers' }] };
+      const mockRoles = { results: [{ role: 'instructor', displayName: 'Instructor' }, { role: 'staff', displayName: 'Staff' }, { role: 'beta_testers', displayName: 'Beta Testers' }] };
 
       mockGetRoles.mockResolvedValue(mockRoles);
 

--- a/src/courseTeam/messages.ts
+++ b/src/courseTeam/messages.ts
@@ -56,6 +56,106 @@ const messages = defineMessages({
     defaultMessage: 'All Roles',
     description: 'Option label for filtering by all roles',
   },
+  staff: {
+    id: 'instruct.courseTeam.roles.staff',
+    defaultMessage: 'Staff',
+    description: 'Role name for staff members',
+  },
+  staffDescription: {
+    id: 'instruct.courseTeam.roles.staffDescription',
+    defaultMessage: 'Course team members with the Staff role help you manage your course. Staff can enroll and unenroll learners, as well as modify their grades and access all course data. Staff also have access to your course in Studio and Insights. Any users not yet enrolled in the course will be automatically enrolled when added as Staff.',
+    description: 'Description for staff role',
+  },
+  limitedStaff: {
+    id: 'instruct.courseTeam.roles.limitedStaff',
+    defaultMessage: 'Limited Staff',
+    description: 'Role name for limited staff members',
+  },
+  limitedStaffDescription: {
+    id: 'instruct.courseTeam.roles.limitedStaffDescription',
+    defaultMessage: 'Course team members with the Limited Staff role help you manage your course. Limited Staff can enroll and unenroll learners, as well as modify their grades and access all course data. Limited Staff don\'t have access to your course in Studio. Any users not yet enrolled in the course will be automatically enrolled when added as Limited Staff.',
+    description: 'Description for limited staff role',
+  },
+  admin: {
+    id: 'instruct.courseTeam.roles.admin',
+    defaultMessage: 'Admin',
+    description: 'Role name for admin members',
+  },
+  adminDescription: {
+    id: 'instruct.courseTeam.roles.adminDescription',
+    defaultMessage: 'Course team members with the Admin role help you manage your course. They can do all of the tasks that Staff can do, and can also add and remove the Staff and Admin roles, discussion moderation roles, and the beta tester role to manage course team membership. Any users not yet enrolled in the course will be automatically enrolled when added as Admin.',
+    description: 'Description for admin role',
+  },
+  beta: {
+    id: 'instruct.courseTeam.roles.beta',
+    defaultMessage: 'Beta Testers',
+    description: 'Role name for beta tester members',
+  },
+  betaDescription: {
+    id: 'instruct.courseTeam.roles.betaDescription',
+    defaultMessage: 'Beta Testers can see course content before other learners. They can make sure that the content works, but have no additional privileges. Any users not yet enrolled in the course will be automatically enrolled when added as Beta Tester.',
+    description: 'Description for beta tester role',
+  },
+  courseDataResearchers: {
+    id: 'instruct.courseTeam.roles.courseDataResearchers',
+    defaultMessage: 'Course Data Researchers',
+    description: 'Role name for course data researcher members',
+  },
+  courseDataResearchersDescription: {
+    id: 'instruct.courseTeam.roles.courseDataResearchersDescription',
+    defaultMessage: 'Course Data Researchers can access the data download tab. Any users not yet enrolled in the course will be automatically enrolled when added as Course Data Researcher.',
+    description: 'Description for course data researcher role',
+  },
+  discussionAdmin: {
+    id: 'instruct.courseTeam.roles.discussionAdmin',
+    defaultMessage: 'Discussion Admin',
+    description: 'Role name for discussion admin members',
+  },
+  discussionAdminDescription: {
+    id: 'instruct.courseTeam.roles.discussionAdminDescription',
+    defaultMessage: 'Discussion Admins can edit or delete any post, clear misuse flags, close and re-open threads, endorse responses, and see posts from all groups. Their posts are marked as \'staff\'. They can also add and remove the discussion moderation roles to manage course team membership. Any users not yet enrolled in the course will be automatically enrolled when added as Discussion Admin.',
+    description: 'Description for discussion admin role',
+  },
+  discussionModerator: {
+    id: 'instruct.courseTeam.roles.discussionModerator',
+    defaultMessage: 'Discussion Moderator',
+    description: 'Role name for discussion moderator members',
+  },
+  discussionModeratorDescription: {
+    id: 'instruct.courseTeam.roles.discussionModeratorDescription',
+    defaultMessage: 'Discussion Moderators can edit or delete any post, clear misuse flags, close and re-open threads, endorse responses, and see posts from all groups. Their posts are marked as \'staff\'. They cannot manage course team membership by adding or removing discussion moderation roles. Any users not yet enrolled in the course will be automatically enrolled when added as Discussion Moderator.',
+    description: 'Description for discussion moderator role',
+  },
+  groupCommunityTA: {
+    id: 'instruct.courseTeam.roles.groupCommunityTA',
+    defaultMessage: 'Group Community TA',
+    description: 'Role name for group community TA members',
+  },
+  groupCommunityTADescription: {
+    id: 'instruct.courseTeam.roles.groupCommunityTADescription',
+    defaultMessage: 'Group Community TAs are members of the community who help course teams moderate discussions. Group Community TAs see only posts by learners in their assigned group. They can edit or delete posts, clear flags, close and re-open threads, and endorse responses, but only for posts by learners in their group. Their posts are marked as \'Community TA\'. Any users not yet enrolled in the course will be automatically enrolled when added as Group Community TA.',
+    description: 'Description for group community TA role',
+  },
+  communityTA: {
+    id: 'instruct.courseTeam.roles.communityTA',
+    defaultMessage: 'Community TA',
+    description: 'Role name for community TA members',
+  },
+  communityTADescription: {
+    id: 'instruct.courseTeam.roles.communityTADescription',
+    defaultMessage: 'Community TAs are members of the community who help course teams moderate discussions. They can see posts by learners in their assigned cohort or enrollment track, and can edit or delete posts, clear flags, close or re-open threads, and endorse responses. Their posts are marked as \'Community TA\'. Any users not yet enrolled in the course will be automatically enrolled when added as Community TA.',
+    description: 'Description for community TA role',
+  },
+  ccxCoach: {
+    id: 'instruct.courseTeam.roles.ccxCoach',
+    defaultMessage: 'CCX Coach',
+    description: 'Role name for CCX coach members',
+  },
+  ccxCoachDescription: {
+    id: 'instruct.courseTeam.roles.ccxCoachDescription',
+    defaultMessage: 'CCX Coaches are able to create their own Custom Courses based on this course, which they can use to provide personalized instruction to their own students based in this course material.',
+    description: 'Description for CCX coach role',
+  }
 });
 
 export default messages;


### PR DESCRIPTION
## Description
Roles tab with all the roles descriptions, we decided to hardcode this since will be a temporary solution until we redirect to admin console.

Note: Only conditional role will be ccx coach and will be displayed only if ccx is enabled, to check that we are checking if its coming on the available roles

## Supporting information
Closes #106 

## Testing instructions
- Go to course_team page with a valid courseId. For example: http://apps.local.openedx.io:2003/instructor/course-v1:OpenedX+DemoX+DemoCourse/course_team
- Click on roles tab
- You should see all roles and descriptions

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
