### PR TITLE
Enrollment filters

### DIFF
--- a/src/dateExtensions/types.ts
+++ b/src/dateExtensions/types.ts
@@ -1,4 +1,4 @@
-import { PaginationQueryKeys } from '@src/types';
+import { PaginationParams } from '@src/types';
 
 export interface LearnerDateExtension {
   username: string,
@@ -22,7 +22,7 @@ export interface AddDateExtensionParams {
   reason: string,
 }
 
-export interface DateExtensionQueryParams extends PaginationQueryKeys {
+export interface DateExtensionQueryParams extends PaginationParams {
   emailOrUsername?: string,
   blockId?: string,
 }

--- a/src/enrollments/components/EnrollmentsList.test.tsx
+++ b/src/enrollments/components/EnrollmentsList.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EnrollmentsList from './EnrollmentsList';
 import { useEnrollments } from '../data/apiHook';
@@ -176,11 +176,13 @@ describe('EnrollmentsList', () => {
       await user.type(usernameFilter, 'test');
 
       // Filter change should reset page to 0
-      expect(useEnrollments).toHaveBeenCalledWith('test-course-id', {
-        page: 0,
-        pageSize: 25,
-        emailOrUsername: '',
-        isBetaTester: '',
+      await waitFor(() => {
+        expect(useEnrollments).toHaveBeenCalledWith('test-course-id', {
+          page: 0,
+          pageSize: 25,
+          emailOrUsername: 'test',
+          isBetaTester: '',
+        });
       });
     });
   });

--- a/src/enrollments/components/EnrollmentsList.test.tsx
+++ b/src/enrollments/components/EnrollmentsList.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import EnrollmentsList from './EnrollmentsList';
 import { useEnrollments } from '../data/apiHook';
 import { renderWithIntl } from '@src/testUtils';
+import messages from '../messages';
 
 jest.mock('../data/apiHook', () => ({
   useEnrollments: jest.fn(),
@@ -37,76 +38,222 @@ const renderComponent = (onUnenroll = jest.fn()) => {
 };
 
 describe('EnrollmentsList', () => {
+  const mockOnUnenroll = jest.fn();
+
   beforeEach(() => {
     (useEnrollments as jest.Mock).mockReturnValue({
-      data: { count: 2, results: mockLearners },
+      data: { count: 2, results: mockLearners, numPages: 1 },
       isLoading: false,
     });
+    mockOnUnenroll.mockClear();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('renders table with enrollments data', () => {
-    renderComponent();
+  describe('Basic rendering and functionality', () => {
+    test('renders table with enrollments data', () => {
+      renderComponent();
 
-    expect(screen.getByText(mockLearners[0].username)).toBeInTheDocument();
-    expect(screen.getByText(mockLearners[0].fullName)).toBeInTheDocument();
-    expect(screen.getByText(mockLearners[0].email)).toBeInTheDocument();
-    expect(screen.getByText(mockLearners[0].mode)).toBeInTheDocument();
-  });
-
-  test('displays beta tester status correctly', () => {
-    renderComponent();
-
-    const rows = screen.getAllByRole('row');
-    expect(rows[1]).toHaveTextContent('True'); // First learner is beta tester
-    expect(rows[2]).not.toHaveTextContent('True'); // Second learner is not beta tester
-  });
-
-  test('calls onUnenroll when unenroll button is clicked', async () => {
-    const mockOnUnenroll = jest.fn();
-    renderComponent(mockOnUnenroll);
-
-    const unenrollButtons = screen.getAllByRole('button', { name: /unenroll/i });
-    const user = userEvent.setup();
-    await user.click(unenrollButtons[0]);
-
-    expect(mockOnUnenroll).toHaveBeenCalledWith(mockLearners[0]);
-  });
-
-  test('handles loading state', () => {
-    (useEnrollments as jest.Mock).mockReturnValue({
-      data: { count: 0, results: [] },
-      isLoading: true,
+      expect(screen.getByText(mockLearners[0].username)).toBeInTheDocument();
+      expect(screen.getByText(mockLearners[0].fullName)).toBeInTheDocument();
+      expect(screen.getByText(mockLearners[0].email)).toBeInTheDocument();
+      expect(screen.getByText(mockLearners[0].mode)).toBeInTheDocument();
     });
 
-    renderComponent();
-    expect(screen.getByRole('table')).toBeInTheDocument();
-  });
+    test('displays beta tester status correctly', () => {
+      renderComponent();
 
-  test('handles empty data', () => {
-    (useEnrollments as jest.Mock).mockReturnValue({
-      data: { count: 0, results: [] },
-      isLoading: false,
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('True'); // First learner is beta tester
+      expect(rows[2]).not.toHaveTextContent('True'); // Second learner is not beta tester
     });
 
-    renderComponent();
-    expect(screen.getByRole('table')).toBeInTheDocument();
-  });
+    test('calls onUnenroll when unenroll button is clicked', async () => {
+      renderComponent(mockOnUnenroll);
 
-  test('displays N/A for missing mode', () => {
-    const learnersWithoutMode = [
-      { ...mockLearners[0], mode: null },
-    ];
+      const unenrollButtons = screen.getAllByRole('button', { name: /unenroll/i });
+      const user = userEvent.setup();
+      await user.click(unenrollButtons[0]);
 
-    (useEnrollments as jest.Mock).mockReturnValue({
-      data: { count: 1, results: learnersWithoutMode },
-      isLoading: false,
+      expect(mockOnUnenroll).toHaveBeenCalledWith(mockLearners[0]);
     });
 
-    renderComponent();
-    expect(screen.getByText('N/A')).toBeInTheDocument();
+    test('handles loading state', () => {
+      (useEnrollments as jest.Mock).mockReturnValue({
+        data: { count: 0, results: [], numPages: 0 },
+        isLoading: true,
+      });
+
+      renderComponent();
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    test('handles empty data', () => {
+      (useEnrollments as jest.Mock).mockReturnValue({
+        data: { count: 0, results: [], numPages: 0 },
+        isLoading: false,
+      });
+
+      renderComponent();
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    test('displays N/A for missing mode', () => {
+      const learnersWithoutMode = [
+        { ...mockLearners[0], mode: null },
+      ];
+
+      (useEnrollments as jest.Mock).mockReturnValue({
+        data: { count: 1, results: learnersWithoutMode, numPages: 1 },
+        isLoading: false,
+      });
+
+      renderComponent();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+  });
+
+  describe('Filtering functionality', () => {
+    test('renders username filter input', () => {
+      renderComponent();
+
+      const usernameFilter = screen.getByPlaceholderText(/search enrollments/i);
+      expect(usernameFilter).toBeInTheDocument();
+    });
+
+    test('renders beta tester filter dropdown', () => {
+      renderComponent();
+
+      const betaTesterFilter = screen.getByDisplayValue(/all enrollees/i);
+      expect(betaTesterFilter).toBeInTheDocument();
+
+      // Check if all options are present
+      expect(screen.getByText('All Enrollees')).toBeInTheDocument();
+      expect(screen.getByText('Beta Testers')).toBeInTheDocument();
+      expect(screen.getByText('Non-Beta Testers')).toBeInTheDocument();
+    });
+
+    test('calls useEnrollments with correct parameters when filters are applied', () => {
+      renderComponent();
+
+      expect(useEnrollments).toHaveBeenCalledWith('test-course-id', {
+        page: 0,
+        pageSize: 25,
+        emailOrUsername: '',
+        isBetaTester: '',
+      });
+    });
+
+    test('username filter updates input value', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      const usernameFilter = screen.getByPlaceholderText(/search enrollments/i);
+      await user.type(usernameFilter, 'john');
+
+      expect(usernameFilter).toBeInTheDocument();
+    });
+
+    test('beta tester filter updates select value', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      const betaTesterFilter = screen.getByDisplayValue(/all enrollees/i);
+      await user.selectOptions(betaTesterFilter, 'true');
+
+      expect(betaTesterFilter).toBeInTheDocument();
+    });
+  });
+
+  describe('Pagination and data fetching', () => {
+    test('resets to page 0 when filters change', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      const usernameFilter = screen.getByPlaceholderText(/search enrollments/i);
+      await user.type(usernameFilter, 'test');
+
+      // Filter change should reset page to 0
+      expect(useEnrollments).toHaveBeenCalledWith('test-course-id', {
+        page: 0,
+        pageSize: 25,
+        emailOrUsername: '',
+        isBetaTester: '',
+      });
+    });
+  });
+
+  describe('DataTable configuration', () => {
+    test('renders DataTable with correct props', () => {
+      renderComponent();
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      // Check that filterable columns are present
+      expect(screen.getByText('Username')).toBeInTheDocument();
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Email')).toBeInTheDocument();
+      expect(screen.getByText('Track')).toBeInTheDocument();
+      expect(screen.getByText('Beta Tester')).toBeInTheDocument();
+    });
+
+    test('displays correct number of rows', () => {
+      renderComponent();
+
+      const rows = screen.getAllByRole('row');
+      // Header row + 2 data rows
+      expect(rows).toHaveLength(3);
+    });
+
+    test('handles edge case with undefined mode', () => {
+      const learnersWithUndefinedMode = [
+        { ...mockLearners[0], mode: undefined },
+      ];
+
+      (useEnrollments as jest.Mock).mockReturnValue({
+        data: { count: 1, results: learnersWithUndefinedMode, numPages: 1 },
+        isLoading: false,
+      });
+
+      renderComponent();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error handling', () => {
+    test('handles API error state', () => {
+      (useEnrollments as jest.Mock).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('API Error'),
+      });
+
+      renderComponent();
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+    });
+  });
+
+  describe('Action buttons functionality', () => {
+    test('renders action buttons for each learner', () => {
+      renderComponent();
+
+      const actionButtons = screen.getAllByRole('button', { name: messages.changeBetaTesterStatus.defaultMessage });
+      expect(actionButtons).toHaveLength(2);
+    });
+
+    test('action buttons have correct accessibility attributes', () => {
+      renderComponent();
+
+      const actionButtons = screen.getAllByRole('button', { name: messages.changeBetaTesterStatus.defaultMessage });
+      actionButtons.forEach(button => {
+        expect(button).toHaveAttribute('aria-label', messages.changeBetaTesterStatus.defaultMessage);
+      });
+    });
   });
 });

--- a/src/enrollments/components/EnrollmentsList.tsx
+++ b/src/enrollments/components/EnrollmentsList.tsx
@@ -1,32 +1,111 @@
 import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { ActionRow, Button, DataTable, IconButton } from '@openedx/paragon';
+import { ActionRow, Button, DataTable, FormControl, Icon, IconButton } from '@openedx/paragon';
 import { useIntl } from '@openedx/frontend-base';
-import { MoreVert } from '@openedx/paragon/icons';
+import { MoreVert, Search } from '@openedx/paragon/icons';
 import messages from '../messages';
 import { useEnrollments } from '../data/apiHook';
 import { Learner } from '../types';
 import { DataTableFetchDataProps, TableCellValue } from '@src/types';
+import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
 
 const ENROLLMENTS_PAGE_SIZE = 25;
+
+const betaTesterOptions = [
+  { value: '', label: 'allEnrollees' },
+  { value: 'true', label: 'betaTesters' },
+  { value: 'false', label: 'nonBetaTesters' },
+];
 
 interface EnrollmentsListProps {
   onUnenroll: (learner: Learner) => void,
 }
 
-const EnrollmentsList = ({ onUnenroll }: EnrollmentsListProps) => {
+const UsernameFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
   const intl = useIntl();
-  const { courseId } = useParams();
-  const [page, setPage] = useState(0);
-  const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useEnrollments(courseId ?? '', {
-    page,
-    pageSize: ENROLLMENTS_PAGE_SIZE
+  const { inputValue, handleChange } = useDebouncedFilter({
+    filterValue,
+    setFilter,
   });
 
-  const pageCount = Math.ceil(data.count / ENROLLMENTS_PAGE_SIZE);
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleChange(e.target.value);
+  };
+
+  return (
+    <FormControl
+      className="mb-0"
+      onChange={handleInputChange}
+      placeholder={intl.formatMessage(messages.searchPlaceholder)}
+      trailingElement={<Icon src={Search} />}
+      value={inputValue}
+    />
+  );
+};
+
+const BetaTesterFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
+  const intl = useIntl();
+  const { inputValue, handleChange } = useDebouncedFilter({
+    filterValue,
+    setFilter,
+  });
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    handleChange(e.target.value);
+  };
+
+  return (
+    <FormControl
+      as="select"
+      className="mb-0"
+      name="isBetaTester"
+      placeholder={intl.formatMessage(messages.betaTesterFilterPlaceholder)}
+      size="md"
+      value={inputValue}
+      onChange={handleSelectChange}
+    >
+      {
+        betaTesterOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {intl.formatMessage(messages[option.label])}
+          </option>
+        ))
+      }
+    </FormControl>
+  );
+};
+
+const EnrollmentsList = ({ onUnenroll }: EnrollmentsListProps) => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams();
+  const [filters, setFilters] = useState({ page: 0, username: '', isBetaTester: '' });
+  const { data = { count: 0, results: [], numPages: 0 }, isLoading } = useEnrollments(courseId, {
+    page: filters.page,
+    pageSize: ENROLLMENTS_PAGE_SIZE,
+    emailOrUsername: filters.username,
+    isBetaTester: filters.isBetaTester,
+  });
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
-    setPage(data.pageIndex);
+    const usernameFilter = data.filters?.find((f) => f.id === 'username');
+    const newEmailOrUsername = usernameFilter ? usernameFilter.value : '';
+    const betaTesterFilter = data.filters?.find((f) => f.id === 'isBetaTester');
+    const newIsBetaTester = betaTesterFilter ? betaTesterFilter.value : '';
+    const filtersChanged = (newEmailOrUsername !== filters.username) || (newIsBetaTester !== filters.isBetaTester);
+
+    if (filtersChanged) {
+      setFilters((prevFilters) => ({
+        ...prevFilters,
+        username: newEmailOrUsername,
+        isBetaTester: newIsBetaTester,
+        page: 0,
+      }));
+      return;
+    }
+
+    if (data.pageIndex !== filters.page) {
+      setFilters((prevFilters) => ({ ...prevFilters, page: data.pageIndex }));
+    }
   };
 
   const handleMoreButton = () => {
@@ -35,17 +114,23 @@ const EnrollmentsList = ({ onUnenroll }: EnrollmentsListProps) => {
   };
 
   const tableColumns = [
-    { accessor: 'username', Header: intl.formatMessage(messages.username) },
-    { accessor: 'fullName', Header: intl.formatMessage(messages.fullName) },
-    { accessor: 'email', Header: intl.formatMessage(messages.email) },
+    { accessor: 'username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter },
+    { accessor: 'fullName', Header: intl.formatMessage(messages.fullName), disableFilters: true },
+    { accessor: 'email', Header: intl.formatMessage(messages.email), disableFilters: true },
     {
       accessor: 'mode',
       Header: intl.formatMessage(messages.track),
       Cell: ({ value }: { value: string }) => (
         <span className="text-capitalize">{value || 'N/A'}</span>
-      )
+      ),
+      disableFilters: true,
     },
-    { accessor: 'isBetaTester', Header: intl.formatMessage(messages.betaTester), Cell: ({ value }: { value: string }) => (value ? intl.formatMessage(messages.trueLabel) : '') },
+    {
+      accessor: 'isBetaTester',
+      Header: intl.formatMessage(messages.betaTester),
+      Cell: ({ value }: { value: string }) => (value ? intl.formatMessage(messages.trueLabel) : ''),
+      Filter: BetaTesterFilter
+    },
   ];
 
   const actionCustomCell = useCallback(({ row: { original } }: TableCellValue<Learner>) => {
@@ -55,7 +140,7 @@ const EnrollmentsList = ({ onUnenroll }: EnrollmentsListProps) => {
           {intl.formatMessage(messages.unenrollButton)}
         </Button>
         <IconButton
-          alt={intl.formatMessage(messages.checkEnrollmentStatus)}
+          alt={intl.formatMessage(messages.changeBetaTesterStatus)}
           className="lead"
           iconAs={MoreVert}
           onClick={handleMoreButton}
@@ -78,17 +163,29 @@ const EnrollmentsList = ({ onUnenroll }: EnrollmentsListProps) => {
       data={data.results}
       fetchData={handleFetchData}
       state={{
-        pageIndex: page,
+        pageIndex: filters.page,
         pageSize: ENROLLMENTS_PAGE_SIZE,
+        filters: [
+          { id: 'username', value: filters.username },
+          { id: 'isBetaTester', value: filters.isBetaTester },
+        ]
       }}
+      isFilterable
       isLoading={isLoading}
       isPaginated
       itemCount={data.count}
       manualFilters
       manualPagination
+      numBreakoutFilters={2}
       pageSize={ENROLLMENTS_PAGE_SIZE}
-      pageCount={pageCount}
-    />
+      pageCount={data.numPages}
+      FilterStatusComponent={() => null}
+    >
+      <DataTable.TableControlBar className="px-3 pt-3 pb-2" />
+      <DataTable.Table />
+      <DataTable.EmptyTable content={intl.formatMessage(messages.noEnrollments)} />
+      <DataTable.TableFooter />
+    </DataTable>
   );
 };
 

--- a/src/enrollments/components/EnrollmentsList.tsx
+++ b/src/enrollments/components/EnrollmentsList.tsx
@@ -12,9 +12,9 @@ import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
 const ENROLLMENTS_PAGE_SIZE = 25;
 
 const betaTesterOptions = [
-  { value: '', label: 'allEnrollees' },
-  { value: 'true', label: 'betaTesters' },
-  { value: 'false', label: 'nonBetaTesters' },
+  { value: '', label: messages.allEnrollees },
+  { value: 'true', label: messages.betaTesters },
+  { value: 'false', label: messages.nonBetaTesters },
 ];
 
 interface EnrollmentsListProps {
@@ -45,13 +45,9 @@ const UsernameFilter = ({ column: { filterValue, setFilter } }: { column: { filt
 
 const BetaTesterFilter = ({ column: { filterValue, setFilter } }: { column: { filterValue: string, setFilter: (value: string) => void } }) => {
   const intl = useIntl();
-  const { inputValue, handleChange } = useDebouncedFilter({
-    filterValue,
-    setFilter,
-  });
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    handleChange(e.target.value);
+    setFilter(e.target.value);
   };
 
   return (
@@ -59,15 +55,14 @@ const BetaTesterFilter = ({ column: { filterValue, setFilter } }: { column: { fi
       as="select"
       className="mb-0"
       name="isBetaTester"
-      placeholder={intl.formatMessage(messages.betaTesterFilterPlaceholder)}
       size="md"
-      value={inputValue}
+      value={filterValue}
       onChange={handleSelectChange}
     >
       {
         betaTesterOptions.map((option) => (
           <option key={option.value} value={option.value}>
-            {intl.formatMessage(messages[option.label])}
+            {intl.formatMessage(option.label)}
           </option>
         ))
       }

--- a/src/enrollments/data/api.test.ts
+++ b/src/enrollments/data/api.test.ts
@@ -1,7 +1,7 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { getEnrollments, getEnrollmentStatus, PaginationParams } from './api';
-import { EnrollmentStatusResponse, Learner } from '../types';
+import { getEnrollments, getEnrollmentStatus } from './api';
+import { EnrollmentsParams, EnrollmentStatusResponse, Learner } from '../types';
 import { DataList } from '@src/types';
 
 jest.mock('@openedx/frontend-base', () => ({
@@ -76,7 +76,7 @@ describe('enrollments api', () => {
       ],
     };
 
-    const pagination: PaginationParams = { page: 1, pageSize: 20 };
+    const params: EnrollmentsParams = { page: 1, pageSize: 20, emailOrUsername: '', isBetaTester: '' };
 
     beforeEach(() => {
       mockHttpClient.get.mockResolvedValue({ data: mockEnrollmentsData });
@@ -85,7 +85,7 @@ describe('enrollments api', () => {
 
     it('fetches enrollments successfully', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const result = await getEnrollments(courseId, pagination);
+      const result = await getEnrollments(courseId, params);
 
       expect(mockGetApiBaseUrl).toHaveBeenCalled();
       expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
@@ -96,21 +96,21 @@ describe('enrollments api', () => {
       expect(result).toBe(mockCamelCaseData);
     });
 
-    it('handles different pagination parameters', async () => {
+    it('handles different params parameters', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const customPagination: PaginationParams = { page: 3, pageSize: 50 };
+      const customparams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
 
-      await getEnrollments(courseId, customPagination);
+      await getEnrollments(courseId, customparams);
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
-        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments?page=4&page_size=50'
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments?page=4&page_size=50&search=student'
       );
     });
 
     it('handles special characters in course ID', async () => {
       const courseId = 'course-v1:edX+Test+Course+2023';
 
-      await getEnrollments(courseId, pagination);
+      await getEnrollments(courseId, params);
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+Course+2023/enrollments?page=2&page_size=20'
@@ -122,7 +122,7 @@ describe('enrollments api', () => {
       const error = new Error('Network error');
       mockHttpClient.get.mockRejectedValue(error);
 
-      await expect(getEnrollments(courseId, pagination)).rejects.toThrow('Network error');
+      await expect(getEnrollments(courseId, params)).rejects.toThrow('Network error');
       expect(mockCamelCaseObject).not.toHaveBeenCalled();
     });
 
@@ -136,7 +136,7 @@ describe('enrollments api', () => {
       };
       mockHttpClient.get.mockRejectedValue(error);
 
-      await expect(getEnrollments(courseId, pagination)).rejects.toEqual(error);
+      await expect(getEnrollments(courseId, params)).rejects.toEqual(error);
     });
   });
 

--- a/src/enrollments/data/api.test.ts
+++ b/src/enrollments/data/api.test.ts
@@ -98,9 +98,9 @@ describe('enrollments api', () => {
 
     it('handles different params parameters', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const customparams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
+      const customParams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
 
-      await getEnrollments(courseId, customparams);
+      await getEnrollments(courseId, customParams);
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/enrollments?page=4&page_size=50&search=student'

--- a/src/enrollments/data/api.ts
+++ b/src/enrollments/data/api.ts
@@ -1,19 +1,27 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '../../data/api';
-import { EnrollmentStatusResponse, Learner } from '../types';
+import { EnrollmentsParams, EnrollmentStatusResponse, Learner } from '../types';
 import { DataList } from '@src/types';
-
-export interface PaginationParams {
-  page: number,
-  pageSize: number,
-}
 
 export const getEnrollments = async (
   courseId: string,
-  pagination: PaginationParams
+  params: EnrollmentsParams
 ): Promise<DataList<Learner>> => {
+  const queryParams = new URLSearchParams({
+    page: (params.page + 1).toString(),
+    page_size: params.pageSize.toString(),
+  });
+
+  if (params.emailOrUsername) {
+    queryParams.append('search', params.emailOrUsername);
+  }
+
+  if (params.isBetaTester) {
+    queryParams.append('is_beta_tester', params.isBetaTester);
+  }
+
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments?page=${pagination.page + 1}&page_size=${pagination.pageSize}`
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/enrollments?${queryParams.toString()}`
   );
   return camelCaseObject(data);
 };

--- a/src/enrollments/data/apiHook.test.tsx
+++ b/src/enrollments/data/apiHook.test.tsx
@@ -95,10 +95,10 @@ describe('enrollments api hooks', () => {
     });
 
     it('handles different params parameters', async () => {
-      const customparams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
+      const customParams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
       mockGetEnrollments.mockResolvedValue(mockEnrollmentsData);
 
-      const { result } = renderHook(() => useEnrollments(courseId, customparams), {
+      const { result } = renderHook(() => useEnrollments(courseId, customParams), {
         wrapper: createWrapper(),
       });
 
@@ -106,7 +106,7 @@ describe('enrollments api hooks', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, customparams);
+      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, customParams);
       expect(result.current.data).toBe(mockEnrollmentsData);
     });
 

--- a/src/enrollments/data/apiHook.test.tsx
+++ b/src/enrollments/data/apiHook.test.tsx
@@ -1,7 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEnrollments, useEnrollmentByUserId } from './apiHook';
-import { getEnrollments, getEnrollmentStatus, PaginationParams } from './api';
+import { getEnrollments, getEnrollmentStatus } from './api';
+import { EnrollmentsParams } from '../types';
 
 jest.mock('./api');
 
@@ -56,12 +57,12 @@ describe('enrollments api hooks', () => {
 
   describe('useEnrollments', () => {
     const courseId = 'course-v1:edX+Test+2023';
-    const pagination: PaginationParams = { page: 1, pageSize: 20 };
+    const params: EnrollmentsParams = { page: 1, pageSize: 20, emailOrUsername: '', isBetaTester: '' };
 
     it('fetches enrollments successfully', async () => {
       mockGetEnrollments.mockResolvedValue(mockEnrollmentsData);
 
-      const { result } = renderHook(() => useEnrollments(courseId, pagination), {
+      const { result } = renderHook(() => useEnrollments(courseId, params), {
         wrapper: createWrapper(),
       });
 
@@ -71,7 +72,7 @@ describe('enrollments api hooks', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, pagination);
+      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, params);
       expect(result.current.data).toBe(mockEnrollmentsData);
       expect(result.current.error).toBe(null);
     });
@@ -80,7 +81,7 @@ describe('enrollments api hooks', () => {
       const mockError = new Error('Network error');
       mockGetEnrollments.mockRejectedValue(mockError);
 
-      const { result } = renderHook(() => useEnrollments(courseId, pagination), {
+      const { result } = renderHook(() => useEnrollments(courseId, params), {
         wrapper: createWrapper(),
       });
 
@@ -88,16 +89,16 @@ describe('enrollments api hooks', () => {
         expect(result.current.isError).toBe(true);
       });
 
-      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, pagination);
+      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, params);
       expect(result.current.error).toBe(mockError);
       expect(result.current.data).toBe(undefined);
     });
 
-    it('handles different pagination parameters', async () => {
-      const customPagination: PaginationParams = { page: 3, pageSize: 50 };
+    it('handles different params parameters', async () => {
+      const customparams: EnrollmentsParams = { page: 3, pageSize: 50, emailOrUsername: 'student', isBetaTester: '' };
       mockGetEnrollments.mockResolvedValue(mockEnrollmentsData);
 
-      const { result } = renderHook(() => useEnrollments(courseId, customPagination), {
+      const { result } = renderHook(() => useEnrollments(courseId, customparams), {
         wrapper: createWrapper(),
       });
 
@@ -105,7 +106,7 @@ describe('enrollments api hooks', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, customPagination);
+      expect(mockGetEnrollments).toHaveBeenCalledWith(courseId, customparams);
       expect(result.current.data).toBe(mockEnrollmentsData);
     });
 
@@ -113,7 +114,7 @@ describe('enrollments api hooks', () => {
       const emptyResults = { count: 0, results: [], numPages: 0 };
       mockGetEnrollments.mockResolvedValue(emptyResults);
 
-      const { result } = renderHook(() => useEnrollments(courseId, pagination), {
+      const { result } = renderHook(() => useEnrollments(courseId, params), {
         wrapper: createWrapper(),
       });
 
@@ -136,7 +137,7 @@ describe('enrollments api hooks', () => {
       };
       mockGetEnrollments.mockRejectedValue(httpError);
 
-      const { result } = renderHook(() => useEnrollments(courseId, pagination), {
+      const { result } = renderHook(() => useEnrollments(courseId, params), {
         wrapper: createWrapper(),
       });
 

--- a/src/enrollments/data/apiHook.ts
+++ b/src/enrollments/data/apiHook.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import { getEnrollments, getEnrollmentStatus, PaginationParams } from './api';
+import { getEnrollments, getEnrollmentStatus } from './api';
 import { enrollmentsQueryKeys } from './queryKeys';
+import { EnrollmentsParams } from '../types';
 
-export const useEnrollments = (courseId: string, pagination: PaginationParams) => (
+export const useEnrollments = (courseId: string, params: EnrollmentsParams) => (
   useQuery({
-    queryKey: enrollmentsQueryKeys.byCoursePaginated(courseId, pagination),
-    queryFn: () => getEnrollments(courseId, pagination),
+    queryKey: enrollmentsQueryKeys.byCoursePaginated(courseId, params),
+    queryFn: () => getEnrollments(courseId, params),
+    enabled: !!courseId,
   })
 );
 

--- a/src/enrollments/data/queryKeys.ts
+++ b/src/enrollments/data/queryKeys.ts
@@ -1,9 +1,9 @@
 import { appId } from '../../constants';
-import { PaginationParams } from './api';
+import { EnrollmentsParams } from '../types';
 
 export const enrollmentsQueryKeys = {
   all: [appId, 'enrollments'] as const,
   byCourse: (courseId: string) => [...enrollmentsQueryKeys.all, courseId] as const,
-  byCoursePaginated: (courseId: string, pagination: PaginationParams) => [...enrollmentsQueryKeys.byCourse(courseId), pagination.page] as const,
+  byCoursePaginated: (courseId: string, params: EnrollmentsParams) => [...enrollmentsQueryKeys.byCourse(courseId), params.page, params.pageSize, params.emailOrUsername, params.isBetaTester] as const,
   byUserId: (courseId: string, userIdentifier: string) => [...enrollmentsQueryKeys.byCourse(courseId), 'enrollment', userIdentifier] as const,
 };

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -76,6 +76,41 @@ const messages = defineMessages({
     defaultMessage: 'Close',
     description: 'Label for close button in modals',
   },
+  searchPlaceholder: {
+    id: 'instruct.enrollments.searchPlaceholder',
+    defaultMessage: 'Search enrollments',
+    description: 'Placeholder for the search input in enrollments list',
+  },
+  betaTesterFilterPlaceholder: {
+    id: 'instruct.enrollments.betaTesterFilterPlaceholder',
+    defaultMessage: 'Filter by Beta Tester status',
+    description: 'Placeholder for the beta tester filter in enrollments list',
+  },
+  noEnrollments: {
+    id: 'instruct.enrollments.noEnrollments',
+    defaultMessage: 'No enrollments found',
+    description: 'Message displayed when there are no enrollments to show',
+  },
+  changeBetaTesterStatus: {
+    id: 'instruct.enrollments.changeBetaTesterStatus',
+    defaultMessage: 'Change Beta Tester Status',
+    description: 'Alt text for change beta tester status icon button',
+  },
+  allEnrollees: {
+    id: 'instruct.enrollments.allEnrollees',
+    defaultMessage: 'All Enrollees',
+    description: 'Option for showing all enrollees in beta tester filter',
+  },
+  betaTesters: {
+    id: 'instruct.enrollments.betaTesters',
+    defaultMessage: 'Beta Testers',
+    description: 'Option for showing only beta testers in beta tester filter',
+  },
+  nonBetaTesters: {
+    id: 'instruct.enrollments.nonBetaTesters',
+    defaultMessage: 'Non-Beta Testers',
+    description: 'Option for showing only non-beta testers in beta tester filter',
+  },
 });
 
 export default messages;

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -81,11 +81,6 @@ const messages = defineMessages({
     defaultMessage: 'Search enrollments',
     description: 'Placeholder for the search input in enrollments list',
   },
-  betaTesterFilterPlaceholder: {
-    id: 'instruct.enrollments.betaTesterFilterPlaceholder',
-    defaultMessage: 'Filter by Beta Tester status',
-    description: 'Placeholder for the beta tester filter in enrollments list',
-  },
   noEnrollments: {
     id: 'instruct.enrollments.noEnrollments',
     defaultMessage: 'No enrollments found',

--- a/src/enrollments/types.ts
+++ b/src/enrollments/types.ts
@@ -1,3 +1,5 @@
+import { PaginationParams } from '@src/types';
+
 export interface EnrollmentStatusResponse {
   enrollmentStatus: string,
 }
@@ -8,4 +10,9 @@ export interface Learner {
   email: string,
   mode: string,
   isBetaTester: boolean,
-};
+}
+
+export interface EnrollmentsParams extends PaginationParams {
+  emailOrUsername: string,
+  isBetaTester: string,
+}

--- a/src/openResponses/components/DetailAssessmentsList.test.tsx
+++ b/src/openResponses/components/DetailAssessmentsList.test.tsx
@@ -1,4 +1,5 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DetailAssessmentsList from './DetailAssessmentsList';
 import { useDetailAssessmentsData } from '../data/apiHook';
 import { renderWithIntl } from '../../testUtils';
@@ -65,7 +66,8 @@ describe('DetailAssessmentsList', () => {
     });
     renderWithIntl(<DetailAssessmentsList />);
     const nextButton = screen.getByLabelText(/next/i);
-    fireEvent.click(nextButton);
+    const user = userEvent.setup();
+    await user.click(nextButton);
     await waitFor(() => {
       expect(useDetailAssessmentsData).toHaveBeenCalled();
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export interface TableCellValue<T> {
   },
 }
 
-export interface PaginationQueryKeys {
+export interface PaginationParams {
   page: number,
   pageSize: number,
 }


### PR DESCRIPTION
## Description
Added filters for search by username or email and if learners are beta tester or not.

## Supporting information
Closes #66 

## Testing instructions
- Go to enrollments tab with a valid course id. Example: http://apps.local.openedx.io:2003/instructor/course-v1:OpenedX+DemoX+DemoCourse/enrollments
- Type on search bar to filter or click on select component to choose an option for beta tester filter.

## Screenshots
- Enrollments view with filters
<img width="1637" height="668" alt="Screenshot 2026-03-26 at 12 29 28 p m" src="https://github.com/user-attachments/assets/fff5c5bd-f27e-44df-ac16-db93bcb545ee" />

- Beta tester select
<img width="1632" height="670" alt="Screenshot 2026-03-26 at 12 29 41 p m" src="https://github.com/user-attachments/assets/e4f3d06e-45be-4a45-b2c9-6279441f1f22" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
