### PR TITLE
fix: change scss to relative to avoid build issues

### DIFF
--- a/src/certificates/components/CertificatesToolbar.tsx
+++ b/src/certificates/components/CertificatesToolbar.tsx
@@ -4,7 +4,7 @@ import { useIntl } from '@openedx/frontend-base';
 import FilterDropdown from '@src/certificates/components/FilterDropdown';
 import { CertificateFilter } from '@src/certificates/types';
 import messages from '@src/certificates/messages';
-import '@src/certificates/CertificatesPage.scss';
+import '../CertificatesPage.scss';
 
 interface CertificatesToolbarProps {
   search: string,


### PR DESCRIPTION
## Description
We had this error on the pipeline
```
#64 79.52 ERROR in ./node_modules/@openedx/frontend-app-instructor-dashboard/dist/certificates/components/CertificatesToolbar.js 8:0-49
#64 79.52 Module not found: Error: Can't resolve '@src/certificates/CertificatesPage.scss' in '/openedx/site/node_modules/@openedx/frontend-app-instructor-dashboard/dist/certificates/components'
```

Absolute path don't work properly on scss files, until we fix this, we will handle scss as relative imports

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`