### PR TITLE
fix: prevent build failure when react-query-devtools is not installed

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { CurrentAppProvider, getAppConfig } from '@openedx/frontend-base';
+import { CurrentAppProvider } from '@openedx/frontend-base';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Outlet } from 'react-router-dom';
 import { AlertProvider } from './providers/AlertProvider';
@@ -8,11 +8,18 @@ import PageWrapper from './pageWrapper/PageWrapper';
 
 import './app.scss';
 
-// Use a dynamic import guarded by process.env.NODE_ENV so the consumer's
-// webpack dead-code-eliminates this in production builds, meaning
-// @tanstack/react-query-devtools does not need to be installed by consumers.
+/*
+ * Use a dynamic import guarded by process.env.NODE_ENV so the consumer's
+ * webpack dead-code-eliminates this in production builds.  webpackIgnore
+ * tells webpack not to resolve the module at build time in dev mode, and
+ * the .catch() gracefully handles the case where it is not installed.
+ */
+const loadDevtools = () => import(/* webpackIgnore: true */ '@tanstack/react-query-devtools')
+  .then((m) => ({ default: m.ReactQueryDevtools }))
+  .catch(() => ({ default: () => null }));
+
 const ReactQueryDevtools = process.env.NODE_ENV === 'development'
-  ? lazy(() => import('@tanstack/react-query-devtools').then((m) => ({ default: m.ReactQueryDevtools })))
+  ? lazy(loadDevtools)
   : null;
 
 const queryClient = new QueryClient();
@@ -25,7 +32,7 @@ const Main = () => (
           <PageWrapper>
             <Outlet />
           </PageWrapper>
-          {ReactQueryDevtools && getAppConfig(appId).NODE_ENV === 'development' && (
+          {ReactQueryDevtools && (
             <Suspense fallback={null}>
               <ReactQueryDevtools initialIsOpen={false} />
             </Suspense>


### PR DESCRIPTION
### Description

Consumers that don't install `@tanstack/react-query-devtools` would fail the webpack build in dev mode because the dynamic import was resolved at build time. This adds `webpackIgnore` so webpack skips the module, and a `.catch()` fallback that renders a no-op component when the package is missing. Also removes a redundant `NODE_ENV` check in the render path and the now-unused `getAppConfig` import.

### LLM usage notice

Built with assistance from Claude.