### PR TITLE
fix: messages for data downloads

### DIFF
--- a/src/dataDownloads/messages.ts
+++ b/src/dataDownloads/messages.ts
@@ -63,7 +63,7 @@ const messages = defineMessages({
   },
   problemResponseReportsTabTitle: {
     id: 'instruct.dataDownloads.tabs.problemResponseReports',
-    defaultMessage: 'Open Response Reports',
+    defaultMessage: 'Problem Response Reports',
     description: 'Tab title for problem response reports',
   },
   certificateReportsTabTitle: {
@@ -108,7 +108,7 @@ const messages = defineMessages({
   },
   pendingActivationsReportDescription: {
     id: 'instruct.dataDownloads.reports.pendingActivations.description',
-    defaultMessage: 'Report of enrolled learners who have not yet activated their account',
+    defaultMessage: 'Report of enrolled learners who have not yet activated their account.',
     description: 'Description for pending activations report',
   },
   generatePendingActivationsReport: {
@@ -123,7 +123,7 @@ const messages = defineMessages({
   },
   anonymizedStudentIdsReportDescription: {
     id: 'instruct.dataDownloads.reports.anonymizedStudentIds.description',
-    defaultMessage: 'Report of enrolled learners who have not yet activated their account',
+    defaultMessage: 'Report of enrolled learners with student IDs anonymized.',
     description: 'Description for anonymized student IDs report',
   },
   generateAnonymizedStudentIdsReport: {
@@ -168,7 +168,7 @@ const messages = defineMessages({
   },
   ora2SummaryReportDescription: {
     id: 'instruct.dataDownloads.reports.ora2Summary.description',
-    defaultMessage: 'Report of details and statuses for ORA',
+    defaultMessage: 'Report of details and statuses for ORA.',
     description: 'Description for ORA summary report',
   },
   generateOra2SummaryReport: {
@@ -183,7 +183,7 @@ const messages = defineMessages({
   },
   ora2DataReportDescription: {
     id: 'instruct.dataDownloads.reports.ora2Data.description',
-    defaultMessage: 'Report of all ORA assignment details',
+    defaultMessage: 'Report of all ORA assignment details.',
     description: 'Description for ORA data report',
   },
   generateOra2DataReport: {
@@ -253,7 +253,7 @@ const messages = defineMessages({
   },
   issuedCertificatesDescription: {
     id: 'instruct.dataDownloads.reports.issuedCertificates.description',
-    defaultMessage: 'Report of Certificates Issued',
+    defaultMessage: 'Report of Certificates Issued.',
     description: 'Description for issued certificates report',
   },
   generateCertificatesReport: {


### PR DESCRIPTION
Closes #127

## Description

- Updates the "Problem Response Reports" tab from incorrect "Open Response Reports".
- Updates the Anonymized Student IDs Report description.
- Adds missing periods to reports descriptions.

## Testing instructions

1. Start the instructor app and navigate to http://apps.local.openedx.io:2003/instructor/course-v1:OpenedX+DemoX+DemoCourse/data_downloads (or use any valid course id)
2. Verify the text matches the screenshot.
<img width="1728" height="541" alt="image" src="https://github.com/user-attachments/assets/f7129143-b63f-4266-a8bc-8e6545cd24eb" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
