### PR TITLE
fix: add team members

### DIFF
--- a/src/courseTeam/components/AddTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/AddTeamMemberModal.test.tsx
@@ -6,6 +6,7 @@ import { useAddTeamMember, useRoles } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
 import { useAlert } from '@src/providers/AlertProvider';
+import { TEAM_MEMBER_ACTION } from '../constants';
 
 // Mocks
 jest.mock('react-router-dom', () => ({
@@ -97,7 +98,7 @@ describe('AddTeamMemberModal', () => {
     await user.click(screen.getByText(messages.saveButton.defaultMessage));
 
     expect(mutateMock).toHaveBeenCalledWith(
-      { identifiers: ['user1', 'user2'], role: 'admin' },
+      { identifiers: ['user1', 'user2'], role: 'admin', action: TEAM_MEMBER_ACTION.ALLOW },
       expect.any(Object)
     );
   });
@@ -207,7 +208,7 @@ describe('AddTeamMemberModal', () => {
     await user.click(screen.getByText(messages.saveButton.defaultMessage));
 
     expect(mutateMock).toHaveBeenCalledWith(
-      { identifiers: ['user1', 'user2', 'user3'], role: 'admin' },
+      { identifiers: ['user1', 'user2', 'user3'], role: 'admin', action: TEAM_MEMBER_ACTION.ALLOW },
       expect.any(Object)
     );
   });
@@ -225,7 +226,7 @@ describe('AddTeamMemberModal', () => {
     await user.click(screen.getByText(messages.saveButton.defaultMessage));
 
     expect(mutateMock).toHaveBeenCalledWith(
-      { identifiers: [], role: 'admin' },
+      { identifiers: [], role: 'admin', action: TEAM_MEMBER_ACTION.ALLOW },
       expect.any(Object)
     );
   });

--- a/src/courseTeam/components/AddTeamMemberModal.tsx
+++ b/src/courseTeam/components/AddTeamMemberModal.tsx
@@ -7,6 +7,7 @@ import messages from '@src/courseTeam/messages';
 import { useCourseInfo } from '@src/data/apiHook';
 import { useDebouncedFilter } from '@src/hooks/useDebouncedFilter';
 import { useAlert } from '@src/providers/AlertProvider';
+import { TEAM_MEMBER_ACTION } from '../constants';
 
 interface AddTeamMemberModalProps {
   isOpen: boolean,
@@ -42,7 +43,7 @@ const AddTeamMemberModal = ({
 
   const handleSave = () => {
     const identifiers = inputValue.split(',').map(user => user.trim()).filter(user => user);
-    addTeamMember({ identifiers, role: selectedRole }, {
+    addTeamMember({ identifiers, role: selectedRole, action: TEAM_MEMBER_ACTION.ALLOW }, {
       onSuccess: (data) => {
         const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
         if (failedUsernames.length > 0) {

--- a/src/courseTeam/components/EditTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.test.tsx
@@ -5,6 +5,7 @@ import { useRoles, useAddTeamMember, useRemoveTeamMember } from '@src/courseTeam
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember } from '@src/courseTeam/types';
 import { renderWithAlertAndIntl } from '@src/testUtils';
+import { TEAM_MEMBER_ACTION } from '../constants';
 
 // Mocks
 jest.mock('react-router-dom', () => ({
@@ -259,6 +260,7 @@ describe('EditTeamMemberModal', () => {
     expect(mockAddTeamMember).toHaveBeenCalledWith({
       identifiers: [mockUser.username],
       role: 'instructor',
+      action: TEAM_MEMBER_ACTION.ALLOW
     }, expect.objectContaining({
       onSuccess: expect.any(Function),
       onError: expect.any(Function)
@@ -333,7 +335,8 @@ describe('EditTeamMemberModal', () => {
 
     expect(mockAddTeamMember).toHaveBeenCalledWith({
       identifiers: [mockUser.username],
-      role: 'instructor'
+      role: 'instructor',
+      action: TEAM_MEMBER_ACTION.ALLOW
     }, expect.objectContaining({
       onSuccess: expect.any(Function),
       onError: expect.any(Function)

--- a/src/courseTeam/components/EditTeamMemberModal.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.tsx
@@ -6,6 +6,7 @@ import { useAddTeamMember, useRemoveTeamMember, useRoles } from '@src/courseTeam
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember, Role } from '@src/courseTeam/types';
 import { useAlert } from '@src/providers/AlertProvider';
+import { TEAM_MEMBER_ACTION } from '../constants';
 
 interface EditTeamMemberModalProps {
   isOpen: boolean,
@@ -54,7 +55,7 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
         onSuccess: () => {
           // After successful removal, add new role if needed
           if (hasRolesToAdd) {
-            addTeamMember({ identifiers: [user.username], role: selectedRole }, {
+            addTeamMember({ identifiers: [user.username], role: selectedRole, action: TEAM_MEMBER_ACTION.ALLOW }, {
               onSuccess: () => {
                 onClose();
               },
@@ -80,7 +81,7 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
       });
     } else if (hasRolesToAdd) {
       // Only add operation needed
-      addTeamMember({ identifiers: [user.username], role: selectedRole }, {
+      addTeamMember({ identifiers: [user.username], role: selectedRole, action: TEAM_MEMBER_ACTION.ALLOW }, {
         onSuccess: () => {
           onClose();
         },

--- a/src/courseTeam/constants.ts
+++ b/src/courseTeam/constants.ts
@@ -1,0 +1,3 @@
+export const TEAM_MEMBER_ACTION = {
+  ALLOW: 'allow',
+} as const;

--- a/src/courseTeam/data/api.test.ts
+++ b/src/courseTeam/data/api.test.ts
@@ -96,12 +96,13 @@ describe('courseTeam API', () => {
       httpClientMock.post.mockResolvedValue({ data: {
         identifiers,
         role,
+        action: 'allow',
       } });
 
       await addTeamMember(courseId, identifiers, role);
 
       const expectedUrl = `/api/instructor/v2/courses/${courseId}/team`;
-      expect(httpClientMock.post).toHaveBeenCalledWith(expectedUrl, { identifiers, role });
+      expect(httpClientMock.post).toHaveBeenCalledWith(expectedUrl, { identifiers, role, action: 'allow' });
     });
   });
 

--- a/src/courseTeam/data/api.test.ts
+++ b/src/courseTeam/data/api.test.ts
@@ -1,5 +1,6 @@
 import { getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getTeamMembers, getRoles, addTeamMember, removeTeamMember } from '@src/courseTeam/data/api';
+import { TEAM_MEMBER_ACTION } from '@src/courseTeam/constants';
 
 jest.mock('@openedx/frontend-base', () => ({
   ...jest.requireActual('@openedx/frontend-base'),
@@ -91,18 +92,18 @@ describe('courseTeam API', () => {
   describe('addTeamMember', () => {
     it('should call the correct endpoint to add a team member', async () => {
       const courseId = 'course-v1:edX+DemoX+Demo_Course';
-      const identifiers = ['testuser'];
-      const role = 'instructor';
-      httpClientMock.post.mockResolvedValue({ data: {
-        identifiers,
-        role,
-        action: 'allow',
-      } });
+      const params = {
+        identifiers: ['testuser'],
+        role: 'instructor',
+        action: TEAM_MEMBER_ACTION.ALLOW,
+      };
 
-      await addTeamMember(courseId, identifiers, role);
+      httpClientMock.post.mockResolvedValue({ data: params });
+
+      await addTeamMember(courseId, params);
 
       const expectedUrl = `/api/instructor/v2/courses/${courseId}/team`;
-      expect(httpClientMock.post).toHaveBeenCalledWith(expectedUrl, { identifiers, role, action: 'allow' });
+      expect(httpClientMock.post).toHaveBeenCalledWith(expectedUrl, params);
     });
   });
 

--- a/src/courseTeam/data/api.ts
+++ b/src/courseTeam/data/api.ts
@@ -36,7 +36,7 @@ export const getRoles = async (courseId: string): Promise<Omit<DataList<Role>, '
 export const addTeamMember = async (courseId: string, identifiers: string[], role: string): Promise<TeamMembersResponse> => {
   const { data } = await getAuthenticatedHttpClient().post(
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team`,
-    { identifiers, role }
+    { identifiers, role, action: 'allow' }
   );
   return camelCaseObject(data);
 };

--- a/src/courseTeam/data/api.ts
+++ b/src/courseTeam/data/api.ts
@@ -1,7 +1,13 @@
 import { camelCaseObject, getAuthenticatedHttpClient } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
-import { TeamMembersResponse, CourseTeamMember, CourseTeamMemberQueryParams, Role } from '@src/courseTeam/types';
+import {
+  TeamMembersResponse,
+  CourseTeamMember,
+  CourseTeamMemberQueryParams,
+  Role,
+  AddTeamMemberParams,
+} from '@src/courseTeam/types';
 
 export const getTeamMembers = async (
   courseId: string,
@@ -33,10 +39,10 @@ export const getRoles = async (courseId: string): Promise<Omit<DataList<Role>, '
   return camelCaseObject(data);
 };
 
-export const addTeamMember = async (courseId: string, identifiers: string[], role: string): Promise<TeamMembersResponse> => {
+export const addTeamMember = async (courseId: string, params: AddTeamMemberParams): Promise<TeamMembersResponse> => {
   const { data } = await getAuthenticatedHttpClient().post(
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team`,
-    { identifiers, role, action: 'allow' }
+    params
   );
   return camelCaseObject(data);
 };

--- a/src/courseTeam/data/apiHook.test.tsx
+++ b/src/courseTeam/data/apiHook.test.tsx
@@ -5,6 +5,7 @@ import { useTeamMembers, useRoles, useAddTeamMember, useRemoveTeamMember } from 
 import * as api from '@src/courseTeam/data/api';
 import { CourseTeamMember } from '@src/courseTeam/types';
 import { DataList } from '@src/types';
+import { TEAM_MEMBER_ACTION } from '../constants';
 
 jest.mock('@src/courseTeam/data/api');
 
@@ -147,7 +148,7 @@ describe('apiHook', () => {
         wrapper: createWrapper(),
       });
 
-      result.current.mutate({ identifiers: ['user1', 'user2'], role: 'admin' }, {
+      result.current.mutate({ identifiers: ['user1', 'user2'], role: 'admin', action: TEAM_MEMBER_ACTION.ALLOW }, {
         onSuccess: jest.fn(),
         onError: jest.fn(),
       });
@@ -156,7 +157,7 @@ describe('apiHook', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(api.addTeamMember).toHaveBeenCalledWith('course-v1:org+course+run', ['user1', 'user2'], 'admin');
+      expect(api.addTeamMember).toHaveBeenCalledWith('course-v1:org+course+run', { identifiers: ['user1', 'user2'], role: 'admin', action: TEAM_MEMBER_ACTION.ALLOW });
     });
   });
 

--- a/src/courseTeam/data/apiHook.ts
+++ b/src/courseTeam/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { addTeamMember, getRoles, getTeamMembers, removeTeamMember } from '@src/courseTeam/data/api';
 import { courseTeamQueryKeys } from '@src/courseTeam/data/queryKeys';
-import { CourseTeamMemberQueryParams } from '@src/courseTeam/types';
+import { AddTeamMemberParams, CourseTeamMemberQueryParams } from '@src/courseTeam/types';
 
 export const useTeamMembers = (courseId: string, params: CourseTeamMemberQueryParams) => (
   useQuery({
@@ -22,7 +22,7 @@ export const useRoles = (courseId: string) => (
 export const useAddTeamMember = (courseId: string) => {
   const queryClient = useQueryClient();
   return (useMutation({
-    mutationFn: ({ identifiers, role }: { identifiers: string[], role: string }) => addTeamMember(courseId, identifiers, role),
+    mutationFn: (params: AddTeamMemberParams) => addTeamMember(courseId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: courseTeamQueryKeys.byCourse(courseId) });
     }

--- a/src/courseTeam/types.ts
+++ b/src/courseTeam/types.ts
@@ -1,3 +1,5 @@
+import { TEAM_MEMBER_ACTION } from './constants';
+
 export interface CourseTeamMember {
   username: string,
   fullName: string,
@@ -22,4 +24,12 @@ export interface TeamMembersResponse {
     identifier: string,
     userDoesNotExist: boolean,
   }[],
+}
+
+export type TeamMemberActionType = typeof TEAM_MEMBER_ACTION[keyof typeof TEAM_MEMBER_ACTION];
+
+export interface AddTeamMemberParams {
+  identifiers: string[],
+  role: string,
+  action: TeamMemberActionType,
 }


### PR DESCRIPTION
## Description
An attribute was missing on add team members endpoint

## Supporting information
Closes #174

## Testing instructions
- Go to course team tab
- click on add team members
- fill with valid data
- submit

## Other information

https://github.com/user-attachments/assets/cd5adb98-01db-49eb-a909-8e22830566d9


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
