### PR TITLE
fix: save date in UTC

### DIFF
--- a/src/dateExtensions/components/AddExtensionModal.test.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.test.tsx
@@ -89,7 +89,7 @@ describe('AddExtensionModal', () => {
       expect(mockProps.onSubmit).toHaveBeenCalledWith({
         emailOrUsername: 'testuser',
         blockId: 'sub1',
-        dueDatetime: new Date('2024-12-31T23:59').toISOString(),
+        dueDatetime: new Date('2024-12-31T23:59Z').toISOString(),
         reason: 'Medical emergency'
       });
     });

--- a/src/dateExtensions/components/AddExtensionModal.tsx
+++ b/src/dateExtensions/components/AddExtensionModal.tsx
@@ -43,7 +43,7 @@ const AddExtensionModal = ({ isOpen, title, onClose, onSubmit }: AddExtensionMod
     onSubmit({
       emailOrUsername,
       blockId,
-      dueDatetime: new Date(`${dueDate}T${dueTime}`).toISOString(),
+      dueDatetime: new Date(`${dueDate}T${dueTime}Z`).toISOString(),
       reason
     });
   };

--- a/src/dateExtensions/components/DateExtensionsList.test.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.test.tsx
@@ -55,7 +55,7 @@ describe('DateExtensionsList', () => {
     expect(screen.getByText(mockData[0].fullName)).toBeInTheDocument();
     expect(screen.getByText(mockData[0].email)).toBeInTheDocument();
     expect(screen.getByText(mockData[0].unitTitle)).toBeInTheDocument();
-    expect(screen.getByText('11/07/2025, 12:00 AM')).toBeInTheDocument();
+    expect(screen.getByText('11/07/2025, 12:00 AM UTC')).toBeInTheDocument();
     const resetExtensions = screen.getByRole('button', { name: /reset extensions/i });
     expect(resetExtensions).toBeInTheDocument();
     await user.click(resetExtensions);

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -71,7 +71,7 @@ const DateExtensionsList = ({
       accessor: 'extendedDueDate',
       Header: intl.formatMessage(messages.extendedDueDate),
       Cell: ({ value }: { value: string }) => (
-        `${intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })} ${intl.formatMessage(messages.utc)}`
+        `${intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })} UTC`
       ),
       disableFilters: true,
     },

--- a/src/dateExtensions/components/DateExtensionsList.tsx
+++ b/src/dateExtensions/components/DateExtensionsList.tsx
@@ -71,7 +71,7 @@ const DateExtensionsList = ({
       accessor: 'extendedDueDate',
       Header: intl.formatMessage(messages.extendedDueDate),
       Cell: ({ value }: { value: string }) => (
-        intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+        `${intl.formatDate(value, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })} ${intl.formatMessage(messages.utc)}`
       ),
       disableFilters: true,
     },

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -121,6 +121,11 @@ const messages = defineMessages({
     defaultMessage: 'No results found',
     description: 'Message shown when there are no date extensions to display in the table',
   },
+  utc: {
+    id: 'instruct.dateExtensions.page.utc',
+    defaultMessage: 'UTC',
+    description: 'Label for Coordinated Universal Time (UTC)',
+  }
 });
 
 export default messages;

--- a/src/dateExtensions/messages.ts
+++ b/src/dateExtensions/messages.ts
@@ -121,11 +121,6 @@ const messages = defineMessages({
     defaultMessage: 'No results found',
     description: 'Message shown when there are no date extensions to display in the table',
   },
-  utc: {
-    id: 'instruct.dateExtensions.page.utc',
-    defaultMessage: 'UTC',
-    description: 'Label for Coordinated Universal Time (UTC)',
-  }
 });
 
 export default messages;


### PR DESCRIPTION
## Description
Date wasn't saving in UTC so it was converted and display a diff date when we retrieve again on the list. Also add UTC in date cell so is clearer for the user.

## Supporting information
Closes #159 

## Testing instructions
- Go to Date extensions tab
- add a new date extension
- Verify is the same date on the table list

## Other information
<img width="1527" height="655" alt="Screenshot 2026-04-22 at 6 22 57 p m" src="https://github.com/user-attachments/assets/d534d14b-71fd-49f5-b0e5-64ef1ee40c48" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
