### PR TITLE
fix: validation to show error in all learners tab if not found

### DIFF
--- a/src/components/SpecifyProblemField.test.tsx
+++ b/src/components/SpecifyProblemField.test.tsx
@@ -218,4 +218,44 @@ describe('SpecifyProblemField', () => {
       testUsername
     );
   });
+
+  describe('when problem not found', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      mockUseDebouncedFilter.mockReturnValue({
+        inputValue: 'invalid-problem-id',
+        handleChange: jest.fn(),
+        resetFilter: jest.fn(),
+      });
+      (useProblemDetails as jest.Mock).mockReturnValue({
+        data: { breadcrumbs: [], name: '', id: '' },
+        refetch: jest.fn().mockResolvedValue({ data: {} }),
+        error: { isAxiosError: true, response: { status: 400 } },
+      });
+    });
+
+    it('shows error message if problem not found', async () => {
+      renderWithIntl(<SpecifyProblemField {...defaultProps} onClickSelect={jest.fn()} />);
+      const input = screen.getByPlaceholderText(messages.problemLocationPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+      await user.type(input, 'invalid-problem-id');
+      const button = screen.getByText('Select Problem');
+      await user.click(button);
+      const staticPart = messages.problemNotFound.defaultMessage.split(':')[0];
+      expect(
+        screen.getByText(new RegExp(staticPart + ':'))
+      ).toBeInTheDocument();
+    });
+
+    it('keeps input visible when error occurs', async () => {
+      renderWithIntl(<SpecifyProblemField {...defaultProps} onClickSelect={jest.fn()} />);
+      const input = screen.getByPlaceholderText(messages.problemLocationPlaceholder.defaultMessage);
+      const user = userEvent.setup();
+      await user.type(input, 'invalid-problem-id');
+      const button = screen.getByText('Select Problem');
+      await user.click(button);
+      // Input should still be visible for user to try again
+      expect(screen.getByPlaceholderText(messages.problemLocationPlaceholder.defaultMessage)).toBeVisible();
+    });
+  });
 });

--- a/src/components/SpecifyProblemField.tsx
+++ b/src/components/SpecifyProblemField.tsx
@@ -1,4 +1,5 @@
 import { useState, useImperativeHandle, forwardRef } from 'react';
+import { isAxiosError } from 'axios';
 import { useParams } from 'react-router-dom';
 import { Button, Form, Icon, OverlayTrigger, Tooltip, useToggle } from '@openedx/paragon';
 import { InfoOutline, SpinnerIcon } from '@openedx/paragon/icons';
@@ -37,7 +38,7 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
     filterValue: problemLocation,
     setFilter: setProblemLocation,
   });
-  const { data = { breadcrumbs: [], name: '', id: '' }, refetch } = useProblemDetails(courseId, inputValue, usernameOrEmail);
+  const { data = { breadcrumbs: [], name: '', id: '' }, refetch, error } = useProblemDetails(courseId, inputValue, usernameOrEmail);
 
   useImperativeHandle(ref, () => ({
     reset: () => {
@@ -55,10 +56,12 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
   };
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    refetch().then(() => {
-      onClickSelect(inputValue, event);
-      enableShowSelectedLocation();
-    });
+    if (inputValue) {
+      refetch().then(() => {
+        onClickSelect(inputValue, event);
+        enableShowSelectedLocation();
+      });
+    }
   };
 
   return (
@@ -82,7 +85,7 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
             )}
       </Form.Label>
       <div className="d-flex align-items-center">
-        {showSelectedLocation && data ? (
+        {showSelectedLocation && data && !error ? (
           <div className="d-flex gap-3 align-items-center col-8 p-0">
             <div className="d-block w-100">
               <p className="x-small mb-0 text-primary-500 text-truncate">
@@ -122,6 +125,13 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
           </>
         )}
       </div>
+      {showSelectedLocation && error
+      && isAxiosError(error)
+      && (error.response?.status === 400) && (
+        <p className="text-danger-500 mb-0 x-small mt-2">
+          {intl.formatMessage(messages.problemNotFound, { identifier: inputValue })}
+        </p>
+      )}
     </Form.Group>
   );
 });

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -116,6 +116,11 @@ const messages = defineMessages({
     defaultMessage: 'Could not find student matching identifier: {identifier}',
     description: 'Error message displayed when a learner cannot be found based on the provided identifier (email or username)',
   },
+  problemNotFound: {
+    id: 'instruct.specifyProblemField.problemNotFound',
+    defaultMessage: 'Could not find problem matching identifier: {identifier}',
+    description: 'Error message displayed when a problem cannot be found based on the provided identifier',
+  },
   searchPlaceholder: {
     id: 'instruct.usernameFilter.searchPlaceholder',
     defaultMessage: 'Search By Username or Email',


### PR DESCRIPTION
## Description

In the grading tools, inside Grading tab, the all Learners option wasn't showing the error when the module is not found.
this closes this [issue](https://github.com/openedx/frontend-app-instructor-dashboard/issues/171)

the validation was added to show the error if the module is not found


## Testing instructions
to see the error:
- Type an invalid problem and click on Select, to see the error below

<img width="784" height="265" alt="Screenshot 2026-04-23 at 1 36 44 p m" src="https://github.com/user-attachments/assets/83f4d6d1-55bc-4027-ad1b-e3ca9848140d" />

to see a successful validation
- Add a valid problem
<img width="715" height="266" alt="Screenshot 2026-04-23 at 1 37 26 p m" src="https://github.com/user-attachments/assets/3c70bbb0-b60b-4b8c-ba93-729336edf8e3" />

