### PR TITLE
feat: Edit team member modal

### DIFF
--- a/src/courseTeam/CourseTeamPage.test.tsx
+++ b/src/courseTeam/CourseTeamPage.test.tsx
@@ -12,10 +12,19 @@ jest.mock('./data/apiHook', () => ({
   useAddTeamMember: () => ({ mutate: jest.fn() }),
 }));
 
-// Mock the child components, each component should have its own test suite
+// Mock the child components but allow passing through props
 jest.mock('./components/MembersContent', () => {
-  return function MembersContent() {
-    return <div>Members Content</div>;
+  return function MembersContent({ onEdit }: { onEdit?: (user: any) => void }) {
+    return (
+      <div>
+        Members Content
+        {onEdit && (
+          <button onClick={() => onEdit({ username: 'testuser', fullName: 'Test User', email: 'test@example.com', roles: [] })}>
+            Edit User
+          </button>
+        )}
+      </div>
+    );
   };
 });
 
@@ -26,8 +35,14 @@ jest.mock('./components/RolesContent', () => {
 });
 
 jest.mock('./components/AddTeamMemberModal', () => {
-  return function AddTeamMemberModal() {
-    return <div>Add Team Member Modal</div>;
+  return function AddTeamMemberModal({ isOpen }: { isOpen?: boolean }) {
+    return isOpen ? <div>Add Team Member Modal</div> : null;
+  };
+});
+
+jest.mock('./components/EditTeamMemberModal', () => {
+  return function EditTeamMemberModal({ isOpen, user }: { isOpen?: boolean, user?: any }) {
+    return isOpen && user ? <div>Edit Team Member Modal for {user.username}</div> : null;
   };
 });
 
@@ -73,5 +88,87 @@ describe('CourseTeamPage', () => {
     const user = userEvent.setup();
     await user.click(rolesTab);
     expect(screen.getByText('Roles Content')).toBeInTheDocument();
+  });
+
+  it('opens EditTeamMemberModal when handleEdit is called', async () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+
+    // Initially, EditTeamMemberModal should not be visible
+    expect(screen.queryByText(/Edit Team Member Modal for/)).not.toBeInTheDocument();
+
+    // Click the edit button which triggers handleEdit
+    const editButton = screen.getByRole('button', { name: /Edit User/i });
+    const user = userEvent.setup();
+    await user.click(editButton);
+
+    // Now EditTeamMemberModal should be visible
+    expect(screen.getByText('Edit Team Member Modal for testuser')).toBeInTheDocument();
+  });
+
+  it('does not render EditTeamMemberModal initially', () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+    expect(screen.queryByText(/Edit Team Member Modal for/)).not.toBeInTheDocument();
+  });
+
+  it('initializes with correct state values', () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+
+    // Verify initial states by checking that EditTeamMemberModal is not rendered
+    expect(screen.queryByText(/Edit Team Member Modal for/)).not.toBeInTheDocument();
+
+    // Verify the component renders without crashing and shows expected initial content
+    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add team member/i })).toBeInTheDocument();
+  });
+
+  it('passes onEdit prop to MembersContent', () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+    // The mock MembersContent component renders an edit button that uses onEdit
+    expect(screen.getByRole('button', { name: /Edit User/i })).toBeInTheDocument();
+  });
+
+  it('sets selected user when handleEdit is called', async () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+
+    const editButton = screen.getByRole('button', { name: /Edit User/i });
+    const user = userEvent.setup();
+    await user.click(editButton);
+
+    // Verify the modal shows with the correct user
+    expect(screen.getByText('Edit Team Member Modal for testuser')).toBeInTheDocument();
+  });
+
+  it('renders both AddTeamMemberModal and EditTeamMemberModal when both are open', async () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+
+    // Open AddTeamMemberModal
+    const addButton = screen.getByRole('button', { name: /add team member/i });
+    const user = userEvent.setup();
+    await user.click(addButton);
+    expect(screen.getByText('Add Team Member Modal')).toBeInTheDocument();
+
+    // Open EditTeamMemberModal
+    const editButton = screen.getByRole('button', { name: /Edit User/i });
+    await user.click(editButton);
+    expect(screen.getByText('Edit Team Member Modal for testuser')).toBeInTheDocument();
+
+    // Both should be visible
+    expect(screen.getByText('Add Team Member Modal')).toBeInTheDocument();
+    expect(screen.getByText('Edit Team Member Modal for testuser')).toBeInTheDocument();
+  });
+
+  it('manages edit modal state correctly through complete cycle', async () => {
+    renderWithAlertAndIntl(<CourseTeamPage />);
+    const user = userEvent.setup();
+
+    // Initial state - modal not visible
+    expect(screen.queryByText(/Edit Team Member Modal for/)).not.toBeInTheDocument();
+
+    // Open modal by triggering edit
+    const editButton = screen.getByRole('button', { name: /Edit User/i });
+    await user.click(editButton);
+
+    // Modal should be visible
+    expect(screen.getByText('Edit Team Member Modal for testuser')).toBeInTheDocument();
   });
 });

--- a/src/courseTeam/CourseTeamPage.tsx
+++ b/src/courseTeam/CourseTeamPage.tsx
@@ -1,15 +1,25 @@
+import { useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, Tab, Tabs, useToggle } from '@openedx/paragon';
 import { Plus } from '@openedx/paragon/icons';
 import AddTeamMemberModal from '@src/courseTeam/components/AddTeamMemberModal';
+import EditTeamMemberModal from '@src/courseTeam/components/EditTeamMemberModal';
 import MembersContent from '@src/courseTeam/components/MembersContent';
 import RolesContent from '@src/courseTeam/components/RolesContent';
 import messages from '@src/courseTeam/messages';
 import { AlertOutlet } from '@src/providers/AlertProvider';
+import { CourseTeamMember } from '@src/courseTeam/types';
 
 const CourseTeamPage = () => {
   const intl = useIntl();
   const [isOpenAddModal, openAddModal, closeAddModal] = useToggle(false);
+  const [isOpenEditModal, openEditModal, closeEditModal] = useToggle(false);
+  const [selectedUser, setSelectedUser] = useState<CourseTeamMember | null>(null);
+
+  const handleEdit = (user: CourseTeamMember) => {
+    setSelectedUser(user);
+    openEditModal();
+  };
 
   return (
     <>
@@ -20,13 +30,14 @@ const CourseTeamPage = () => {
       <AlertOutlet />
       <Tabs>
         <Tab eventKey="members" title={intl.formatMessage(messages.membersTab)}>
-          <MembersContent />
+          <MembersContent onEdit={handleEdit} />
         </Tab>
         <Tab eventKey="roles" title={intl.formatMessage(messages.rolesTab)}>
           <RolesContent />
         </Tab>
       </Tabs>
       {isOpenAddModal && <AddTeamMemberModal isOpen={isOpenAddModal} onClose={closeAddModal} />}
+      {isOpenEditModal && selectedUser && <EditTeamMemberModal isOpen={isOpenEditModal} user={selectedUser} onClose={closeEditModal} />}
     </>
   );
 };

--- a/src/courseTeam/components/AddTeamMemberModal.tsx
+++ b/src/courseTeam/components/AddTeamMemberModal.tsx
@@ -72,10 +72,10 @@ const AddTeamMemberModal = ({
 
   return (
     <ModalDialog isOpen={isOpen} onClose={onClose} title={intl.formatMessage(messages.addNewTeamMember)} isOverflowVisible={false} size="lg">
-      <ModalDialog.Header>
+      <ModalDialog.Header className="border-light-700 border-bottom">
         <h3 className="text-primary-500">{intl.formatMessage(messages.addNewTeamMember)}</h3>
       </ModalDialog.Header>
-      <ModalDialog.Body>
+      <ModalDialog.Body className="position-relative overflow-auto">
         <p>{intl.formatMessage(messages.addNewTeamMemberDescription, { courseName: displayName })}</p>
         <Form.Group>
           <Form.Label>{intl.formatMessage(messages.addUsersLabel)}</Form.Label>
@@ -94,7 +94,7 @@ const AddTeamMemberModal = ({
           </Form.Control>
         </Form.Group>
       </ModalDialog.Body>
-      <ModalDialog.Footer>
+      <ModalDialog.Footer className="border-light-700 border-top">
         <ActionRow>
           <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelButton)}</Button>
           <Button variant="primary" onClick={handleSave} disabled={!selectedRole || !inputValue}>{intl.formatMessage(messages.saveButton)}</Button>

--- a/src/courseTeam/components/EditTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.test.tsx
@@ -45,8 +45,22 @@ describe('EditTeamMemberModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
-    (useAddTeamMember as jest.Mock).mockReturnValue({ mutate: mockAddTeamMember });
-    (useRemoveTeamMember as jest.Mock).mockReturnValue({ mutate: mockRemoveTeamMember });
+    (useAddTeamMember as jest.Mock).mockReturnValue({
+      mutate: mockAddTeamMember,
+      isPending: false
+    });
+    (useRemoveTeamMember as jest.Mock).mockReturnValue({
+      mutate: mockRemoveTeamMember,
+      isPending: false
+    });
+
+    // Mock successful operations by default
+    mockAddTeamMember.mockImplementation((_params, { onSuccess }) => {
+      if (onSuccess) onSuccess();
+    });
+    mockRemoveTeamMember.mockImplementation((_params, { onSuccess }) => {
+      if (onSuccess) onSuccess();
+    });
   });
 
   it('renders modal with correct title', () => {
@@ -124,17 +138,6 @@ describe('EditTeamMemberModal', () => {
     const user = userEvent.setup();
     const cancelButton = screen.getByRole('button', { name: messages.cancelButton.defaultMessage });
     await user.click(cancelButton);
-
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onClose when save button is clicked', async () => {
-    const mockOnClose = jest.fn();
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
-
-    const user = userEvent.setup();
-    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
-    await user.click(saveButton);
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
@@ -242,7 +245,8 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('calls addTeamMember when save is clicked with selected role', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    const mockOnClose = jest.fn();
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -255,11 +259,18 @@ describe('EditTeamMemberModal', () => {
     expect(mockAddTeamMember).toHaveBeenCalledWith({
       identifiers: [mockUser.username],
       role: 'instructor',
-    }, expect.any(Object));
+    }, expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function)
+    }));
+
+    // Should close after successful operation
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('calls removeTeamMember when save is clicked with roles unchecked for removal', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    const mockOnClose = jest.fn();
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -273,11 +284,29 @@ describe('EditTeamMemberModal', () => {
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
       roles: ['staff'],
-    }, expect.any(Object));
+    }, expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function)
+    }));
+
+    // Should close after successful operation
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('calls both addTeamMember and removeTeamMember when both actions are needed', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    const mockOnClose = jest.fn();
+
+    // Mock sequential execution: remove first, then add
+    let removeCallback: (() => void) | undefined;
+    mockRemoveTeamMember.mockImplementation((_params, { onSuccess }) => {
+      removeCallback = onSuccess;
+    });
+
+    mockAddTeamMember.mockImplementation((_params, { onSuccess }) => {
+      if (onSuccess) onSuccess();
+    });
+
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -290,14 +319,28 @@ describe('EditTeamMemberModal', () => {
     await user.click(staffCheckbox);
     await user.click(saveButton);
 
-    expect(mockAddTeamMember).toHaveBeenCalledWith({
-      identifiers: [mockUser.username],
-      role: 'instructor'
-    }, expect.any(Object));
+    // Should call remove first
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
       roles: ['staff']
-    }, expect.any(Object));
+    }, expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function)
+    }));
+
+    // Simulate remove success to trigger add
+    if (removeCallback) removeCallback();
+
+    expect(mockAddTeamMember).toHaveBeenCalledWith({
+      identifiers: [mockUser.username],
+      role: 'instructor'
+    }, expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function)
+    }));
+
+    // Should close after all operations succeed
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('does not call addTeamMember when no role is selected', async () => {
@@ -325,7 +368,8 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles multiple role unchecking for removal', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    const mockOnClose = jest.fn();
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -342,7 +386,13 @@ describe('EditTeamMemberModal', () => {
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
       roles: ['staff', 'admin']
-    }, expect.any(Object));
+    }, expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function)
+    }));
+
+    // Should close after successful operation
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('handles role selection with empty string value', async () => {
@@ -376,5 +426,85 @@ describe('EditTeamMemberModal', () => {
 
     const options = screen.getAllByRole('option');
     expect(options).toHaveLength(expectedAvailableRoles.length + 1); // +1 for placeholder
+  });
+
+  it('handles add role error and keeps modal open', async () => {
+    const mockOnClose = jest.fn();
+    mockAddTeamMember.mockImplementation((_params, { onError }) => {
+      if (onError) onError();
+    });
+
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    await user.selectOptions(selectElement, 'instructor');
+    await user.click(saveButton);
+
+    expect(mockAddTeamMember).toHaveBeenCalled();
+    // Modal should NOT close on error
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('handles remove role error and keeps modal open', async () => {
+    const mockOnClose = jest.fn();
+    mockRemoveTeamMember.mockImplementation((_params, { onError }) => {
+      if (onError) onError();
+    });
+
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+
+    const user = userEvent.setup();
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    await user.click(staffCheckbox);
+    await user.click(saveButton);
+
+    expect(mockRemoveTeamMember).toHaveBeenCalled();
+    // Modal should NOT close on error
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('handles remove success but add failure in sequential operations', async () => {
+    const mockOnClose = jest.fn();
+
+    // Remove succeeds, add fails
+    mockRemoveTeamMember.mockImplementation((_params, { onSuccess }) => {
+      if (onSuccess) onSuccess();
+    });
+    mockAddTeamMember.mockImplementation((_params, { onError }) => {
+      if (onError) onError();
+    });
+
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    await user.selectOptions(selectElement, 'instructor');
+    await user.click(staffCheckbox);
+    await user.click(saveButton);
+
+    expect(mockRemoveTeamMember).toHaveBeenCalled();
+    expect(mockAddTeamMember).toHaveBeenCalled();
+    // Modal should NOT close due to add failure
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('disables save button when operations are pending', () => {
+    (useAddTeamMember as jest.Mock).mockReturnValue({
+      mutate: mockAddTeamMember,
+      isPending: true
+    });
+
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+    expect(saveButton).toBeDisabled();
   });
 });

--- a/src/courseTeam/components/EditTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.test.tsx
@@ -1,0 +1,380 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditTeamMemberModal from '@src/courseTeam/components/EditTeamMemberModal';
+import { useRoles, useAddTeamMember, useRemoveTeamMember } from '@src/courseTeam/data/apiHook';
+import messages from '@src/courseTeam/messages';
+import { CourseTeamMember } from '@src/courseTeam/types';
+import { renderWithIntl } from '@src/testUtils';
+
+// Mocks
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ courseId: 'course-v1:test+course+run' }),
+}));
+
+jest.mock('@src/courseTeam/data/apiHook', () => ({
+  useRoles: jest.fn(),
+  useAddTeamMember: jest.fn(() => ({ mutate: jest.fn() })),
+  useRemoveTeamMember: jest.fn(() => ({ mutate: jest.fn() })),
+}));
+
+const mockUser: CourseTeamMember = {
+  username: 'test_user',
+  fullName: 'Test User',
+  email: 'test@example.com',
+  roles: [{ role: 'staff', displayName: 'Staff' }, { role: 'admin', displayName: 'Admin' }],
+};
+
+const mockRoles = [
+  { role: 'instructor', displayName: 'Instructor' },
+  { role: 'staff', displayName: 'Staff' },
+  { role: 'admin', displayName: 'Admin' },
+  { role: 'beta_testers', displayName: 'Beta Testers' },
+  { role: 'data_researcher', displayName: 'Data Researcher' },
+];
+
+describe('EditTeamMemberModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    user: mockUser,
+    onClose: jest.fn(),
+  };
+
+  const mockAddTeamMember = jest.fn();
+  const mockRemoveTeamMember = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+    (useAddTeamMember as jest.Mock).mockReturnValue({ mutate: mockAddTeamMember });
+    (useRemoveTeamMember as jest.Mock).mockReturnValue({ mutate: mockRemoveTeamMember });
+  });
+
+  it('renders modal with correct title', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
+    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+  });
+
+  it('renders modal header and body correctly', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
+    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+  });
+
+  it('renders edit instructions with username', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const expectedInstructions = messages.editInstructions.defaultMessage.replace('{username}', mockUser.username);
+    expect(screen.getByText(expectedInstructions)).toBeInTheDocument();
+  });
+
+  it('renders current user roles as checkboxes that are initially checked', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    mockUser.roles.forEach((role) => {
+      const checkbox = screen.getByRole('checkbox', { name: role.displayName });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('renders add role label', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    expect(screen.getByText(messages.addRole.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders role selection dropdown with filtered roles', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeInTheDocument();
+
+    // Verify select is present
+    expect(screen.getByRole('option', { name: messages.rolePlaceholder.defaultMessage })).toBeInTheDocument();
+
+    // Verify only roles not already assigned to user are available
+    const availableRoles = mockRoles.filter(role => !mockUser.roles.some(userRole => userRole.role === role.role));
+    availableRoles.forEach((role) => {
+      expect(screen.getByRole('option', { name: role.displayName })).toBeInTheDocument();
+    });
+
+    // Verify user's current roles are not in the dropdown options
+    mockUser.roles.forEach((userRole) => {
+      const roleInMockData = mockRoles.find(role => role.role === userRole.role);
+      if (roleInMockData) {
+        expect(screen.queryByRole('option', { name: roleInMockData.displayName })).not.toBeInTheDocument();
+      }
+    });
+  });
+
+  it('renders cancel and save buttons', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const mockOnClose = jest.fn();
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+
+    const user = userEvent.setup();
+    const cancelButton = screen.getByRole('button', { name: messages.cancelButton.defaultMessage });
+    await user.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when save button is clicked', async () => {
+    const mockOnClose = jest.fn();
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+
+    const user = userEvent.setup();
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+    await user.click(saveButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} isOpen={false} />);
+
+    const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
+    expect(screen.queryByText(expectedTitle)).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when no roles data is available', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: [] });
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    // Should only show placeholder in dropdown
+    expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
+
+    // Select should be disabled when no roles are available
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeDisabled();
+
+    // Should still show current user roles as checkboxes that are checked
+    mockUser.roles.forEach((role) => {
+      const checkbox = screen.getByRole('checkbox', { name: role.displayName });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('renders correctly when useRoles returns undefined data', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: undefined });
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    // Should only show placeholder in dropdown
+    expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
+
+    // Select should be disabled when no roles are available
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeDisabled();
+
+    // Should still show current user roles as checkboxes that are checked
+    mockUser.roles.forEach((role) => {
+      const checkbox = screen.getByRole('checkbox', { name: role.displayName });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('handles user with all available roles assigned', () => {
+    const userWithAllRoles = {
+      ...mockUser,
+      roles: mockRoles.map(role => ({ role: role.role, displayName: role.displayName })),
+    };
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} user={userWithAllRoles} />);
+
+    // Should show all roles as checkboxes that are checked
+    userWithAllRoles.roles.forEach((role) => {
+      const checkbox = screen.getByRole('checkbox', { name: role.displayName });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeChecked();
+    });
+
+    // Dropdown should only have placeholder since all roles are assigned
+    expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1); // Only placeholder option
+  });
+
+  it('enables select when roles are available for assignment', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    // Should be enabled when there are roles available to assign
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).not.toBeDisabled();
+  });
+
+  it('handles checkbox interactions for keeping/removing roles', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+
+    // Initially checked (role will be kept)
+    expect(staffCheckbox).toBeChecked();
+
+    // Uncheck to mark role for removal
+    await user.click(staffCheckbox);
+    expect(staffCheckbox).not.toBeChecked();
+
+    // Check again to keep the role
+    await user.click(staffCheckbox);
+    expect(staffCheckbox).toBeChecked();
+  });
+
+  it('handles role selection from dropdown', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+
+    // Select a role
+    await user.selectOptions(selectElement, 'instructor');
+    expect(selectElement).toHaveValue('instructor');
+  });
+
+  it('calls addTeamMember when save is clicked with selected role', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Select a role and save
+    await user.selectOptions(selectElement, 'instructor');
+    await user.click(saveButton);
+
+    expect(mockAddTeamMember).toHaveBeenCalledWith({
+      identifiers: [mockUser.username],
+      role: 'instructor'
+    });
+  });
+
+  it('calls removeTeamMember when save is clicked with roles unchecked for removal', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Initially checked, uncheck to mark role for removal
+    expect(staffCheckbox).toBeChecked();
+    await user.click(staffCheckbox);
+    await user.click(saveButton);
+
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith({
+      identifier: mockUser.username,
+      role: ['staff']
+    });
+  });
+
+  it('calls both addTeamMember and removeTeamMember when both actions are needed', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Select a new role and uncheck existing role for removal
+    await user.selectOptions(selectElement, 'instructor');
+    expect(staffCheckbox).toBeChecked();
+    await user.click(staffCheckbox);
+    await user.click(saveButton);
+
+    expect(mockAddTeamMember).toHaveBeenCalledWith({
+      identifiers: [mockUser.username],
+      role: 'instructor'
+    });
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith({
+      identifier: mockUser.username,
+      role: ['staff']
+    });
+  });
+
+  it('does not call addTeamMember when no role is selected', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Save without selecting a role
+    await user.click(saveButton);
+
+    expect(mockAddTeamMember).not.toHaveBeenCalled();
+  });
+
+  it('does not call removeTeamMember when all roles remain checked', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Save without unchecking any roles (all remain checked/kept)
+    await user.click(saveButton);
+
+    expect(mockRemoveTeamMember).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple role unchecking for removal', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
+    const adminCheckbox = screen.getByRole('checkbox', { name: 'Admin' });
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Initially both are checked, uncheck both to remove them
+    expect(staffCheckbox).toBeChecked();
+    expect(adminCheckbox).toBeChecked();
+    await user.click(staffCheckbox);
+    await user.click(adminCheckbox);
+    await user.click(saveButton);
+
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith({
+      identifier: mockUser.username,
+      role: ['staff', 'admin']
+    });
+  });
+
+  it('handles role selection with empty string value', async () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const user = userEvent.setup();
+    const selectElement = screen.getByRole('combobox');
+    const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
+
+    // Select placeholder (empty value) and save
+    await user.selectOptions(selectElement, '');
+    await user.click(saveButton);
+
+    expect(mockAddTeamMember).not.toHaveBeenCalled();
+  });
+
+  it('renders correct number of user roles as checkboxes', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(mockUser.roles.length);
+  });
+
+  it('filters out user current roles from dropdown options', () => {
+    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+
+    // Should have placeholder + available roles (not user's current roles)
+    const expectedAvailableRoles = mockRoles.filter(role =>
+      !mockUser.roles.some(userRole => userRole.role === role.role)
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(expectedAvailableRoles.length + 1); // +1 for placeholder
+  });
+});

--- a/src/courseTeam/components/EditTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.test.tsx
@@ -4,7 +4,7 @@ import EditTeamMemberModal from '@src/courseTeam/components/EditTeamMemberModal'
 import { useRoles, useAddTeamMember, useRemoveTeamMember } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember } from '@src/courseTeam/types';
-import { renderWithIntl } from '@src/testUtils';
+import { renderWithAlertAndIntl } from '@src/testUtils';
 
 // Mocks
 jest.mock('react-router-dom', () => ({
@@ -50,28 +50,28 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders modal with correct title', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedTitle)).toBeInTheDocument();
   });
 
   it('renders modal header and body correctly', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedTitle)).toBeInTheDocument();
   });
 
   it('renders edit instructions with username', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedInstructions = messages.editInstructions.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedInstructions)).toBeInTheDocument();
   });
 
   it('renders current user roles as checkboxes that are initially checked', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     mockUser.roles.forEach((role) => {
       const checkbox = screen.getByRole('checkbox', { name: role.displayName });
@@ -81,13 +81,13 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders add role label', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     expect(screen.getByText(messages.addRole.defaultMessage)).toBeInTheDocument();
   });
 
   it('renders role selection dropdown with filtered roles', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const selectElement = screen.getByRole('combobox');
     expect(selectElement).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders cancel and save buttons', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
@@ -119,7 +119,7 @@ describe('EditTeamMemberModal', () => {
 
   it('calls onClose when cancel button is clicked', async () => {
     const mockOnClose = jest.fn();
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const cancelButton = screen.getByRole('button', { name: messages.cancelButton.defaultMessage });
@@ -130,7 +130,7 @@ describe('EditTeamMemberModal', () => {
 
   it('calls onClose when save button is clicked', async () => {
     const mockOnClose = jest.fn();
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
@@ -140,7 +140,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('does not render when isOpen is false', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} isOpen={false} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} isOpen={false} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.queryByText(expectedTitle)).not.toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('EditTeamMemberModal', () => {
 
   it('renders correctly when no roles data is available', () => {
     (useRoles as jest.Mock).mockReturnValue({ data: [] });
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     // Should only show placeholder in dropdown
     expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
@@ -167,7 +167,7 @@ describe('EditTeamMemberModal', () => {
 
   it('renders correctly when useRoles returns undefined data', () => {
     (useRoles as jest.Mock).mockReturnValue({ data: undefined });
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     // Should only show placeholder in dropdown
     expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('EditTeamMemberModal', () => {
       ...mockUser,
       roles: mockRoles.map(role => ({ role: role.role, displayName: role.displayName })),
     };
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} user={userWithAllRoles} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} user={userWithAllRoles} />);
 
     // Should show all roles as checkboxes that are checked
     userWithAllRoles.roles.forEach((role) => {
@@ -205,7 +205,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('enables select when roles are available for assignment', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     // Should be enabled when there are roles available to assign
     const selectElement = screen.getByRole('combobox');
@@ -213,7 +213,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles checkbox interactions for keeping/removing roles', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -231,7 +231,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles role selection from dropdown', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -242,7 +242,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('calls addTeamMember when save is clicked with selected role', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -254,12 +254,12 @@ describe('EditTeamMemberModal', () => {
 
     expect(mockAddTeamMember).toHaveBeenCalledWith({
       identifiers: [mockUser.username],
-      role: 'instructor'
-    });
+      role: 'instructor',
+    }, expect.any(Object));
   });
 
   it('calls removeTeamMember when save is clicked with roles unchecked for removal', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -272,12 +272,12 @@ describe('EditTeamMemberModal', () => {
 
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
-      role: ['staff']
-    });
+      roles: ['staff'],
+    }, expect.any(Object));
   });
 
   it('calls both addTeamMember and removeTeamMember when both actions are needed', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -293,15 +293,15 @@ describe('EditTeamMemberModal', () => {
     expect(mockAddTeamMember).toHaveBeenCalledWith({
       identifiers: [mockUser.username],
       role: 'instructor'
-    });
+    }, expect.any(Object));
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
-      role: ['staff']
-    });
+      roles: ['staff']
+    }, expect.any(Object));
   });
 
   it('does not call addTeamMember when no role is selected', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
@@ -313,7 +313,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('does not call removeTeamMember when all roles remain checked', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
@@ -325,7 +325,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles multiple role unchecking for removal', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -341,12 +341,12 @@ describe('EditTeamMemberModal', () => {
 
     expect(mockRemoveTeamMember).toHaveBeenCalledWith({
       identifier: mockUser.username,
-      role: ['staff', 'admin']
-    });
+      roles: ['staff', 'admin']
+    }, expect.any(Object));
   });
 
   it('handles role selection with empty string value', async () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -360,14 +360,14 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders correct number of user roles as checkboxes', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(mockUser.roles.length);
   });
 
   it('filters out user current roles from dropdown options', () => {
-    renderWithIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
 
     // Should have placeholder + available roles (not user's current roles)
     const expectedAvailableRoles = mockRoles.filter(role =>

--- a/src/courseTeam/components/EditTeamMemberModal.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { ActionRow, Button, Form, FormControl, FormLabel, ModalDialog } from '@openedx/paragon';
+import { useAddTeamMember, useRemoveTeamMember, useRoles } from '@src/courseTeam/data/apiHook';
+import messages from '@src/courseTeam/messages';
+import { CourseTeamMember, Role } from '@src/courseTeam/types';
+
+interface EditTeamMemberModalProps {
+  isOpen: boolean,
+  user: CourseTeamMember,
+  onClose: () => void,
+}
+
+const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const [selectedRole, setSelectedRole] = useState('');
+  const [keepRoles, setKeepRoles] = useState<string[]>(user.roles.map(role => role.role));
+  const { mutate: addTeamMember } = useAddTeamMember(courseId);
+  const { mutate: removeTeamMember } = useRemoveTeamMember(courseId);
+
+  const { data: { results } = { results: [] } } = useRoles(courseId);
+
+  const filteredRoles = results?.filter(role => !user.roles.some(userRole => userRole.role === role.role)) || [];
+
+  const roles = [{ role: '', displayName: intl.formatMessage(messages.rolePlaceholder) }, ...filteredRoles];
+
+  const handleToggleRole = (roleName: string) => {
+    if (keepRoles.includes(roleName)) {
+      setKeepRoles(keepRoles.filter(role => role !== roleName));
+    } else {
+      setKeepRoles([...keepRoles, roleName]);
+    }
+  };
+
+  const handleSave = () => {
+    if (selectedRole) {
+      addTeamMember({ identifiers: [user.username], role: selectedRole });
+    }
+    const rolesToRemove = user.roles.filter(role => !keepRoles.includes(role.role)).map(role => role.role);
+    if (rolesToRemove.length > 0) {
+      removeTeamMember({ identifier: user.username, role: rolesToRemove });
+    }
+    onClose();
+  };
+
+  return (
+    <ModalDialog
+      isOpen={isOpen}
+      title={intl.formatMessage(messages.editTeamTitle, { username: user.username })}
+      onClose={onClose}
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header className="border-light-700 border-bottom">
+        <h3 className="text-primary-500">{intl.formatMessage(messages.editTeamTitle, { username: user.username })}</h3>
+      </ModalDialog.Header>
+      <ModalDialog.Body className="position-relative overflow-auto">
+        <p>{intl.formatMessage(messages.editInstructions, { username: user.username })}</p>
+        <Form.CheckboxSet onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleToggleRole(e.target.value)} value={keepRoles} name="keepRoles">
+          {
+            (user.roles || [])
+              .map((role: Role) => (
+                <Form.Checkbox className="mt-2" key={role.role} value={role.role}>
+                  {role.displayName}
+                </Form.Checkbox>
+              ))
+          }
+        </Form.CheckboxSet>
+        <FormLabel className="mt-4">{intl.formatMessage(messages.addRole)}</FormLabel>
+        <FormControl
+          as="select"
+          disabled={roles.length === 1}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSelectedRole(e.target.value)}
+          value={selectedRole}
+        >
+          {
+            roles.map((role) => (
+              <option key={role.role} value={role.role}>
+                {role.displayName}
+              </option>
+            ))
+          }
+        </FormControl>
+      </ModalDialog.Body>
+      <ModalDialog.Footer className="border-light-700 border-top">
+        <ActionRow>
+          <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelButton)}</Button>
+          <Button variant="primary" onClick={handleSave}>{intl.formatMessage(messages.saveButton)}</Button>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default EditTeamMemberModal;

--- a/src/courseTeam/components/EditTeamMemberModal.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.tsx
@@ -44,30 +44,55 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
   };
 
   const handleSave = () => {
-    if (selectedRole) {
-      addTeamMember({ identifiers: [user.username], role: selectedRole }, {
-        onError: () => {
-          showModal({
-            message: intl.formatMessage(messages.addRoleError),
-            variant: 'danger',
-            confirmText: intl.formatMessage(messages.closeButton),
-          });
-        } }
-      );
-    }
     const rolesToRemove = user.roles.filter(role => !keepRoles.includes(role.role)).map(role => role.role);
-    if (rolesToRemove.length > 0) {
+    const hasRolesToAdd = selectedRole;
+    const hasRolesToRemove = rolesToRemove.length > 0;
+
+    // Sequential approach: remove roles first, then add new role
+    if (hasRolesToRemove) {
       removeTeamMember({ identifier: user.username, roles: rolesToRemove }, {
+        onSuccess: () => {
+          // After successful removal, add new role if needed
+          if (hasRolesToAdd) {
+            addTeamMember({ identifiers: [user.username], role: selectedRole }, {
+              onSuccess: () => {
+                onClose();
+              },
+              onError: () => {
+                showModal({
+                  message: intl.formatMessage(messages.addRoleError),
+                  variant: 'danger',
+                  confirmText: intl.formatMessage(messages.closeButton),
+                });
+              }
+            });
+          } else {
+            onClose();
+          }
+        },
         onError: () => {
           showModal({
             message: intl.formatMessage(messages.removeTeamMemberError, { username: user.username }),
             variant: 'danger',
             confirmText: intl.formatMessage(messages.closeButton),
           });
-        } }
-      );
+        }
+      });
+    } else if (hasRolesToAdd) {
+      // Only add operation needed
+      addTeamMember({ identifiers: [user.username], role: selectedRole }, {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: () => {
+          showModal({
+            message: intl.formatMessage(messages.addRoleError),
+            variant: 'danger',
+            confirmText: intl.formatMessage(messages.closeButton),
+          });
+        }
+      });
     }
-    onClose();
   };
 
   return (
@@ -111,7 +136,7 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
       <ModalDialog.Footer className="border-light-700 border-top">
         <ActionRow>
           <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelButton)}</Button>
-          <Button variant="primary" onClick={handleSave} disabled={isAdding || isRemoving}>
+          <Button variant="primary" onClick={handleSave} disabled={isAdding || isRemoving || (keepRoles.length === user.roles.length && !selectedRole)}>
             {intl.formatMessage(messages.saveButton)}
           </Button>
         </ActionRow>

--- a/src/courseTeam/components/EditTeamMemberModal.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { ActionRow, Button, Form, FormControl, FormLabel, ModalDialog } from '@openedx/paragon';
 import { useAddTeamMember, useRemoveTeamMember, useRoles } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember, Role } from '@src/courseTeam/types';
+import { useAlert } from '@src/providers/AlertProvider';
 
 interface EditTeamMemberModalProps {
   isOpen: boolean,
@@ -16,11 +17,19 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [selectedRole, setSelectedRole] = useState('');
-  const [keepRoles, setKeepRoles] = useState<string[]>(user.roles.map(role => role.role));
-  const { mutate: addTeamMember } = useAddTeamMember(courseId);
-  const { mutate: removeTeamMember } = useRemoveTeamMember(courseId);
+  const [keepRoles, setKeepRoles] = useState<string[]>([]);
+  const { mutate: addTeamMember, isPending: isAdding } = useAddTeamMember(courseId);
+  const { mutate: removeTeamMember, isPending: isRemoving } = useRemoveTeamMember(courseId);
+  const { showModal } = useAlert();
 
   const { data: { results } = { results: [] } } = useRoles(courseId);
+
+  useEffect(() => {
+    if (isOpen) {
+      setKeepRoles(user.roles.map(role => role.role));
+      setSelectedRole('');
+    }
+  }, [isOpen, user]);
 
   const filteredRoles = results?.filter(role => !user.roles.some(userRole => userRole.role === role.role)) || [];
 
@@ -36,11 +45,27 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
 
   const handleSave = () => {
     if (selectedRole) {
-      addTeamMember({ identifiers: [user.username], role: selectedRole });
+      addTeamMember({ identifiers: [user.username], role: selectedRole }, {
+        onError: () => {
+          showModal({
+            message: intl.formatMessage(messages.addRoleError),
+            variant: 'danger',
+            confirmText: intl.formatMessage(messages.closeButton),
+          });
+        } }
+      );
     }
     const rolesToRemove = user.roles.filter(role => !keepRoles.includes(role.role)).map(role => role.role);
     if (rolesToRemove.length > 0) {
-      removeTeamMember({ identifier: user.username, role: rolesToRemove });
+      removeTeamMember({ identifier: user.username, roles: rolesToRemove }, {
+        onError: () => {
+          showModal({
+            message: intl.formatMessage(messages.removeTeamMemberError, { username: user.username }),
+            variant: 'danger',
+            confirmText: intl.formatMessage(messages.closeButton),
+          });
+        } }
+      );
     }
     onClose();
   };
@@ -86,7 +111,9 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
       <ModalDialog.Footer className="border-light-700 border-top">
         <ActionRow>
           <Button variant="tertiary" onClick={onClose}>{intl.formatMessage(messages.cancelButton)}</Button>
-          <Button variant="primary" onClick={handleSave}>{intl.formatMessage(messages.saveButton)}</Button>
+          <Button variant="primary" onClick={handleSave} disabled={isAdding || isRemoving}>
+            {intl.formatMessage(messages.saveButton)}
+          </Button>
         </ActionRow>
       </ModalDialog.Footer>
     </ModalDialog>

--- a/src/courseTeam/components/MembersContent.test.tsx
+++ b/src/courseTeam/components/MembersContent.test.tsx
@@ -18,13 +18,14 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockTeamMembers = [
-  { username: 'user1', email: 'user1@example.com', role: 'Admin' },
-  { username: 'user2', email: 'user2@example.com', role: 'Staff' },
+  { username: 'user1', fullName: 'User One', email: 'user1@example.com', roles: [{ role: 'Admin', displayName: 'Admin' }] },
+  { username: 'user2', fullName: 'User Two', email: 'user2@example.com', roles: [{ role: 'Staff', displayName: 'Staff' }] },
 ];
 
 const mockRoles = { results: [{ role: 'Admin', displayName: 'Admin' }, { role: 'Staff', displayName: 'Staff' }] };
+const mockOnEdit = jest.fn();
 
-const renderComponent = () => renderWithIntl(<MembersContent />);
+const renderComponent = () => renderWithIntl(<MembersContent onEdit={mockOnEdit} />);
 
 describe('MembersContent', () => {
   beforeEach(() => {
@@ -52,10 +53,10 @@ describe('MembersContent', () => {
 
     expect(screen.getByText(mockTeamMembers[0].username)).toBeInTheDocument();
     expect(screen.getByText(mockTeamMembers[0].email)).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: mockTeamMembers[0].role })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: mockTeamMembers[0].roles.map((role) => role.displayName).join(', ') })).toBeInTheDocument();
     expect(screen.getByText(mockTeamMembers[1].username)).toBeInTheDocument();
     expect(screen.getByText(mockTeamMembers[1].email)).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: mockTeamMembers[1].role })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: mockTeamMembers[1].roles.map((role) => role.displayName).join(', ') })).toBeInTheDocument();
   });
 
   it('renders empty state when no team members', () => {
@@ -128,5 +129,41 @@ describe('MembersContent', () => {
     expect(screen.getByText(messages.email.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.role.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.actions.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('calls onEdit when edit button is clicked', async () => {
+    (useTeamMembers as jest.Mock).mockReturnValue({
+      data: { results: mockTeamMembers, numPages: 1, count: 2 },
+      isLoading: false,
+    });
+
+    renderComponent();
+
+    const user = userEvent.setup();
+    const editButtons = screen.getAllByText(messages.edit.defaultMessage);
+
+    // Click the first edit button
+    await user.click(editButtons[0]);
+
+    expect(mockOnEdit).toHaveBeenCalledTimes(1);
+    expect(mockOnEdit).toHaveBeenCalledWith(mockTeamMembers[0]);
+  });
+
+  it('calls onEdit with correct user data for second edit button', async () => {
+    (useTeamMembers as jest.Mock).mockReturnValue({
+      data: { results: mockTeamMembers, numPages: 1, count: 2 },
+      isLoading: false,
+    });
+
+    renderComponent();
+
+    const user = userEvent.setup();
+    const editButtons = screen.getAllByText(messages.edit.defaultMessage);
+
+    // Click the second edit button
+    await user.click(editButtons[1]);
+
+    expect(mockOnEdit).toHaveBeenCalledTimes(1);
+    expect(mockOnEdit).toHaveBeenCalledWith(mockTeamMembers[1]);
   });
 });

--- a/src/courseTeam/components/MembersContent.tsx
+++ b/src/courseTeam/components/MembersContent.tsx
@@ -6,10 +6,14 @@ import { FilterList } from '@openedx/paragon/icons';
 import UsernameFilter from '@src/components/UsernameFilter';
 import { useRoles, useTeamMembers } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
-import { Role } from '@src/courseTeam/types';
+import { CourseTeamMember, Role } from '@src/courseTeam/types';
 import { DataTableFetchDataProps } from '@src/types';
 
 const TEAM_MEMBERS_PAGE_SIZE = 25;
+
+interface MembersContentProps {
+  onEdit: (user: CourseTeamMember) => void,
+}
 
 const RoleFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
   const intl = useIntl();
@@ -44,7 +48,7 @@ const RoleFilter = ({ column: { filterValue, setFilter } }: { column: { filterVa
   );
 };
 
-const MembersContent = () => {
+const MembersContent = ({ onEdit }: MembersContentProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [filters, setFilters] = useState({ page: 0, emailOrUsername: '', role: '' });
@@ -53,23 +57,23 @@ const MembersContent = () => {
   const tableColumns = useMemo(() => [
     { accessor: 'username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter },
     { accessor: 'email', Header: intl.formatMessage(messages.email), disableFilters: true },
-    { accessor: 'role', Header: intl.formatMessage(messages.role), Filter: RoleFilter },
+    { accessor: 'roles', Header: intl.formatMessage(messages.role), Cell: ({ cell: { value } }: { cell: { value: Role[] } }) => value.map(role => role.displayName).join(', '), Filter: RoleFilter },
   ], [intl]);
 
   const additionalColumns = useMemo(() => [{
     id: 'actions',
     Header: intl.formatMessage(messages.actions),
-    Cell: () => (
-      <Button variant="link" size="inline">
+    Cell: ({ row }: { row: { original: any } }) => (
+      <Button variant="link" size="inline" onClick={() => onEdit(row.original)}>
         {intl.formatMessage(messages.edit)}
       </Button>
     )
-  }], [intl]);
+  }], [intl, onEdit]);
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
     const usernameFilter = data.filters?.find((f) => f.id === 'username');
     const newEmailOrUsername = usernameFilter ? usernameFilter.value : '';
-    const rolesFilter = data.filters?.find((f) => f.id === 'role');
+    const rolesFilter = data.filters?.find((f) => f.id === 'roles');
     const newRole = rolesFilter ? rolesFilter.value : '';
     const filtersChanged = (newEmailOrUsername !== filters.emailOrUsername) || (newRole !== filters.role);
 

--- a/src/courseTeam/components/MembersContent.tsx
+++ b/src/courseTeam/components/MembersContent.tsx
@@ -1,10 +1,10 @@
 import { useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, DataTable, FormControl, Icon } from '@openedx/paragon';
-import { FilterList } from '@openedx/paragon/icons';
+import { Button, DataTable } from '@openedx/paragon';
 import UsernameFilter from '@src/components/UsernameFilter';
-import { useRoles, useTeamMembers } from '@src/courseTeam/data/apiHook';
+import RoleFilter from '@src/courseTeam/components/RoleFilter';
+import { useTeamMembers } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember, Role } from '@src/courseTeam/types';
 import { DataTableFetchDataProps } from '@src/types';
@@ -14,39 +14,6 @@ const TEAM_MEMBERS_PAGE_SIZE = 25;
 interface MembersContentProps {
   onEdit: (user: CourseTeamMember) => void,
 }
-
-const RoleFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
-  const intl = useIntl();
-  const { courseId = '' } = useParams<{ courseId: string }>();
-  const { data } = useRoles(courseId);
-
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setFilter(e.target.value);
-  };
-
-  const roles = useMemo(() => {
-    return [{ value: '', label: intl.formatMessage(messages.allRoles) }, ...(data?.results || []).map((role: Role) => ({ value: role.role, label: role.displayName }))];
-  }, [data, intl]);
-
-  return (
-    <FormControl
-      as="select"
-      className="mb-0"
-      disabled={!data}
-      name="role"
-      size="md"
-      value={filterValue}
-      onChange={handleSelectChange}
-      leadingElement={<Icon src={FilterList} />}
-    >
-      {roles.map(role => (
-        <option key={role.value} value={role.value}>
-          {role.label}
-        </option>
-      ))}
-    </FormControl>
-  );
-};
 
 const MembersContent = ({ onEdit }: MembersContentProps) => {
   const intl = useIntl();

--- a/src/courseTeam/components/RoleFilter.test.tsx
+++ b/src/courseTeam/components/RoleFilter.test.tsx
@@ -1,0 +1,181 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RoleFilter from '@src/courseTeam/components/RoleFilter';
+import { useRoles } from '@src/courseTeam/data/apiHook';
+import messages from '@src/courseTeam/messages';
+import { renderWithIntl } from '@src/testUtils';
+
+// Mocks
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ courseId: 'course-v1:test+course+run' }),
+}));
+
+jest.mock('@src/courseTeam/data/apiHook', () => ({
+  useRoles: jest.fn(),
+}));
+
+const mockRoles = [
+  { role: 'instructor', displayName: 'Instructor' },
+  { role: 'staff', displayName: 'Staff' },
+  { role: 'admin', displayName: 'Admin' },
+  { role: 'beta_testers', displayName: 'Beta Testers' },
+  { role: 'data_researcher', displayName: 'Data Researcher' },
+];
+
+describe('RoleFilter', () => {
+  const mockSetFilter = jest.fn();
+  const defaultProps = {
+    column: {
+      filterValue: '',
+      setFilter: mockSetFilter,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly with data loaded', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).not.toBeDisabled();
+  });
+
+  it('renders disabled when data is not loaded', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: null });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).toBeDisabled();
+  });
+
+  it('displays "All Roles" as the first option', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const allRolesOption = screen.getByRole('option', { name: messages.allRoles.defaultMessage });
+    expect(allRolesOption).toBeInTheDocument();
+    expect(allRolesOption).toHaveValue('');
+  });
+
+  it('displays role options from API data', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    mockRoles.forEach((role) => {
+      const roleOption = screen.getByRole('option', { name: role.displayName });
+      expect(roleOption).toBeInTheDocument();
+      expect(roleOption).toHaveValue(role.role);
+    });
+  });
+
+  it('displays current filter value as selected', () => {
+    const propsWithFilterValue = {
+      column: {
+        filterValue: 'staff',
+        setFilter: mockSetFilter,
+      },
+    };
+
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...propsWithFilterValue} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveValue('staff');
+  });
+
+  it('calls setFilter when option is selected', async () => {
+    const user = userEvent.setup();
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    await user.selectOptions(selectElement, 'instructor');
+
+    expect(mockSetFilter).toHaveBeenCalledWith('instructor');
+  });
+
+  it('calls setFilter with empty string when "All Roles" is selected', async () => {
+    const user = userEvent.setup();
+    const propsWithFilterValue = {
+      column: {
+        filterValue: 'staff',
+        setFilter: mockSetFilter,
+      },
+    };
+
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...propsWithFilterValue} />);
+
+    const selectElement = screen.getByRole('combobox');
+    await user.selectOptions(selectElement, '');
+
+    expect(mockSetFilter).toHaveBeenCalledWith('');
+  });
+
+  it('handles empty roles array gracefully', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: [] } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).not.toBeDisabled();
+
+    // Should still have "All Roles" option
+    const allRolesOption = screen.getByRole('option', { name: messages.allRoles.defaultMessage });
+    expect(allRolesOption).toBeInTheDocument();
+
+    // Should not have any other options
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+  });
+
+  it('handles undefined results gracefully', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: undefined } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).not.toBeDisabled();
+
+    // Should still have "All Roles" option
+    const allRolesOption = screen.getByRole('option', { name: messages.allRoles.defaultMessage });
+    expect(allRolesOption).toBeInTheDocument();
+
+    // Should not have any other options
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+  });
+
+  it('includes filter icon as leading element', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    // The icon is rendered as a leading element, we can check it exists by looking for the svg
+    const iconElement = document.querySelector('svg');
+    expect(iconElement).toBeInTheDocument();
+  });
+
+  it('has correct accessibility attributes', () => {
+    (useRoles as jest.Mock).mockReturnValue({ data: { results: mockRoles } });
+
+    renderWithIntl(<RoleFilter {...defaultProps} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveAttribute('name', 'role');
+  });
+});

--- a/src/courseTeam/components/RoleFilter.tsx
+++ b/src/courseTeam/components/RoleFilter.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router';
+import { useIntl } from '@openedx/frontend-base';
+import { FormControl, Icon } from '@openedx/paragon';
+import { FilterList } from '@openedx/paragon/icons';
+import { useRoles } from '@src/courseTeam/data/apiHook';
+import messages from '@src/courseTeam/messages';
+import { Role } from '@src/courseTeam/types';
+
+const RoleFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { data } = useRoles(courseId);
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilter(e.target.value);
+  };
+
+  const roles = useMemo(() => {
+    return [{ value: '', label: intl.formatMessage(messages.allRoles) }, ...(data?.results || []).map((role: Role) => ({ value: role.role, label: role.displayName }))];
+  }, [data, intl]);
+
+  return (
+    <FormControl
+      as="select"
+      className="mb-0"
+      disabled={!data}
+      name="role"
+      size="md"
+      value={filterValue}
+      onChange={handleSelectChange}
+      leadingElement={<Icon src={FilterList} />}
+    >
+      {roles.map(role => (
+        <option key={role.value} value={role.value}>
+          {role.label}
+        </option>
+      ))}
+    </FormControl>
+  );
+};
+
+export default RoleFilter;

--- a/src/courseTeam/components/RoleFilter.tsx
+++ b/src/courseTeam/components/RoleFilter.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { FormControl, Icon } from '@openedx/paragon';
 import { FilterList } from '@openedx/paragon/icons';

--- a/src/courseTeam/data/api.test.ts
+++ b/src/courseTeam/data/api.test.ts
@@ -109,16 +109,16 @@ describe('courseTeam API', () => {
     it('should call the correct endpoint to remove a team member', async () => {
       const courseId = 'course-v1:edX+DemoX+Demo_Course';
       const identifier = 'testuser';
-      const role = ['instructor'];
+      const roles = ['instructor'];
       httpClientMock.delete.mockResolvedValue({ data: {
         identifier,
-        role,
+        roles,
       } });
 
-      await removeTeamMember(courseId, identifier, role);
+      await removeTeamMember(courseId, identifier, roles);
 
       const expectedUrl = `/api/instructor/v2/courses/${courseId}/team/${identifier}`;
-      expect(httpClientMock.delete).toHaveBeenCalledWith(expectedUrl, { data: { role } });
+      expect(httpClientMock.delete).toHaveBeenCalledWith(expectedUrl, { data: { roles } });
     });
   });
 });

--- a/src/courseTeam/data/api.test.ts
+++ b/src/courseTeam/data/api.test.ts
@@ -1,5 +1,5 @@
 import { getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { getTeamMembers, getRoles, addTeamMember } from '@src/courseTeam/data/api';
+import { getTeamMembers, getRoles, addTeamMember, removeTeamMember } from '@src/courseTeam/data/api';
 
 jest.mock('@openedx/frontend-base', () => ({
   ...jest.requireActual('@openedx/frontend-base'),
@@ -13,6 +13,7 @@ jest.mock('../../data/api', () => ({
 const httpClientMock = {
   get: jest.fn(),
   post: jest.fn(),
+  delete: jest.fn(),
 };
 
 beforeEach(() => {
@@ -101,6 +102,23 @@ describe('courseTeam API', () => {
 
       const expectedUrl = `/api/instructor/v2/courses/${courseId}/team`;
       expect(httpClientMock.post).toHaveBeenCalledWith(expectedUrl, { identifiers, role });
+    });
+  });
+
+  describe('removeTeamMember', () => {
+    it('should call the correct endpoint to remove a team member', async () => {
+      const courseId = 'course-v1:edX+DemoX+Demo_Course';
+      const identifier = 'testuser';
+      const role = ['instructor'];
+      httpClientMock.delete.mockResolvedValue({ data: {
+        identifier,
+        role,
+      } });
+
+      await removeTeamMember(courseId, identifier, role);
+
+      const expectedUrl = `/api/instructor/v2/courses/${courseId}/team/${identifier}`;
+      expect(httpClientMock.delete).toHaveBeenCalledWith(expectedUrl, { data: { role } });
     });
   });
 });

--- a/src/courseTeam/data/api.ts
+++ b/src/courseTeam/data/api.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
-import { AddTeamMembersResponse, CourseTeamMember, CourseTeamMemberQueryParams, Role } from '@src/courseTeam/types';
+import { TeamMembersResponse, CourseTeamMember, CourseTeamMemberQueryParams, Role } from '@src/courseTeam/types';
 
 export const getTeamMembers = async (
   courseId: string,
@@ -33,10 +33,18 @@ export const getRoles = async (courseId: string): Promise<Omit<DataList<Role>, '
   return camelCaseObject(data);
 };
 
-export const addTeamMember = async (courseId: string, identifiers: string[], role: string): Promise<AddTeamMembersResponse> => {
+export const addTeamMember = async (courseId: string, identifiers: string[], role: string): Promise<TeamMembersResponse> => {
   const { data } = await getAuthenticatedHttpClient().post(
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team`,
     { identifiers, role }
+  );
+  return camelCaseObject(data);
+};
+
+export const removeTeamMember = async (courseId: string, identifier: string, role: string[]): Promise<TeamMembersResponse> => {
+  const { data } = await getAuthenticatedHttpClient().delete(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team/${identifier}`,
+    { data: { role } }
   );
   return camelCaseObject(data);
 };

--- a/src/courseTeam/data/api.ts
+++ b/src/courseTeam/data/api.ts
@@ -41,10 +41,10 @@ export const addTeamMember = async (courseId: string, identifiers: string[], rol
   return camelCaseObject(data);
 };
 
-export const removeTeamMember = async (courseId: string, identifier: string, role: string[]): Promise<TeamMembersResponse> => {
+export const removeTeamMember = async (courseId: string, identifier: string, roles: string[]): Promise<TeamMembersResponse> => {
   const { data } = await getAuthenticatedHttpClient().delete(
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team/${identifier}`,
-    { data: { role } }
+    { data: { roles } }
   );
   return camelCaseObject(data);
 };

--- a/src/courseTeam/data/apiHook.test.tsx
+++ b/src/courseTeam/data/apiHook.test.tsx
@@ -168,7 +168,7 @@ describe('apiHook', () => {
         wrapper: createWrapper(),
       });
 
-      result.current.mutate({ identifier: 'user1', role: ['admin'] }, {
+      result.current.mutate({ identifier: 'user1', roles: ['admin'] }, {
         onSuccess: jest.fn(),
         onError: jest.fn(),
       });

--- a/src/courseTeam/data/apiHook.test.tsx
+++ b/src/courseTeam/data/apiHook.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { useTeamMembers, useRoles, useAddTeamMember } from '@src/courseTeam/data/apiHook';
+import { useTeamMembers, useRoles, useAddTeamMember, useRemoveTeamMember } from '@src/courseTeam/data/apiHook';
 import * as api from '@src/courseTeam/data/api';
 import { CourseTeamMember } from '@src/courseTeam/types';
 import { DataList } from '@src/types';
@@ -11,6 +11,7 @@ jest.mock('@src/courseTeam/data/api');
 const mockGetTeamMembers = api.getTeamMembers as jest.MockedFunction<typeof api.getTeamMembers>;
 const mockGetRoles = api.getRoles as jest.MockedFunction<typeof api.getRoles>;
 const mockAddTeamMember = api.addTeamMember as jest.MockedFunction<typeof api.addTeamMember>;
+const mockRemoveTeamMember = api.removeTeamMember as jest.MockedFunction<typeof api.removeTeamMember>;
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -36,8 +37,8 @@ describe('apiHook', () => {
         count: 2,
         numPages: 1,
         results: [
-          { username: 'john.doe', email: 'john@example.com', role: 'instructor' },
-          { username: 'jane.smith', email: 'jane@example.com', role: 'staff' },
+          { username: 'john.doe', fullName: 'John Doe', email: 'john@example.com', roles: [{ role: 'instructor', displayName: 'Admin' }] },
+          { username: 'jane.smith', fullName: 'Jane Smith', email: 'jane@example.com', roles: [{ role: 'staff', displayName: 'Staff' }, { role: 'admin', displayName: 'Admin' }] },
         ],
       };
 
@@ -156,6 +157,27 @@ describe('apiHook', () => {
       });
 
       expect(api.addTeamMember).toHaveBeenCalledWith('course-v1:org+course+run', ['user1', 'user2'], 'admin');
+    });
+  });
+
+  describe('useRemoveTeamMember', () => {
+    it('should call removeTeamMember API with correct parameters', async () => {
+      mockRemoveTeamMember.mockResolvedValue({ results: [] });
+
+      const { result } = renderHook(() => useRemoveTeamMember('course-v1:org+course+run'), {
+        wrapper: createWrapper(),
+      });
+
+      result.current.mutate({ identifier: 'user1', role: ['admin'] }, {
+        onSuccess: jest.fn(),
+        onError: jest.fn(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(api.removeTeamMember).toHaveBeenCalledWith('course-v1:org+course+run', 'user1', ['admin']);
     });
   });
 });

--- a/src/courseTeam/data/apiHook.ts
+++ b/src/courseTeam/data/apiHook.ts
@@ -33,7 +33,7 @@ export const useAddTeamMember = (courseId: string) => {
 export const useRemoveTeamMember = (courseId: string) => {
   const queryClient = useQueryClient();
   return (useMutation({
-    mutationFn: ({ identifier, role }: { identifier: string, role: string[] }) => removeTeamMember(courseId, identifier, role),
+    mutationFn: ({ identifier, roles }: { identifier: string, roles: string[] }) => removeTeamMember(courseId, identifier, roles),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: courseTeamQueryKeys.byCourse(courseId) });
     }

--- a/src/courseTeam/data/apiHook.ts
+++ b/src/courseTeam/data/apiHook.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { addTeamMember, getRoles, getTeamMembers } from '@src/courseTeam/data/api';
+import { addTeamMember, getRoles, getTeamMembers, removeTeamMember } from '@src/courseTeam/data/api';
 import { courseTeamQueryKeys } from '@src/courseTeam/data/queryKeys';
 import { CourseTeamMemberQueryParams } from '@src/courseTeam/types';
 
@@ -23,6 +23,17 @@ export const useAddTeamMember = (courseId: string) => {
   const queryClient = useQueryClient();
   return (useMutation({
     mutationFn: ({ identifiers, role }: { identifiers: string[], role: string }) => addTeamMember(courseId, identifiers, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: courseTeamQueryKeys.byCourse(courseId) });
+    }
+  })
+  );
+};
+
+export const useRemoveTeamMember = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return (useMutation({
+    mutationFn: ({ identifier, role }: { identifier: string, role: string[] }) => removeTeamMember(courseId, identifier, role),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: courseTeamQueryKeys.byCourse(courseId) });
     }

--- a/src/courseTeam/messages.ts
+++ b/src/courseTeam/messages.ts
@@ -231,6 +231,16 @@ const messages = defineMessages({
     defaultMessage: 'Add role',
     description: 'Label for adding a role to a team member',
   },
+  removeTeamMemberError: {
+    id: 'instruct.courseTeam.removeTeamMemberError',
+    defaultMessage: 'Failed to remove one or more roles from {username}.',
+    description: 'Error message displayed when removing a team member fails',
+  },
+  addRoleError: {
+    id: 'instruct.courseTeam.addRoleError',
+    defaultMessage: 'Failed to add role to {username}.',
+    description: 'Error message displayed when adding a role to a team member fails',
+  }
 });
 
 export default messages;

--- a/src/courseTeam/messages.ts
+++ b/src/courseTeam/messages.ts
@@ -216,6 +216,21 @@ const messages = defineMessages({
     defaultMessage: 'Unknown learner: {learner}',
     description: 'Displayed when a learner does not have a full name or username available',
   },
+  editTeamTitle: {
+    id: 'instruct.courseTeam.editTeamTitle',
+    defaultMessage: 'Edit {username} Roles',
+    description: 'Title for edit team member modal',
+  },
+  editInstructions: {
+    id: 'instruct.courseTeam.editInstructions',
+    defaultMessage: 'Uncheck to remove role from {username}',
+    description: 'Instructions for editing a team member',
+  },
+  addRole: {
+    id: 'instruct.courseTeam.addRole',
+    defaultMessage: 'Add role',
+    description: 'Label for adding a role to a team member',
+  },
 });
 
 export default messages;

--- a/src/courseTeam/types.ts
+++ b/src/courseTeam/types.ts
@@ -1,8 +1,9 @@
 export interface CourseTeamMember {
   username: string,
+  fullName: string,
   email: string,
-  role: string,
-}
+  roles: Role[],
+};
 
 export interface CourseTeamMemberQueryParams {
   page: number,
@@ -16,7 +17,7 @@ export interface Role {
   displayName: string,
 }
 
-export interface AddTeamMembersResponse {
+export interface TeamMembersResponse {
   results: {
     identifier: string,
     userDoesNotExist: boolean,


### PR DESCRIPTION
## Description
Edit team member modal

## Supporting information
Closes #105 

## Testing instructions
- Go to course team tab with a valid course id, example: http://apps.local.openedx.io:2003/instructor-dashboard/course-v1:OpenedX+DemoX+DemoCourse/course_team
- Click on edit on some user row on the main table on members tab
- modify the roles of the user

## Screenshot
<img width="1537" height="888" alt="Screenshot 2026-04-17 at 1 10 36 p m" src="https://github.com/user-attachments/assets/b4e2bd17-da5b-498b-84fa-37507e96e592" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
