### PR TITLE
Special exam attempts

### DIFF
--- a/src/specialExams/SpecialExamsPage.test.tsx
+++ b/src/specialExams/SpecialExamsPage.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithIntl } from '@src/testUtils';
+import SpecialExamsPage from './SpecialExamsPage';
+
+// Mock child components
+jest.mock('./components/Allowances', () => {
+  function MockedAllowances() {
+    return <div>Allowances Component</div>;
+  }
+  return MockedAllowances;
+});
+jest.mock('./components/AttemptsList', () => {
+  function MockedAttemptsList() {
+    return <div>AttemptsList Component</div>;
+  }
+  return MockedAttemptsList;
+});
+
+describe('SpecialExamsPage', () => {
+  it('renders the page title', () => {
+    renderWithIntl(<SpecialExamsPage />);
+    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+  });
+
+  it('renders the attempts tab and its content by default', () => {
+    renderWithIntl(<SpecialExamsPage />);
+    expect(screen.getByText('Exam Attempts')).toBeInTheDocument();
+    expect(screen.getByText('AttemptsList Component')).toBeInTheDocument();
+    expect(screen.queryByText('Allowances Component')).not.toBeInTheDocument();
+  });
+
+  it('switches to allowances tab when clicked', async () => {
+    renderWithIntl(<SpecialExamsPage />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Allowances'));
+    expect(screen.getByText('Allowances Component')).toBeInTheDocument();
+    expect(screen.queryByText('AttemptsList Component')).not.toBeInTheDocument();
+  });
+
+  it('switches back to attempts tab when clicked', async () => {
+    renderWithIntl(<SpecialExamsPage />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Allowances'));
+    await user.click(screen.getByText('Exam Attempts'));
+    expect(screen.getByText('AttemptsList Component')).toBeInTheDocument();
+    expect(screen.queryByText('Allowances Component')).not.toBeInTheDocument();
+  });
+
+  it('applies correct button variants based on selected tab', async () => {
+    renderWithIntl(<SpecialExamsPage />);
+    const attemptsButton = screen.getByText('Exam Attempts');
+    const allowancesButton = screen.getByText('Allowances');
+    expect(attemptsButton).toHaveClass('btn-primary');
+    expect(allowancesButton).toHaveClass('btn-outline-primary');
+    const user = userEvent.setup();
+    await user.click(allowancesButton);
+    expect(allowancesButton).toHaveClass('btn-primary');
+    expect(attemptsButton).toHaveClass('btn-outline-primary');
+  });
+});

--- a/src/specialExams/SpecialExamsPage.tsx
+++ b/src/specialExams/SpecialExamsPage.tsx
@@ -1,8 +1,27 @@
+import { useState } from 'react';
+import { useIntl } from '@openedx/frontend-base';
+import { Button, ButtonGroup, Card } from '@openedx/paragon';
+import messages from './messages';
+import Allowances from './components/Allowances';
+import AttemptsList from './components/AttemptsList';
+
 const SpecialExamsPage = () => {
+  const intl = useIntl();
+  const [selectedTab, setSelectedTab] = useState<'attempts' | 'allowances'>('attempts');
+
   return (
-    <div>
-      <h3>Special Exams</h3>
-    </div>
+    <>
+      <h3 className="text-primary-700">{intl.formatMessage(messages.specialExamsTitle)}</h3>
+      <Card className="bg-light-200 mt-4.5">
+        <ButtonGroup className="d-block mx-4 mt-4">
+          <Button variant={selectedTab === 'attempts' ? 'primary' : 'outline-primary'} onClick={() => setSelectedTab('attempts')}>{intl.formatMessage(messages.examAttempts)}</Button>
+          <Button variant={selectedTab === 'allowances' ? 'primary' : 'outline-primary'} onClick={() => setSelectedTab('allowances')}>{intl.formatMessage(messages.allowances)}</Button>
+        </ButtonGroup>
+        {
+          selectedTab === 'attempts' ? <AttemptsList /> : <Allowances />
+        }
+      </Card>
+    </>
   );
 };
 

--- a/src/specialExams/components/Allowances.tsx
+++ b/src/specialExams/components/Allowances.tsx
@@ -1,0 +1,5 @@
+const Allowances = () => {
+  return <div>Allowances</div>;
+};
+
+export default Allowances;

--- a/src/specialExams/components/AttemptsList.test.tsx
+++ b/src/specialExams/components/AttemptsList.test.tsx
@@ -1,0 +1,103 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AttemptsList, { ATTEMPTS_PAGE_SIZE } from './AttemptsList';
+import { renderWithIntl } from '@src/testUtils';
+import { useAttempts } from '../data/apiHook';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useAttempts: jest.fn(),
+}));
+
+const mockExamAttempts = {
+  results: [
+    {
+      username: 'user1',
+      examName: 'Midterm',
+      timeLimit: '60',
+      type: 'proctored',
+      startedAt: '2024-01-01',
+      completedAt: '2024-01-02',
+      status: 'completed',
+    },
+  ],
+  count: 1,
+  numPages: 1,
+};
+
+describe('AttemptsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders DataTable with correct columns and empty data', () => {
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: { results: [], count: 0, numPages: 0 },
+      isLoading: false,
+    });
+
+    renderWithIntl(<AttemptsList />);
+
+    expect(screen.getByText('No exam attempts found')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search By Username or Email')).toBeInTheDocument();
+  });
+
+  it('shows loading state when isLoading is true', () => {
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: { results: [], count: 0, numPages: 0 },
+      isLoading: true,
+    });
+
+    renderWithIntl(<AttemptsList />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders attempts data', () => {
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: mockExamAttempts,
+      isLoading: false,
+    });
+
+    renderWithIntl(<AttemptsList />);
+    expect(screen.getByText(mockExamAttempts.results[0].username)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].examName)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].timeLimit)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].type)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].startedAt)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].completedAt)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].status)).toBeInTheDocument();
+  });
+
+  it('calls fetchData when filter changes', async () => {
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: { results: [], count: 0, numPages: 0 },
+      isLoading: false,
+    });
+
+    renderWithIntl(<AttemptsList />);
+
+    const input = screen.getByRole('textbox');
+    const user = userEvent.setup();
+    await user.type(input, 'testuser');
+
+    await waitFor(() => {
+      expect(useAttempts).toHaveBeenCalledWith(
+        'course-v1:edX+Test+2024', expect.objectContaining({ emailOrUsername: 'testuser', page: 0, pageSize: ATTEMPTS_PAGE_SIZE }),
+      );
+    });
+  });
+
+  it('uses courseId from route params', () => {
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: { results: [], count: 0, numPages: 0 },
+      isLoading: false,
+    });
+
+    renderWithIntl(<AttemptsList />);
+    expect(useAttempts).toHaveBeenCalledWith('course-v1:edX+Test+2024', expect.any(Object));
+  });
+});

--- a/src/specialExams/components/AttemptsList.tsx
+++ b/src/specialExams/components/AttemptsList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { DataTable } from '@openedx/paragon';
@@ -18,7 +18,7 @@ const AttemptsList = () => {
     pageSize: ATTEMPTS_PAGE_SIZE
   });
 
-  const columns = [
+  const columns = useMemo(() => [
     { accessor: 'username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter, },
     { accessor: 'examName', Header: intl.formatMessage(messages.examName), disableFilters: true, },
     { accessor: 'timeLimit', Header: intl.formatMessage(messages.timeLimit), disableFilters: true, },
@@ -26,7 +26,7 @@ const AttemptsList = () => {
     { accessor: 'startedAt', Header: intl.formatMessage(messages.startedAt), disableFilters: true, },
     { accessor: 'completedAt', Header: intl.formatMessage(messages.completedAt), disableFilters: true, },
     { accessor: 'status', Header: intl.formatMessage(messages.status), disableFilters: true, },
-  ];
+  ], [intl]);
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
     const emailOrUsernameFilter = data.filters?.find((f) => f.id === 'username');

--- a/src/specialExams/components/AttemptsList.tsx
+++ b/src/specialExams/components/AttemptsList.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { DataTable } from '@openedx/paragon';
+import UsernameFilter from '@src/components/UsernameFilter';
+import messages from '@src/specialExams/messages';
+import { useAttempts } from '@src/specialExams/data/apiHook';
+import { DataTableFetchDataProps } from '@src/types';
+
+export const ATTEMPTS_PAGE_SIZE = 25;
+
+const AttemptsList = () => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams();
+  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '' });
+  const { data = { results: [], count: 0, numPages: 0 }, isLoading = false } = useAttempts(courseId, {
+    ...filters,
+    pageSize: ATTEMPTS_PAGE_SIZE
+  });
+
+  const columns = [
+    { accessor: 'username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter, },
+    { accessor: 'examName', Header: intl.formatMessage(messages.examName), disableFilters: true, },
+    { accessor: 'timeLimit', Header: intl.formatMessage(messages.timeLimit), disableFilters: true, },
+    { accessor: 'type', Header: intl.formatMessage(messages.type), disableFilters: true, },
+    { accessor: 'startedAt', Header: intl.formatMessage(messages.startedAt), disableFilters: true, },
+    { accessor: 'completedAt', Header: intl.formatMessage(messages.completedAt), disableFilters: true, },
+    { accessor: 'status', Header: intl.formatMessage(messages.status), disableFilters: true, },
+  ];
+
+  const handleFetchData = (data: DataTableFetchDataProps) => {
+    const emailOrUsernameFilter = data.filters?.find((f) => f.id === 'username');
+    if (emailOrUsernameFilter && emailOrUsernameFilter.value !== filters.emailOrUsername) {
+      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: emailOrUsernameFilter.value, page: 0 }));
+      return;
+    }
+    if (data.pageIndex !== filters.page) {
+      setFilters((prevFilters) => ({ ...prevFilters, page: data.pageIndex }));
+    }
+  };
+
+  return (
+    <DataTable
+      className="mt-3"
+      columns={columns}
+      data={data.results}
+      state={{
+        pageIndex: filters.page,
+        pageSize: ATTEMPTS_PAGE_SIZE,
+        filters: [
+          { id: 'emailOrUsername', value: filters.emailOrUsername }
+        ]
+      }}
+      fetchData={handleFetchData}
+      isFilterable
+      isLoading={isLoading}
+      isPaginated
+      isSortable
+      itemCount={data.count}
+      manualFilters
+      manualPagination
+      manualSortBy
+      pageSize={ATTEMPTS_PAGE_SIZE}
+      pageCount={data.numPages}
+      FilterStatusComponent={() => null}
+    >
+      <DataTable.TableControlBar className="bg-light-200 py-3 px-4" />
+      <DataTable.Table />
+      <DataTable.EmptyTable content={intl.formatMessage(messages.noAttempts)} />
+      <DataTable.TableFooter />
+    </DataTable>
+  );
+};
+
+export default AttemptsList;

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -1,0 +1,162 @@
+import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { getApiBaseUrl } from '@src/data/api';
+import { getAttempts } from '@src/specialExams/data/api';
+import { AttemptsParams, Attempt } from '@src/specialExams/types';
+import { DataList } from '@src/types';
+
+jest.mock('@openedx/frontend-base', () => ({
+  ...jest.requireActual('@openedx/frontend-base'),
+  camelCaseObject: jest.fn((obj) => obj),
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+jest.mock('@src/data/api', () => ({
+  getApiBaseUrl: jest.fn(),
+}));
+
+const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
+const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
+const mockGetApiBaseUrl = getApiBaseUrl as jest.MockedFunction<typeof getApiBaseUrl>;
+
+describe('specialExams api', () => {
+  const mockHttpClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockGetApiBaseUrl.mockReturnValue('https://test-lms.com');
+    mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getAttempts', () => {
+    const mockAttemptsData = {
+      count: 2,
+      num_pages: 1,
+      results: [
+        {
+          username: 'student1',
+          exam_name: 'Final Exam',
+          time_limit: 180,
+          type: 'proctored',
+          started_at: '2023-01-01T10:00:00Z',
+          completed_at: '2023-01-01T13:00:00Z',
+          status: 'completed',
+        },
+        {
+          username: 'student2',
+          exam_name: 'Midterm Exam',
+          time_limit: 120,
+          type: 'timed',
+          started_at: '2023-01-02T14:00:00Z',
+          completed_at: '2023-01-02T16:00:00Z',
+          status: 'completed',
+        },
+      ],
+    };
+
+    const mockCamelCaseData: DataList<Attempt> = {
+      count: 2,
+      numPages: 1,
+      results: [
+        {
+          username: 'student1',
+          examName: 'Final Exam',
+          timeLimit: 180,
+          type: 'proctored',
+          startedAt: '2023-01-01T10:00:00Z',
+          completedAt: '2023-01-01T13:00:00Z',
+          status: 'completed',
+        },
+        {
+          username: 'student2',
+          examName: 'Midterm Exam',
+          timeLimit: 120,
+          type: 'timed',
+          startedAt: '2023-01-02T14:00:00Z',
+          completedAt: '2023-01-02T16:00:00Z',
+          status: 'completed',
+        },
+      ],
+    };
+
+    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '' };
+
+    beforeEach(() => {
+      mockHttpClient.get.mockResolvedValue({ data: mockAttemptsData });
+      mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
+    });
+
+    it('fetches attempts successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const result = await getAttempts(courseId, params);
+
+      expect(mockGetApiBaseUrl).toHaveBeenCalled();
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=2&page_size=20'
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockAttemptsData);
+      expect(result).toBe(mockCamelCaseData);
+    });
+
+    it('handles search parameter correctly', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const paramsWithSearch: AttemptsParams = { page: 0, pageSize: 10, emailOrUsername: 'student1' };
+
+      await getAttempts(courseId, paramsWithSearch);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=1&page_size=10&search=student1'
+      );
+    });
+
+    it('handles different page and pageSize parameters', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const customParams: AttemptsParams = { page: 5, pageSize: 50, emailOrUsername: '' };
+
+      await getAttempts(courseId, customParams);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=6&page_size=50'
+      );
+    });
+
+    it('handles empty emailOrUsername parameter', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const paramsWithEmptySearch: AttemptsParams = { page: 2, pageSize: 25, emailOrUsername: '' };
+
+      await getAttempts(courseId, paramsWithEmptySearch);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=3&page_size=25'
+      );
+    });
+
+    it('handles API error', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const error = new Error('Network error');
+      mockHttpClient.get.mockRejectedValue(error);
+
+      await expect(getAttempts(courseId, params)).rejects.toThrow('Network error');
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.get).toHaveBeenCalled();
+    });
+
+    it('handles special characters in courseId and search', async () => {
+      const courseId = 'course-v1:edX+Special%20Course+2023';
+      const paramsWithSpecialChars: AttemptsParams = { page: 0, pageSize: 20, emailOrUsername: 'user@example.com' };
+
+      await getAttempts(courseId, paramsWithSpecialChars);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Special%20Course+2023/special_exams/attempts?page=1&page_size=20&search=user%40example.com'
+      );
+    });
+  });
+});

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -1,0 +1,20 @@
+import { getAuthenticatedHttpClient, camelCaseObject } from '@openedx/frontend-base';
+import { getApiBaseUrl } from '@src/data/api';
+import { DataList } from '@src/types';
+import { Attempt, AttemptsParams } from '../types';
+
+export const getAttempts = async (courseId: string, params: AttemptsParams): Promise<DataList<Attempt>> => {
+  const queryParams = new URLSearchParams({
+    page: (params.page + 1).toString(),
+    page_size: params.pageSize.toString(),
+  });
+
+  if (params.emailOrUsername) {
+    queryParams.append('search', params.emailOrUsername);
+  }
+
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/special_exams/attempts?${queryParams.toString()}`
+  );
+  return camelCaseObject(data);
+};

--- a/src/specialExams/data/apiHook.test.tsx
+++ b/src/specialExams/data/apiHook.test.tsx
@@ -1,0 +1,195 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { getAttempts } from '@src/specialExams/data/api';
+import { useAttempts } from '@src/specialExams/data/apiHook';
+import { AttemptsParams } from '@src/specialExams/types';
+
+jest.mock('@src/specialExams/data/api');
+
+const mockGetAttempts = getAttempts as jest.MockedFunction<typeof getAttempts>;
+
+const mockAttemptsData = {
+  count: 2,
+  numPages: 1,
+  results: [
+    {
+      username: 'student1',
+      examName: 'Final Exam',
+      timeLimit: 180,
+      type: 'proctored',
+      startedAt: '2023-01-01T10:00:00Z',
+      completedAt: '2023-01-01T13:00:00Z',
+      status: 'completed',
+    },
+    {
+      username: 'student2',
+      examName: 'Midterm Exam',
+      timeLimit: 120,
+      type: 'timed',
+      startedAt: '2023-01-02T14:00:00Z',
+      completedAt: '2023-01-02T16:00:00Z',
+      status: 'completed',
+    },
+  ],
+};
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  Wrapper.displayName = 'TestWrapper';
+  return Wrapper;
+};
+
+describe('specialExams api hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useAttempts', () => {
+    const courseId = 'course-v1:edX+Test+2023';
+    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '' };
+
+    it('fetches attempts successfully', async () => {
+      mockGetAttempts.mockResolvedValue(mockAttemptsData);
+
+      const { result } = renderHook(() => useAttempts(courseId, params), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
+      expect(result.current.data).toBe(mockAttemptsData);
+      expect(result.current.error).toBe(null);
+    });
+
+    it('handles API error', async () => {
+      const mockError = new Error('Network error');
+      mockGetAttempts.mockRejectedValue(mockError);
+
+      const { result } = renderHook(() => useAttempts(courseId, params), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
+      expect(result.current.error).toBe(mockError);
+      expect(result.current.data).toBe(undefined);
+    });
+
+    it('handles different params parameters', async () => {
+      const customParams: AttemptsParams = { page: 3, pageSize: 50, emailOrUsername: 'student1' };
+      mockGetAttempts.mockResolvedValue(mockAttemptsData);
+
+      const { result } = renderHook(() => useAttempts(courseId, customParams), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, customParams);
+      expect(result.current.data).toBe(mockAttemptsData);
+    });
+
+    it('is disabled when courseId is empty', () => {
+      const { result } = renderHook(() => useAttempts('', params), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(mockGetAttempts).not.toHaveBeenCalled();
+    });
+
+    it('is enabled when courseId is provided', async () => {
+      mockGetAttempts.mockResolvedValue(mockAttemptsData);
+
+      const { result } = renderHook(() => useAttempts(courseId, params), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
+    });
+
+    it('refetches data when params change', async () => {
+      mockGetAttempts.mockResolvedValue(mockAttemptsData);
+
+      const { result, rerender } = renderHook(
+        ({ params: hookParams }) => useAttempts(courseId, hookParams),
+        {
+          wrapper: createWrapper(),
+          initialProps: { params },
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledTimes(1);
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
+
+      // Change params
+      const newParams: AttemptsParams = { page: 2, pageSize: 10, emailOrUsername: 'student2' };
+      rerender({ params: newParams });
+
+      await waitFor(() => {
+        expect(mockGetAttempts).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockGetAttempts).toHaveBeenLastCalledWith(courseId, newParams);
+    });
+
+    it('refetches data when courseId changes', async () => {
+      mockGetAttempts.mockResolvedValue(mockAttemptsData);
+
+      const { result, rerender } = renderHook(
+        ({ courseId: hookCourseId }) => useAttempts(hookCourseId, params),
+        {
+          wrapper: createWrapper(),
+          initialProps: { courseId },
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetAttempts).toHaveBeenCalledTimes(1);
+      expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
+
+      // Change courseId
+      const newCourseId = 'course-v1:edX+NewCourse+2023';
+      rerender({ courseId: newCourseId });
+
+      await waitFor(() => {
+        expect(mockGetAttempts).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockGetAttempts).toHaveBeenLastCalledWith(newCourseId, params);
+    });
+  });
+});

--- a/src/specialExams/data/apiHook.ts
+++ b/src/specialExams/data/apiHook.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAttempts } from './api';
+import { specialExamsQueryKeys } from './queryKeys';
+import { AttemptsParams } from '../types';
+
+export const useAttempts = (courseId: string, params: AttemptsParams) => (
+  useQuery({
+    queryKey: specialExamsQueryKeys.attempts(courseId, params),
+    queryFn: () => getAttempts(courseId, params),
+    enabled: !!courseId,
+  })
+);

--- a/src/specialExams/data/queryKeys.ts
+++ b/src/specialExams/data/queryKeys.ts
@@ -1,0 +1,7 @@
+import { appId } from '@src/constants';
+import { AttemptsParams } from '../types';
+
+export const specialExamsQueryKeys = {
+  all: [appId, 'specialExams'] as const,
+  attempts: (courseId: string, params: AttemptsParams) => [...specialExamsQueryKeys.all, 'attempts', courseId, params.page, params.emailOrUsername] as const,
+};

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -51,11 +51,6 @@ const messages = defineMessages({
     defaultMessage: 'Status',
     description: 'Column header for status in exam attempts list',
   },
-  emailOrUsername: {
-    id: 'instruct.specialExams.emailOrUsername',
-    defaultMessage: 'username or email',
-    description: 'Placeholder for the username or email filter in exam attempts list',
-  },
   noAttempts: {
     id: 'instruct.specialExams.noAttempts',
     defaultMessage: 'No exam attempts found',

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -1,0 +1,66 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+  specialExamsTitle: {
+    id: 'instruct.specialExams.title',
+    defaultMessage: 'Special Exams',
+    description: 'Title for the special exams page'
+  },
+  examAttempts: {
+    id: 'instruct.specialExams.examAttempts',
+    defaultMessage: 'Exam Attempts',
+    description: 'Label for the exam attempts tab'
+  },
+  allowances: {
+    id: 'instruct.specialExams.allowances',
+    defaultMessage: 'Allowances',
+    description: 'Label for the allowances tab'
+  },
+  username: {
+    id: 'instruct.specialExams.username',
+    defaultMessage: 'Username',
+    description: 'Column header for username in exam attempts list',
+  },
+  examName: {
+    id: 'instruct.specialExams.examName',
+    defaultMessage: 'Exam Name',
+    description: 'Column header for exam name in exam attempts list',
+  },
+  timeLimit: {
+    id: 'instruct.specialExams.timeLimit',
+    defaultMessage: 'Time Limit',
+    description: 'Column header for time limit in exam attempts list',
+  },
+  type: {
+    id: 'instruct.specialExams.type',
+    defaultMessage: 'Type',
+    description: 'Column header for type in exam attempts list',
+  },
+  startedAt: {
+    id: 'instruct.specialExams.startedAt',
+    defaultMessage: 'Started At',
+    description: 'Column header for started at in exam attempts list',
+  },
+  completedAt: {
+    id: 'instruct.specialExams.completedAt',
+    defaultMessage: 'Completed At',
+    description: 'Column header for completed at in exam attempts list',
+  },
+  status: {
+    id: 'instruct.specialExams.status',
+    defaultMessage: 'Status',
+    description: 'Column header for status in exam attempts list',
+  },
+  emailOrUsername: {
+    id: 'instruct.specialExams.emailOrUsername',
+    defaultMessage: 'username or email',
+    description: 'Placeholder for the username or email filter in exam attempts list',
+  },
+  noAttempts: {
+    id: 'instruct.specialExams.noAttempts',
+    defaultMessage: 'No exam attempts found',
+    description: 'Message displayed when there are no exam attempts to show',
+  }
+});
+
+export default messages;

--- a/src/specialExams/types.ts
+++ b/src/specialExams/types.ts
@@ -1,0 +1,15 @@
+import { PaginationParams } from '@src/types';
+
+export interface Attempt {
+  username: string,
+  examName: string,
+  timeLimit: number,
+  type: string,
+  startedAt: string,
+  completedAt: string,
+  status: string,
+}
+
+export interface AttemptsParams extends PaginationParams {
+  emailOrUsername: string,
+}


### PR DESCRIPTION
## Description
Special Exams Layout and Attempts content tab

## Supporting information
Closes #87 

## Testing instructions
- Go to a special exams tab with a valid course id
- You should see the page title, attempts and allowances tabs, in attempts tab you should see the table with pagination and search bar

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
