### PR TITLE
fix: pass ATLAS_OPTIONS through to translations:pull in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ detect_changed_source_translations:
 
 # Pulls translations using atlas.
 pull_translations: | requirements
-	npm run translations:pull
+	npm run translations:pull -- --atlas-options="$(ATLAS_OPTIONS)"
 
 clean:
 	rm -rf dist


### PR DESCRIPTION
Noticed this was missing from the migration guide when I was updating some other PRs. The guide has been updated in openedx/frontend-base#217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)