### PR TITLE
fix: baseUrl was getting the wrong value to hit backend endpoints

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,10 +9,6 @@ const app: App = {
   routes,
   provides,
   slots,
-  config: {
-    NODE_ENV: 'development',
-    LMS_BASE_URL: 'http://local.openedx.io:8000'
-  },
 };
 
 export default app;

--- a/src/cohorts/data/api.test.ts
+++ b/src/cohorts/data/api.test.ts
@@ -1,6 +1,5 @@
 import { getCohortStatus, getCohorts, toggleCohorts } from './api';
-import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { appId } from '@src/constants';
+import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 
 jest.mock('@openedx/frontend-base');
 
@@ -11,7 +10,7 @@ const mockHttpClient = {
   put: jest.fn(),
 };
 
-const mockGetAppConfig = getAppConfig as jest.MockedFunction<typeof getAppConfig>;
+const mockGetSiteConfig = getSiteConfig as jest.MockedFunction<typeof getSiteConfig>;
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
@@ -21,7 +20,7 @@ describe('getCohortStatus', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCaseCohortStatusData);
     mockHttpClient.get.mockResolvedValue({ data: mockCohortStatusData });
@@ -32,7 +31,7 @@ describe('getCohortStatus', () => {
 
     const result = await getCohortStatus(courseId);
 
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(getSiteConfig).toHaveBeenCalled();
     expect(mockHttpClient.get).toHaveBeenCalledWith(
       `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`
     );
@@ -45,7 +44,7 @@ describe('getCohorts', () => {
   const mockData = [{ id: 1, name: 'Cohort 1' }];
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockData);
     mockHttpClient.get.mockResolvedValue({ data: mockData });
@@ -57,7 +56,7 @@ describe('getCohorts', () => {
 
     const result = await getCohorts(courseId);
 
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(getSiteConfig).toHaveBeenCalled();
     expect(mockHttpClient.get).toHaveBeenCalledWith(
       `${mockBaseUrl}/api/cohorts/v1/courses/${courseId}/cohorts/`, { params: { page_size: 100 } }
     );
@@ -72,7 +71,7 @@ describe('toggleCohorts', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: mockBaseUrl });
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: mockBaseUrl });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCasedData);
   });
@@ -84,7 +83,7 @@ describe('toggleCohorts', () => {
 
     const result = await toggleCohorts(courseId, isCohorted);
 
-    expect(getAppConfig).toHaveBeenCalledWith(appId);
+    expect(getSiteConfig).toHaveBeenCalled();
     expect(mockHttpClient.put).toHaveBeenCalledWith(
       `${mockBaseUrl}/api/cohorts/v1/settings/${courseId}`,
       { is_cohorted: isCohorted }

--- a/src/data/api.test.ts
+++ b/src/data/api.test.ts
@@ -1,15 +1,15 @@
 import { getCourseInfo, getLearner } from './api';
-import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { fetchPendingTasks } from './api';
 
 jest.mock('@openedx/frontend-base', () => ({
   ...jest.requireActual('@openedx/frontend-base'),
   camelCaseObject: jest.fn((obj) => obj),
-  getAppConfig: jest.fn(),
+  getSiteConfig: jest.fn(),
   getAuthenticatedHttpClient: jest.fn(),
 }));
 
-const mockGetAppConfig = getAppConfig as jest.MockedFunction<typeof getAppConfig>;
+const mockGetSiteConfig = getSiteConfig as jest.MockedFunction<typeof getSiteConfig>;
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
@@ -26,7 +26,7 @@ describe('base api', () => {
     const mockCamelCaseData = { courseName: 'Test Course' };
 
     beforeEach(() => {
-      mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://test-lms.com' });
+      (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
       mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
       mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
       mockHttpClient.get.mockResolvedValue({ data: mockCourseData });
@@ -35,7 +35,7 @@ describe('base api', () => {
     it('fetches course info successfully', async () => {
       const courseId = 'test-course-123';
       const result = await getCourseInfo(courseId);
-      expect(mockGetAppConfig).toHaveBeenCalledWith('org.openedx.frontend.app.instructorDashboard');
+      expect(mockGetSiteConfig).toHaveBeenCalled();
       expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
       expect(mockHttpClient.get).toHaveBeenCalledWith('https://test-lms.com/api/instructor/v2/courses/test-course-123');
       expect(mockCamelCaseObject).toHaveBeenCalledWith(mockCourseData);
@@ -56,7 +56,7 @@ describe('base api', () => {
 
     beforeEach(() => {
       mockCamelCaseObject.mockImplementation((obj) => obj);
-      mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://example.com' });
+      (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://example.com' });
       mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     });
 
@@ -92,7 +92,7 @@ describe('base api', () => {
     const mockCamelCaseData = { username: 'testuser', email: 'test@example.com', fullName: 'Test User' };
 
     beforeEach(() => {
-      mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://test-lms.com' });
+      (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
       mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
       mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
       mockHttpClient.get.mockResolvedValue({ data: mockLearnerData });

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,9 +1,8 @@
-import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
-import { appId } from '@src/constants';
+import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { CourseInfoResponse } from '@src/courseInfo/types';
 import { SelectedLearner } from '@src/types';
 
-export const getApiBaseUrl = () => getAppConfig(appId).LMS_BASE_URL;
+export const getApiBaseUrl = () => getSiteConfig().lmsBaseUrl;
 
 /**
  * Get course settings.

--- a/src/grading/data/api.test.ts
+++ b/src/grading/data/api.test.ts
@@ -1,14 +1,14 @@
-import { camelCaseObject, getAppConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
+import { camelCaseObject, getSiteConfig, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getGradingConfiguration } from '@src/grading/data/api';
 
 jest.mock('@openedx/frontend-base', () => ({
   ...jest.requireActual('@openedx/frontend-base'),
   camelCaseObject: jest.fn((obj) => obj),
-  getAppConfig: jest.fn(),
+  getSiteConfig: jest.fn(),
   getAuthenticatedHttpClient: jest.fn(),
 }));
 
-const mockGetAppConfig = getAppConfig as jest.MockedFunction<typeof getAppConfig>;
+const mockGetSiteConfig = getSiteConfig as jest.MockedFunction<typeof getSiteConfig>;
 const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.MockedFunction<typeof getAuthenticatedHttpClient>;
 const mockCamelCaseObject = camelCaseObject as jest.MockedFunction<typeof camelCaseObject>;
 
@@ -20,7 +20,7 @@ describe('getGradingConfiguration', () => {
   const mockCamelCaseData = { gradingPolicy: 'test_policy' };
 
   beforeEach(() => {
-    mockGetAppConfig.mockReturnValue({ LMS_BASE_URL: 'https://test-lms.com' });
+    (mockGetSiteConfig as jest.Mock).mockReturnValue({ lmsBaseUrl: 'https://test-lms.com' });
     mockGetAuthenticatedHttpClient.mockReturnValue(mockHttpClient as any);
     mockCamelCaseObject.mockReturnValue(mockCamelCaseData);
     mockHttpClient.get.mockResolvedValue({ data: mockConfigData });
@@ -33,7 +33,7 @@ describe('getGradingConfiguration', () => {
   it('fetches grading configuration successfully', async () => {
     const courseId = 'test-course-123';
     const result = await getGradingConfiguration(courseId);
-    expect(mockGetAppConfig).toHaveBeenCalled();
+    expect(mockGetSiteConfig).toHaveBeenCalled();
     expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
     expect(mockHttpClient.get).toHaveBeenCalledWith('https://test-lms.com/api/instructor/v2/courses/test-course-123/grading-config');
     expect(mockCamelCaseObject).toHaveBeenCalledWith(mockConfigData);


### PR DESCRIPTION
## Description
As part of sandbox testing we find out that we were retrieving incorrect value from lms, so we fix it and the proper tests related.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
