### PR TITLE
fix: add check enrollment status popup menu

### DIFF
--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -84,16 +84,31 @@ describe('EnrollmentsPage', () => {
     const user = userEvent.setup();
     await user.click(moreButton);
 
+    // Verify popup menu is opened
+    const checkEnrollmentStatusOption = screen.getByText(messages.checkEnrollmentStatus.defaultMessage);
+    expect(checkEnrollmentStatusOption).toBeInTheDocument();
+    await user.click(checkEnrollmentStatusOption);
+
+    // Verify dialog is opened and popup is closed
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(checkEnrollmentStatusOption).not.toBeInTheDocument();
   });
 
   it('closes enrollment status modal', async () => {
     renderWithAlertAndIntl(<EnrollmentsPage />);
 
+    // Open the popup menu first
     const moreButton = screen.getByRole('button', { name: messages.checkEnrollmentStatus.defaultMessage });
     const user = userEvent.setup();
     await user.click(moreButton);
 
+    // Click on the "Check Enrollment Status" option to open the dialog
+    const checkEnrollmentStatusOption = screen.getByText(messages.checkEnrollmentStatus.defaultMessage);
+    await user.click(checkEnrollmentStatusOption);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Close the dialog
     const closeButton = screen.getByText('Close');
     await user.click(closeButton);
 

--- a/src/enrollments/EnrollmentsPage.tsx
+++ b/src/enrollments/EnrollmentsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
-import { ActionRow, Button, IconButton } from '@openedx/paragon';
+import { ActionRow, Button, IconButton, Menu, MenuItem, ModalPopup, useToggle } from '@openedx/paragon';
 import { MoreVert } from '@openedx/paragon/icons';
 import messages from '@src/enrollments/messages';
 import AddBetaTestersModal from '@src/enrollments/components/AddBetaTestersModal';
@@ -20,10 +20,13 @@ const EnrollmentsPage = () => {
   const [isUnenrollModalOpen, setIsUnenrollModalOpen] = useState(false);
   const [isUpdateBetaTesterModalOpen, setIsUpdateBetaTesterModalOpen] = useState(false);
   const [selectedLearner, setSelectedLearner] = useState<EnrolledLearner | null>(null);
+  const [statusMenuTarget, setStatusMenuTarget] = useState<HTMLButtonElement | null>(null);
+  const [isOpenMenu, openMenu, closeMenu] = useToggle(false);
   const { clearAlerts } = useAlert();
 
-  const handleMoreButton = () => {
+  const handleOpenEnrollmentStatusModal = () => {
     setIsEnrollmentStatusModalOpen(true);
+    closeMenu();
   };
 
   const handleUnenroll = (learner: EnrolledLearner) => {
@@ -64,6 +67,11 @@ const EnrollmentsPage = () => {
     setSelectedLearner(null);
   };
 
+  const handleStatusMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setStatusMenuTarget(event?.currentTarget);
+    openMenu();
+  };
+
   return (
     <>
       <div className="d-flex justify-content-between align-items-center">
@@ -73,12 +81,19 @@ const EnrollmentsPage = () => {
             alt={intl.formatMessage(messages.checkEnrollmentStatus)}
             className="lead"
             iconAs={MoreVert}
-            onClick={handleMoreButton}
+            onClick={handleStatusMenuClick}
           />
           <Button variant="outline-primary" onClick={handleAddBetaTesters}>+ {intl.formatMessage(messages.addBetaTesters)}</Button>
           <Button onClick={handleEnrollLearners}>+ {intl.formatMessage(messages.enrollLearners)}</Button>
         </ActionRow>
       </div>
+      <ModalPopup positionRef={statusMenuTarget} onClose={closeMenu} isOpen={isOpenMenu}>
+        <Menu>
+          <MenuItem onClick={handleOpenEnrollmentStatusModal}>
+            {intl.formatMessage(messages.checkEnrollmentStatus)}
+          </MenuItem>
+        </Menu>
+      </ModalPopup>
       <AlertOutlet />
       <EnrollmentsList onUnenroll={handleUnenroll} onBetaTesterChange={handleBetaTesterChange} />
       <EnrollmentStatusModal isOpen={isEnrollmentStatusModalOpen} onClose={handleCloseEnrollmentStatusModal} />


### PR DESCRIPTION
## Description
We needed to add a popup menu when 3 dot was click before opening the check enrollment status dialog.

## Supporting information
Closes #165 

## Testing instructions
- Go to enrollments tab
- Click on 3 dot icon
- Click on check enrollment status menu option
- Should open check enrollment status dialog

## Demo


https://github.com/user-attachments/assets/70c23ce8-4cfe-409c-b994-f6dcf930f910


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
