### PR TITLE
fix: add specify learner validation if is enrolled

### DIFF
--- a/src/components/SpecifyLearnerField.test.tsx
+++ b/src/components/SpecifyLearnerField.test.tsx
@@ -69,6 +69,78 @@ describe('SpecifyLearnerField', () => {
       expect(screen.getByText(mockLearnerData.email)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: messages.change.defaultMessage })).toBeInTheDocument();
     });
+
+    it('resets values when clicking change button', async () => {
+      const handleClick = jest.fn();
+      renderWithIntl(<SpecifyLearnerField onClickSelect={handleClick} />);
+      const input = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+
+      // First select a learner
+      await user.type(input, mockLearnerData.username);
+      const selectButton = screen.getByText(messages.select.defaultMessage);
+      await user.click(selectButton);
+
+      // Verify learner is shown and change button appears
+      expect(screen.getByText(mockLearnerData.username)).toBeInTheDocument();
+      const changeButton = screen.getByRole('button', { name: messages.change.defaultMessage });
+      expect(changeButton).toBeInTheDocument();
+
+      // Click change button
+      await user.click(changeButton);
+
+      // Verify reset behavior
+      expect(handleClick).toHaveBeenLastCalledWith('');
+      expect(screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage)).toBeVisible();
+      expect(screen.getByText(messages.select.defaultMessage)).toBeInTheDocument();
+      expect(screen.queryByText(mockLearnerData.username)).not.toBeInTheDocument();
+    });
+
+    it('clears input value when clicking change button', async () => {
+      const handleClick = jest.fn();
+      renderWithIntl(<SpecifyLearnerField onClickSelect={handleClick} />);
+      const input = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+
+      // First select a learner
+      await user.type(input, mockLearnerData.username);
+      const selectButton = screen.getByText(messages.select.defaultMessage);
+      await user.click(selectButton);
+
+      // Click change button
+      const changeButton = screen.getByRole('button', { name: messages.change.defaultMessage });
+      await user.click(changeButton);
+
+      // Verify input is cleared
+      const inputAfterReset = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      expect(inputAfterReset).toHaveValue('');
+    });
+
+    it('hides learner information when clicking change button', async () => {
+      const handleClick = jest.fn();
+      renderWithIntl(<SpecifyLearnerField onClickSelect={handleClick} />);
+      const input = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+
+      // First select a learner
+      await user.type(input, mockLearnerData.username);
+      const selectButton = screen.getByText(messages.select.defaultMessage);
+      await user.click(selectButton);
+
+      // Verify learner info is visible
+      expect(screen.getByText(mockLearnerData.username)).toBeInTheDocument();
+      expect(screen.getByText(mockLearnerData.fullName)).toBeInTheDocument();
+      expect(screen.getByText(mockLearnerData.email)).toBeInTheDocument();
+
+      // Click change button
+      const changeButton = screen.getByRole('button', { name: messages.change.defaultMessage });
+      await user.click(changeButton);
+
+      // Verify learner info is hidden
+      expect(screen.queryByText(mockLearnerData.fullName)).not.toBeInTheDocument();
+      expect(screen.queryByText(mockLearnerData.email)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: messages.change.defaultMessage })).not.toBeInTheDocument();
+    });
   });
 
   describe('when learner not found', () => {
@@ -93,6 +165,49 @@ describe('SpecifyLearnerField', () => {
       expect(
         screen.getByText(new RegExp(staticPart + ':'))
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('when learner is found but not enrolled', () => {
+    const mockNotEnrolledLearnerData = {
+      username: 'notenrolleduser',
+      fullName: 'Not Enrolled User',
+      email: 'notenrolled@email.com',
+      isEnrolled: false,
+    };
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      (useCourseInfo as jest.Mock).mockReturnValue({ data: { permissions: { admin: true, dataResearcher: false } } });
+      (useLearner as jest.Mock).mockReturnValue({
+        data: mockNotEnrolledLearnerData,
+        refetch: jest.fn().mockResolvedValue({ data: mockNotEnrolledLearnerData }),
+        error: null,
+      });
+    });
+
+    it('shows learner not enrolled message', async () => {
+      renderWithIntl(<SpecifyLearnerField onClickSelect={jest.fn()} />);
+      const input = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+      await user.type(input, mockNotEnrolledLearnerData.username);
+      const button = screen.getByText(messages.select.defaultMessage);
+      await user.click(button);
+
+      // Wait for the message to appear
+      await expect(screen.findByText(messages.learnerNotEnrolled.defaultMessage.replace('{identifier}', mockNotEnrolledLearnerData.username))).resolves.toBeInTheDocument();
+    });
+
+    it('calls onClickSelect with empty string when learner is not enrolled', async () => {
+      const handleClick = jest.fn();
+      renderWithIntl(<SpecifyLearnerField onClickSelect={handleClick} />);
+      const input = screen.getByPlaceholderText(messages.specifyLearnerPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+      await user.type(input, mockNotEnrolledLearnerData.username);
+      const button = screen.getByText(messages.select.defaultMessage);
+      await user.click(button);
+
+      expect(handleClick).toHaveBeenCalledWith('');
     });
   });
 });

--- a/src/components/SpecifyLearnerField.test.tsx
+++ b/src/components/SpecifyLearnerField.test.tsx
@@ -14,6 +14,7 @@ const mockLearnerData = {
   username: 'testuser',
   fullName: 'Test User',
   email: 'test@email.com',
+  isEnrolled: true,
 };
 
 describe('SpecifyLearnerField', () => {

--- a/src/components/SpecifyLearnerField.tsx
+++ b/src/components/SpecifyLearnerField.tsx
@@ -31,11 +31,14 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
   });
   const { data = { email: '', fullName: '', username: '', isEnrolled: false }, refetch, error } = useLearner(courseId, inputValue);
 
+  const resetState = () => {
+    resetFilter();
+    onClickSelect('');
+    disableShowLearner();
+  };
+
   useImperativeHandle(ref, () => ({
-    reset: () => {
-      resetFilter();
-      disableShowLearner();
-    }
+    reset: resetState,
   }));
 
   const selectedLearner = learner || data;
@@ -51,13 +54,11 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
   const handleClickSelect = () => {
     if (inputValue) {
       refetch().then((result) => {
-        enableShowLearner();
-        if (result?.data?.isEnrolled) {
         // Need to pass empty value if learner is not valid to clear out any previously selected learner
         // We could have other conditions/fields depending on valid learner
-          const formValue = !result.error ? inputValue : '';
-          onClickSelect(formValue);
-        }
+        const formValue = !result.error && result.data?.isEnrolled ? inputValue : '';
+        onClickSelect(formValue);
+        enableShowLearner();
       });
     }
   };
@@ -88,7 +89,7 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
                 </div>
               )}
             </div>
-            {!learner && <Button iconBefore={SpinnerIcon} onClick={disableShowLearner}>{intl.formatMessage(messages.change)}</Button>}
+            {!learner && <Button iconBefore={SpinnerIcon} onClick={resetState}>{intl.formatMessage(messages.change)}</Button>}
           </>
         ) : (
           <Button onClick={handleClickSelect} disabled={!inputValue}>{intl.formatMessage(messages.select)}</Button>
@@ -102,7 +103,7 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
         </p>
       )}
       {
-        showLearner && !selectedLearner?.isEnrolled && (
+        showLearner && !error && !selectedLearner?.isEnrolled && (
           <p className="text-danger-500 mb-0 x-small mt-2">
             {intl.formatMessage(messages.learnerNotEnrolled, { identifier })}
           </p>

--- a/src/components/SpecifyLearnerField.tsx
+++ b/src/components/SpecifyLearnerField.tsx
@@ -29,7 +29,7 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
     filterValue: identifier,
     setFilter: setIdentifier,
   });
-  const { data = { email: '', fullName: '', username: '' }, refetch, error } = useLearner(courseId, inputValue);
+  const { data = { email: '', fullName: '', username: '', isEnrolled: false }, refetch, error } = useLearner(courseId, inputValue);
 
   useImperativeHandle(ref, () => ({
     reset: () => {
@@ -51,11 +51,13 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
   const handleClickSelect = () => {
     if (inputValue) {
       refetch().then((result) => {
+        enableShowLearner();
+        if (result?.data?.isEnrolled) {
         // Need to pass empty value if learner is not valid to clear out any previously selected learner
         // We could have other conditions/fields depending on valid learner
-        const formValue = !result.error ? inputValue : '';
-        onClickSelect(formValue);
-        enableShowLearner();
+          const formValue = !result.error ? inputValue : '';
+          onClickSelect(formValue);
+        }
       });
     }
   };
@@ -99,6 +101,13 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
           {intl.formatMessage(messages.learnerNotFound, { identifier })}
         </p>
       )}
+      {
+        showLearner && !selectedLearner?.isEnrolled && (
+          <p className="text-danger-500 mb-0 x-small mt-2">
+            {intl.formatMessage(messages.learnerNotEnrolled, { identifier })}
+          </p>
+        )
+      }
     </FormGroup>
   );
 });

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -140,6 +140,11 @@ const messages = defineMessages({
     id: 'instruct.specifyProblemField.selectedProblem',
     defaultMessage: 'Selected Problem:',
     description: 'Label for specify problem field when a problem has been selected',
+  },
+  learnerNotEnrolled: {
+    id: 'instruct.specifyLearner.learnerNotEnrolled',
+    defaultMessage: '{identifier} is not enrolled in this course',
+    description: 'Error message displayed when a learner is found based on the provided identifier (email or username) but is not enrolled in the course',
   }
 });
 

--- a/src/data/apiHook.test.tsx
+++ b/src/data/apiHook.test.tsx
@@ -133,6 +133,7 @@ describe('api hooks', () => {
         fullName: 'Test User',
         email: 'test@example.com',
         progressUrl: '/progress/testuser',
+        isEnrolled: true,
       };
       mockGetLearner.mockResolvedValue(mockLearner);
 

--- a/src/dateExtensions/components/AddExtensionModal.test.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.test.tsx
@@ -21,6 +21,7 @@ const mockLearnerData = {
   username: 'testuser',
   fullName: 'Test User',
   email: 'test@email.com',
+  isEnrolled: true,
 };
 
 jest.mock('@src/data/apiHook', () => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,4 +49,5 @@ export interface Learner {
 
 export interface SelectedLearner extends Learner {
   progressUrl: string,
+  isEnrolled: boolean,
 }


### PR DESCRIPTION
## Description
It was asked to add a new validation for the learner, not allowing to do actions if it is not enrolled on the current course, so we add a message displaying that info and doesn't pass the learner info to the form so it doesn't enable the action buttons.

## Supporting information
Closes #164 

## Testing instructions
- Go to date extensions tab
- click on add extension, fill all the form but learner should be an existing user but not enrolled
- You should see the message and the add extension button disabled

## Screenshot
<img width="1134" height="619" alt="Screenshot 2026-04-22 at 9 19 56 a m" src="https://github.com/user-attachments/assets/2b032a8b-179c-4b7f-a949-f6fbc62cbe7b" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
