### PR TITLE
fix: use dynamic import for ReactQueryDevtools to fix consumer builds

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,12 +1,19 @@
+import { lazy, Suspense } from 'react';
 import { CurrentAppProvider, getAppConfig } from '@openedx/frontend-base';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AlertProvider } from './providers/AlertProvider';
 import { appId } from './constants';
 import PageWrapper from './pageWrapper/PageWrapper';
 
 import './app.scss';
+
+// Use a dynamic import guarded by process.env.NODE_ENV so the consumer's
+// webpack dead-code-eliminates this in production builds, meaning
+// @tanstack/react-query-devtools does not need to be installed by consumers.
+const ReactQueryDevtools = process.env.NODE_ENV === 'development'
+  ? lazy(() => import('@tanstack/react-query-devtools').then((m) => ({ default: m.ReactQueryDevtools })))
+  : null;
 
 const queryClient = new QueryClient();
 
@@ -18,7 +25,11 @@ const Main = () => (
           <PageWrapper>
             <Outlet />
           </PageWrapper>
-          { getAppConfig(appId).NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} /> }
+          {ReactQueryDevtools && getAppConfig(appId).NODE_ENV === 'development' && (
+            <Suspense fallback={null}>
+              <ReactQueryDevtools initialIsOpen={false} />
+            </Suspense>
+          )}
         </main>
       </AlertProvider>
     </QueryClientProvider>


### PR DESCRIPTION
### Description

The static import of `@tanstack/react-query-devtools` in `Main.tsx` caused
consumer webpack builds to fail. Since the package is in `devDependencies`,
it's not installed by consumers, so webpack can't resolve it.

Switching to a dynamic import guarded by `process.env.NODE_ENV` allows the
consumer's webpack to dead-code-eliminate it in production builds, so the
package no longer needs to be installed by consumers.

Closes #143

### LLM usage notice

Built with assistance from Claude.