### PR TITLE
fix: let composing site own shell and brand CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "lodash": "^4.17.23"
       },
@@ -2214,13 +2213,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.5.1",
@@ -4654,9 +4646,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-eTjdN4tx4zdUA0IgtEKDE4reYsG0ZLsSc62eFXyt1kbHj6UaKEn0WjPotp/2zDLMsk+BcQ7V/LQEVps6FRGK7Q==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4699,7 +4691,7 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "html-webpack-plugin": "5.6.0",
+        "html-webpack-plugin": "5.6.7",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
         "jest": "^29.7.0",
@@ -11964,9 +11956,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "git+https://github.com/openedx/frontend-app-instructor-dashboard.git"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./app.scss": "./dist/app.scss"
+    ".": "./dist/index.js"
   },
   "files": [
     "/dist"
@@ -56,7 +55,6 @@
     "url": "https://github.com/openedx/frontend-app-instructor-dashboard/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/openedx-atlas": "^0.7.0",
     "lodash": "^4.17.23"
   },

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -2,7 +2,7 @@ import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@o
 
 import { instructorDashboardApp } from './src';
 
-import './src/app.scss';
+import '@openedx/frontend-base/shell/style';
 
 const siteConfig: SiteConfig = {
   siteId: 'instructor-dev',

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -4,7 +4,7 @@ import { AlertProvider } from './providers/AlertProvider';
 import { appId } from './constants';
 import PageWrapper from './pageWrapper/PageWrapper';
 
-import './app.scss';
+import './style.scss';
 
 const Main = () => (
   <CurrentAppProvider appId={appId}>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -55,7 +55,7 @@ const routes = [
       roles: [instructorDashboardRole]
     },
     async lazy() {
-      const module = await import('./Main');
+      const module = await import(/* webpackChunkName: "instructor-dashboard-main" */ './Main');
       return { Component: module.default };
     },
     children: [

--- a/src/slots/README.md
+++ b/src/slots/README.md
@@ -31,7 +31,7 @@ import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@o
 
 import { instructorDashboardApp } from './src';
 
-import './src/app.scss';
+import '@openedx/frontend-base/shell/style';
 
 const siteConfig: SiteConfig = {
   siteId: 'instructor-dev',

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,3 @@
-@use "@openedx/frontend-base/shell/app.scss";
-
 .toast-container {
     left: unset;
     right: var(--pgn-spacing-toast-container-gutter-lg);


### PR DESCRIPTION
### Description

Adopts the shell style manifest from openedx/frontend-base#232 so lazy-loaded app chunks stop re-bundling the shell stylesheet and redeclaring Paragon's `:root` custom properties at runtime. Without this, composing-site brand tokens get clobbered when navigating into the app.

The dev harness now imports `@openedx/frontend-base/shell/style` directly from `site.config.dev.tsx` instead of going through a local SCSS entry point. `src/app.scss` is renamed to `src/style.scss` and keeps only the app-scoped class rules loaded per-chunk via `Main.tsx`. The `./app.scss` subpath export is removed, and `@edx/brand` is uninstalled since the dev harness runs unbranded.

### LLM usage notice

Built with assistance from Claude.