### PR TITLE
chore: add build:ci smoke test to verify webpack build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       run: npm run test
     - name: Build
       run: npm run build
+    - name: Build (CI)
+      run: npm run build:ci
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,6 @@ build:
 	    mkdir -p "$$(dirname "$$d")"; \
 	    cp "$$f" "$$d"; \
 	  done' sh {} +
+
+build-ci:
+	SITE_CONFIG_PATH=site.config.ci.tsx openedx build

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "make build",
+    "build:ci": "make build-ci",
     "build:packages": "make build-packages",
     "clean": "make clean",
     "clean:packages": "make clean-packages",

--- a/site.config.ci.tsx
+++ b/site.config.ci.tsx
@@ -1,0 +1,24 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+
+import { instructorDashboardApp } from './src';
+
+import '@openedx/frontend-base/shell/style';
+
+const siteConfig: SiteConfig = {
+  siteId: 'instructor-ci',
+  siteName: 'Instructor CI',
+  baseUrl: 'http://apps.local.openedx.io',
+  lmsBaseUrl: 'http://local.openedx.io',
+  loginUrl: 'http://local.openedx.io/login',
+  logoutUrl: 'http://local.openedx.io/logout',
+
+  environment: EnvironmentTypes.PRODUCTION,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+    instructorDashboardApp
+  ],
+};
+
+export default siteConfig;


### PR DESCRIPTION
### Description

Apps are distributed build-less, so `npm run build` only compiles the library `dist/` via `tsc` and nothing in CI verifies that the app can actually be webpack-bundled as a deployable site. This PR adds an `npm run build:ci` script that exercises the real app graph through webpack, and wires it into the CI workflow after the existing build step.

Refs openedx/frontend-base#124.

### Verifying the check

Introduce a typo in an import somewhere in `src/` that is reached from the app's route/component graph (for example, rename a file import to a path that doesn't exist). `npm run build` still passes, but `npm run build:ci` fails with a module resolution error. Revert the typo and the build goes green again.

### LLM usage notice

Built with assistance from Claude.