### PR TITLE
fix: use roles array in route handle config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,9 +4654,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.25.tgz",
-      "integrity": "sha512-CtrcsqiYFRhxION1ys7moT1A7IWTutc0uWiHOxbs6yVFfPYlvUZAB4rUMYx6k3TvtdKICmZOT97KCq7YZzL9Dw==",
+      "version": "1.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
+      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -52,7 +52,7 @@ const routes = [
     id: 'org.openedx.frontend.route.instructorDashboard.main',
     path: 'instructor-dashboard/:courseId',
     handle: {
-      role: instructorDashboardRole
+      roles: [instructorDashboardRole]
     },
     async lazy() {
       const module = await import('./Main');


### PR DESCRIPTION
### Description

The latest version of frontend-base expects route handle objects to use `roles: [role]` instead of the previous `role: role` format. This updates the instructor dashboard route handle configuration in `routes.tsx` accordingly, and bumps the `package-lock.json` to match.

### LLM usage notice

Built with assistance from Claude.