### PR TITLE
fix: change scss to relative to avoid build issues

### DIFF
--- a/src/certificates/CertificatesPage.tsx
+++ b/src/certificates/CertificatesPage.tsx
@@ -26,7 +26,7 @@ import { CertificateFilter } from '@src/certificates/types';
 import { CERTIFICATES_PAGE_SIZE, TAB_KEYS, MODAL_TITLES, ALERT_VARIANTS } from '@src/certificates/constants';
 import { getErrorMessage } from '@src/certificates/utils/errorHandling';
 import messages from '@src/certificates/messages';
-import '@src/certificates/CertificatesPage.scss';
+import './CertificatesPage.scss';
 
 const CertificatesPage = () => {
   const intl = useIntl();


### PR DESCRIPTION
## Description
We had this error on the pipeline
```
#64 79.52 ERROR in ./node_modules/@openedx/frontend-app-instructor-dashboard/dist/certificates/components/CertificatesToolbar.js 8:0-49
#64 79.52 Module not found: Error: Can't resolve '@src/certificates/CertificatesPage.scss' in '/openedx/site/node_modules/@openedx/frontend-app-instructor-dashboard/dist/certificates/components'
```

Absolute path don't work properly on scss files, until we fix this, we will handle scss as relative imports

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
