### PR TITLE
chore: add semantic-release configuration for NPM publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release CI
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: write  # For Semantic Release tagging
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Release to npm/Github
+        run: npx semantic-release@25
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,13 @@
+{
+  "branches": [
+    "placeholder",
+    { "name": "main", "prerelease": "alpha", "channel": "latest" }
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
### Description

Adds semantic-release configuration to automatically publish this package to NPM on every push to `main`. Since this package is not yet in NPM, the first release will create it under the `@openedx/frontend-app-instructor-dashboard` name.

The setup mirrors what was done in openedx/frontend-app-authn#1660, with `main` as the alpha branch instead of `frontend-base`. Releases from `main` are tagged as alpha prereleases and published to the `latest` dist-tag (necessary for the initial NPM publish to succeed).

### LLM usage notice

Built with assistance from Claude.