### PR TITLE
fix: change extension due date label

### DIFF
--- a/src/dateExtensions/components/AddExtensionModal.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { ActionRow, Button, Form, FormControl, FormGroup, FormLabel, ModalDialog } from '@openedx/paragon';
 import { useIntl } from '@openedx/frontend-base';
 import SpecifyLearnerField from '@src/components/SpecifyLearnerField';
-import messages from '../messages';
-import SelectGradedSubsection from './SelectGradedSubsection';
-import { AddDateExtensionFormData, AddDateExtensionParams } from '../types';
+import SelectGradedSubsection from '@src/dateExtensions/components/SelectGradedSubsection';
+import messages from '@src/dateExtensions/messages';
+import { AddDateExtensionFormData, AddDateExtensionParams } from '@src/dateExtensions/types';
 
 interface AddExtensionModalProps {
   isOpen: boolean,
@@ -17,7 +17,7 @@ const initialFormData: AddDateExtensionFormData = {
   emailOrUsername: '',
   blockId: '',
   dueDate: '',
-  dueTime: '',
+  dueTime: '23:59',
   reason: '',
 };
 
@@ -30,7 +30,6 @@ const AddExtensionModal = ({ isOpen, title, onClose, onSubmit }: AddExtensionMod
       formData.emailOrUsername.trim() !== ''
       && formData.blockId.trim() !== ''
       && formData.dueDate.trim() !== ''
-      && formData.dueTime.trim() !== ''
     );
   };
 
@@ -95,7 +94,7 @@ const AddExtensionModal = ({ isOpen, title, onClose, onSubmit }: AddExtensionMod
                 </FormLabel>
                 <div className="d-md-flex w-md-50 align-items-center">
                   <FormControl name="dueDate" type="date" size="md" onChange={onChange} />
-                  <FormControl name="dueTime" type="time" size="md" className="mt-sm-3 mt-md-0" onChange={onChange} />
+                  <FormControl name="dueTime" type="time" size="md" className="mt-sm-3 mt-md-0" defaultValue={initialFormData.dueTime} onChange={onChange} />
                 </div>
               </FormGroup>
               <FormGroup className="mt-3" size="sm">

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -98,7 +98,7 @@ const messages = defineMessages({
   },
   extensionDate: {
     id: 'instruct.dateExtensions.page.addIndividualDueDateExtensionModal.extensionDate',
-    defaultMessage: 'Extension Date',
+    defaultMessage: 'Extension Date and time (in UTC)',
     description: 'Label for the extension date field',
   },
   reasonForExtension: {


### PR DESCRIPTION
## Description
As part of AC Testing, was asked to put as default 11:59 pm and change extension date and time label:

## Supporting information
Closes #163 

## Testing instructions
- Go to date extensions tab
- Click on add date extension

## Other information
Before
<img width="1134" height="587" alt="Screenshot 2026-04-20 at 9 15 31 a m" src="https://github.com/user-attachments/assets/ca96c38b-3265-45b9-8d5e-0fa6f39d91ca" />

After
<img width="1138" height="588" alt="Screenshot 2026-04-20 at 9 14 21 a m" src="https://github.com/user-attachments/assets/2406f032-bfea-46a6-98ee-d35a3a53bdf9" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
