### PR TITLE
fix: Multiple bug fixes

### DIFF
--- a/src/courseInfo/types.ts
+++ b/src/courseInfo/types.ts
@@ -30,6 +30,7 @@ export interface CourseInfoResponse {
   studioGradingUrl?: string,
   certificatesEnabled?: boolean,
   adminConsoleUrl: string | null,
+  username: string,
 }
 
 interface EnrollmentCounts extends Record<string, number> {

--- a/src/courseTeam/components/EditTeamMemberModal.test.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.test.tsx
@@ -4,7 +4,7 @@ import EditTeamMemberModal from '@src/courseTeam/components/EditTeamMemberModal'
 import { useRoles, useAddTeamMember, useRemoveTeamMember } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember } from '@src/courseTeam/types';
-import { renderWithAlertAndIntl } from '@src/testUtils';
+import { renderWithQueryClient } from '@src/testUtils';
 import { TEAM_MEMBER_ACTION } from '../constants';
 
 // Mocks
@@ -65,28 +65,28 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders modal with correct title', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedTitle)).toBeInTheDocument();
   });
 
   it('renders modal header and body correctly', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedTitle)).toBeInTheDocument();
   });
 
   it('renders edit instructions with username', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const expectedInstructions = messages.editInstructions.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.getByText(expectedInstructions)).toBeInTheDocument();
   });
 
   it('renders current user roles as checkboxes that are initially checked', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     mockUser.roles.forEach((role) => {
       const checkbox = screen.getByRole('checkbox', { name: role.displayName });
@@ -96,13 +96,13 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders add role label', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     expect(screen.getByText(messages.addRole.defaultMessage)).toBeInTheDocument();
   });
 
   it('renders role selection dropdown with filtered roles', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const selectElement = screen.getByRole('combobox');
     expect(selectElement).toBeInTheDocument();
@@ -126,7 +126,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders cancel and save buttons', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: messages.cancelButton.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: messages.saveButton.defaultMessage })).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('EditTeamMemberModal', () => {
 
   it('calls onClose when cancel button is clicked', async () => {
     const mockOnClose = jest.fn();
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const cancelButton = screen.getByRole('button', { name: messages.cancelButton.defaultMessage });
@@ -144,7 +144,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('does not render when isOpen is false', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} isOpen={false} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} isOpen={false} />);
 
     const expectedTitle = messages.editTeamTitle.defaultMessage.replace('{username}', mockUser.username);
     expect(screen.queryByText(expectedTitle)).not.toBeInTheDocument();
@@ -152,7 +152,7 @@ describe('EditTeamMemberModal', () => {
 
   it('renders correctly when no roles data is available', () => {
     (useRoles as jest.Mock).mockReturnValue({ data: [] });
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     // Should only show placeholder in dropdown
     expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
@@ -171,7 +171,7 @@ describe('EditTeamMemberModal', () => {
 
   it('renders correctly when useRoles returns undefined data', () => {
     (useRoles as jest.Mock).mockReturnValue({ data: undefined });
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     // Should only show placeholder in dropdown
     expect(screen.getByText(messages.rolePlaceholder.defaultMessage)).toBeInTheDocument();
@@ -193,7 +193,7 @@ describe('EditTeamMemberModal', () => {
       ...mockUser,
       roles: mockRoles.map(role => ({ role: role.role, displayName: role.displayName })),
     };
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} user={userWithAllRoles} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} user={userWithAllRoles} />);
 
     // Should show all roles as checkboxes that are checked
     userWithAllRoles.roles.forEach((role) => {
@@ -209,7 +209,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('enables select when roles are available for assignment', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     // Should be enabled when there are roles available to assign
     const selectElement = screen.getByRole('combobox');
@@ -217,7 +217,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles checkbox interactions for keeping/removing roles', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -235,7 +235,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles role selection from dropdown', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -247,7 +247,7 @@ describe('EditTeamMemberModal', () => {
 
   it('calls addTeamMember when save is clicked with selected role', async () => {
     const mockOnClose = jest.fn();
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -272,7 +272,7 @@ describe('EditTeamMemberModal', () => {
 
   it('calls removeTeamMember when save is clicked with roles unchecked for removal', async () => {
     const mockOnClose = jest.fn();
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -308,7 +308,7 @@ describe('EditTeamMemberModal', () => {
       if (onSuccess) onSuccess();
     });
 
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -347,7 +347,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('does not call addTeamMember when no role is selected', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
@@ -359,7 +359,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('does not call removeTeamMember when all roles remain checked', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
@@ -372,7 +372,7 @@ describe('EditTeamMemberModal', () => {
 
   it('handles multiple role unchecking for removal', async () => {
     const mockOnClose = jest.fn();
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -399,7 +399,7 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('handles role selection with empty string value', async () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -413,14 +413,14 @@ describe('EditTeamMemberModal', () => {
   });
 
   it('renders correct number of user roles as checkboxes', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(mockUser.roles.length);
   });
 
   it('filters out user current roles from dropdown options', () => {
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     // Should have placeholder + available roles (not user's current roles)
     const expectedAvailableRoles = mockRoles.filter(role =>
@@ -437,7 +437,7 @@ describe('EditTeamMemberModal', () => {
       if (onError) onError();
     });
 
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -457,7 +457,7 @@ describe('EditTeamMemberModal', () => {
       if (onError) onError();
     });
 
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const staffCheckbox = screen.getByRole('checkbox', { name: 'Staff' });
@@ -482,7 +482,7 @@ describe('EditTeamMemberModal', () => {
       if (onError) onError();
     });
 
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} onClose={mockOnClose} />);
 
     const user = userEvent.setup();
     const selectElement = screen.getByRole('combobox');
@@ -505,7 +505,7 @@ describe('EditTeamMemberModal', () => {
       isPending: true
     });
 
-    renderWithAlertAndIntl(<EditTeamMemberModal {...defaultProps} />);
+    renderWithQueryClient(<EditTeamMemberModal {...defaultProps} />);
 
     const saveButton = screen.getByRole('button', { name: messages.saveButton.defaultMessage });
     expect(saveButton).toBeDisabled();

--- a/src/courseTeam/components/EditTeamMemberModal.tsx
+++ b/src/courseTeam/components/EditTeamMemberModal.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { ActionRow, Button, Form, FormControl, FormLabel, ModalDialog } from '@openedx/paragon';
+import { ActionRow, Button, Form, FormControl, FormLabel, ModalDialog, OverlayTrigger, Tooltip } from '@openedx/paragon';
 import { useAddTeamMember, useRemoveTeamMember, useRoles } from '@src/courseTeam/data/apiHook';
 import messages from '@src/courseTeam/messages';
 import { CourseTeamMember, Role } from '@src/courseTeam/types';
 import { useAlert } from '@src/providers/AlertProvider';
 import { TEAM_MEMBER_ACTION } from '../constants';
+import { useCourseInfo } from '@src/data/apiHook';
 
 interface EditTeamMemberModalProps {
   isOpen: boolean,
@@ -23,7 +24,10 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
   const { mutate: removeTeamMember, isPending: isRemoving } = useRemoveTeamMember(courseId);
   const { showModal } = useAlert();
 
-  const { data: { results } = { results: [] } } = useRoles(courseId);
+  const { data: { results } = { results: [] } } = useRoles(courseId, true);
+
+  const { data } = useCourseInfo(courseId);
+  const { username: currentUser } = data || {};
 
   useEffect(() => {
     if (isOpen) {
@@ -111,11 +115,32 @@ const EditTeamMemberModal = ({ isOpen, user, onClose }: EditTeamMemberModalProps
         <Form.CheckboxSet onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleToggleRole(e.target.value)} value={keepRoles} name="keepRoles">
           {
             (user.roles || [])
-              .map((role: Role) => (
-                <Form.Checkbox className="mt-2" key={role.role} value={role.role}>
-                  {role.displayName}
-                </Form.Checkbox>
-              ))
+              .map((role: Role) => {
+                // Disable roles that user is not available to edit based on his current role
+                // Also Admins cannot remove their own Admin role
+                // Discussion Admins cannot remove their own Discussion Admins role, unless they have Admin role as well
+                const isDiscussionAdminWithoutAdminRole = currentUser === user.username && role.role === 'Administrator' && !user.roles.some(r => r.role === 'instructor');
+                const isOwnAdminRole = currentUser === user.username && role.role === 'instructor';
+                const isEditAvailable = results?.some(availableRole => availableRole.role === role.role) && !isOwnAdminRole && !isDiscussionAdminWithoutAdminRole;
+                return (
+                  isEditAvailable ? (
+                    <Form.Checkbox className="mt-2" key={role.role} value={role.role}>
+                      {role.displayName}
+                    </Form.Checkbox>
+                  ) : (
+                    <OverlayTrigger
+                      placement="top"
+                      overlay={
+                        <Tooltip id={`tooltip-${role.role}`} className="info-tooltip">{isOwnAdminRole || isDiscussionAdminWithoutAdminRole ? intl.formatMessage(messages.cannotRemoveOwnRole) : intl.formatMessage(messages.roleNotEditable)}</Tooltip>
+                      }
+                    >
+                      <Form.Checkbox className="mt-2" key={role.role} value={role.role} disabled>
+                        {role.displayName}
+                      </Form.Checkbox>
+                    </OverlayTrigger>
+                  )
+                );
+              })
           }
         </Form.CheckboxSet>
         <FormLabel className="mt-4">{intl.formatMessage(messages.addRole)}</FormLabel>

--- a/src/courseTeam/data/api.ts
+++ b/src/courseTeam/data/api.ts
@@ -32,9 +32,9 @@ export const getTeamMembers = async (
   return camelCaseObject(data);
 };
 
-export const getRoles = async (courseId: string): Promise<Omit<DataList<Role>, 'numPages' | 'count'>> => {
+export const getRoles = async (courseId: string, editableRoles = false): Promise<Omit<DataList<Role>, 'numPages' | 'count'>> => {
   const { data } = await getAuthenticatedHttpClient().get(
-    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team/roles`
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/team/roles${editableRoles ? '?editable=true' : ''}`
   );
   return camelCaseObject(data);
 };

--- a/src/courseTeam/data/apiHook.test.tsx
+++ b/src/courseTeam/data/apiHook.test.tsx
@@ -111,7 +111,7 @@ describe('apiHook', () => {
       });
 
       expect(result.current.data).toEqual(mockRoles);
-      expect(mockGetRoles).toHaveBeenCalledWith('course-v1:org+course+run');
+      expect(mockGetRoles).toHaveBeenCalledWith('course-v1:org+course+run', false);
     });
 
     it('should handle error when fetching roles fails', async () => {

--- a/src/courseTeam/data/apiHook.ts
+++ b/src/courseTeam/data/apiHook.ts
@@ -11,10 +11,10 @@ export const useTeamMembers = (courseId: string, params: CourseTeamMemberQueryPa
   })
 );
 
-export const useRoles = (courseId: string) => (
+export const useRoles = (courseId: string, editableRoles = false) => (
   useQuery({
     queryKey: courseTeamQueryKeys.roles(courseId),
-    queryFn: () => getRoles(courseId),
+    queryFn: () => getRoles(courseId, editableRoles),
     enabled: !!courseId,
   })
 );

--- a/src/courseTeam/data/apiHook.ts
+++ b/src/courseTeam/data/apiHook.ts
@@ -13,7 +13,7 @@ export const useTeamMembers = (courseId: string, params: CourseTeamMemberQueryPa
 
 export const useRoles = (courseId: string, editableRoles = false) => (
   useQuery({
-    queryKey: courseTeamQueryKeys.roles(courseId),
+    queryKey: courseTeamQueryKeys.roles(courseId, editableRoles),
     queryFn: () => getRoles(courseId, editableRoles),
     enabled: !!courseId,
   })

--- a/src/courseTeam/data/queryKeys.ts
+++ b/src/courseTeam/data/queryKeys.ts
@@ -14,5 +14,5 @@ export const courseTeamQueryKeys = {
     params.emailOrUsername || '',
     params.role || ''
   ] as const,
-  roles: (courseId: string) => [...courseTeamQueryKeys.byCourse(courseId), 'roles'] as const,
+  roles: (courseId: string, editableRoles: boolean) => [...courseTeamQueryKeys.byCourse(courseId), 'roles', editableRoles] as const,
 };

--- a/src/courseTeam/messages.ts
+++ b/src/courseTeam/messages.ts
@@ -245,6 +245,16 @@ const messages = defineMessages({
     id: 'instruct.courseTeam.viewStudioRoles',
     defaultMessage: 'View Studio Roles',
     description: 'Button label for viewing course team roles in Studio',
+  },
+  roleNotEditable: {
+    id: 'instruct.courseTeam.roleNotEditable',
+    defaultMessage: 'You do not have permission to change this role.',
+    description: 'Tooltip message displayed when a role cannot be edited by the user',
+  },
+  cannotRemoveOwnRole: {
+    id: 'instruct.courseTeam.cannotRemoveOwnRole',
+    defaultMessage: 'Admins cannot remove their own admin access.',
+    description: 'Tooltip message displayed when a user tries to remove their own admin role',
   }
 });
 

--- a/src/data/apiHook.test.tsx
+++ b/src/data/apiHook.test.tsx
@@ -36,6 +36,7 @@ const mockCourseData = {
   },
   gradebookUrl: 'http://example.com/gradebook',
   adminConsoleUrl: 'http://example.com/admin-console',
+  username: 'testuser',
 };
 
 const createWrapper = () => {

--- a/src/enrollments/components/AddBetaTestersModal.test.tsx
+++ b/src/enrollments/components/AddBetaTestersModal.test.tsx
@@ -176,7 +176,7 @@ describe('AddBetaTestersModal', () => {
 
   it('calls onClose when mutation succeeds with no failures', async () => {
     const mutateWithCallback = (_users: any, callbacks: any) => {
-      callbacks.onSuccess({ results: [{ identifier: 'test@example.com', userDoesNotExist: false }] });
+      callbacks.onSuccess({ results: [{ identifier: 'test@example.com', userDoesNotExist: false, isActive: true }] });
     };
     mutateMock.mockImplementation(mutateWithCallback);
 
@@ -194,12 +194,13 @@ describe('AddBetaTestersModal', () => {
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
-  it('shows alert for failed users and still calls onClose', async () => {
+  it('shows alert for failed users, inactive users, and still calls onClose', async () => {
     const mutateWithCallback = (_users: any, callbacks: any) => {
       callbacks.onSuccess({
         results: [
-          { identifier: 'valid@example.com', userDoesNotExist: false },
-          { identifier: 'invalid@example.com', userDoesNotExist: true }
+          { identifier: 'valid@example.com', userDoesNotExist: false, isActive: true },
+          { identifier: 'invalid@example.com', userDoesNotExist: true, isActive: null },
+          { identifier: 'inactive@example.com', userDoesNotExist: false, isActive: false },
         ]
       });
     };
@@ -210,7 +211,7 @@ describe('AddBetaTestersModal', () => {
       messages.userIdentifierPlaceholder.defaultMessage
     );
     const user = userEvent.setup();
-    await user.type(textarea, 'valid@example.com, invalid@example.com');
+    await user.type(textarea, 'valid@example.com, invalid@example.com, inactive@example.com');
     const saveBtn = screen.getByRole('button', {
       name: messages.saveButton.defaultMessage,
     });
@@ -219,6 +220,11 @@ describe('AddBetaTestersModal', () => {
     expect(mockAddAlert).toHaveBeenCalledWith({
       type: 'danger',
       message: messages.failedBetaTesters.defaultMessage,
+      extraContent: expect.any(Array),
+    });
+    expect(mockAddAlert).toHaveBeenCalledWith({
+      type: 'warning',
+      message: messages.inactiveUsers.defaultMessage,
       extraContent: expect.any(Array),
     });
     expect(defaultProps.onClose).toHaveBeenCalled();

--- a/src/enrollments/components/AddBetaTestersModal.tsx
+++ b/src/enrollments/components/AddBetaTestersModal.tsx
@@ -38,6 +38,7 @@ const AddBetaTestersModal = ({
     addBetaTesters({ identifier, action: 'add', autoEnroll, emailStudents }, {
       onSuccess: (data) => {
         const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
+        const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
         if (failedUsernames.length > 0) {
           addAlert({
             type: 'danger',
@@ -45,6 +46,17 @@ const AddBetaTestersModal = ({
             extraContent: (
               failedUsernames.map((learner: string) => (
                 <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
+              ))
+            )
+          });
+        }
+        if (inactiveUsernames.length > 0) {
+          addAlert({
+            type: 'warning',
+            message: intl.formatMessage(messages.inactiveUsers),
+            extraContent: (
+              inactiveUsernames.map((learner: string) => (
+                <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
               ))
             )
           });

--- a/src/enrollments/data/apiHook.test.tsx
+++ b/src/enrollments/data/apiHook.test.tsx
@@ -344,7 +344,7 @@ describe('enrollments api hooks', () => {
     const courseId = 'course-v1:edX+Test+2023';
 
     it('calls updateEnrollments and succeeds', async () => {
-      mockPostUpdateBetaTesters.mockResolvedValue({ results: [{ identifier: 'student1', userDoesNotExist: false }] });
+      mockPostUpdateBetaTesters.mockResolvedValue({ results: [{ identifier: 'student1', userDoesNotExist: false, isActive: true }] });
 
       const { result } = renderHook(() => useUpdateBetaTesters(courseId), {
         wrapper: createWrapper(),

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -206,6 +206,16 @@ const messages = defineMessages({
     defaultMessage: 'The following usernames and/or email addresses are invalid. All other beta testers have been added.',
     description: 'Message displaying the learners that could not be added as beta testers',
   },
+  inactiveUsers: {
+    id: 'instruct.enrollments.modals.addBetaTesters.inactiveUsers',
+    defaultMessage: 'The following users are inactive. They have been added as beta testers, but may not have access to the course until their accounts are active.',
+    description: 'Message displaying the learners that are inactive when adding beta testers',
+  },
+  inactiveLearner: {
+    id: 'instruct.enrollments.inactiveLearner',
+    defaultMessage: 'Inactive learner: {learner}',
+    description: 'Displayed when a learner is inactive',
+  },
   addBetaTesterError: {
     id: 'instruct.enrollments.modals.addBetaTesters.addBetaTesterError',
     defaultMessage: 'Error adding users as beta testers.',

--- a/src/enrollments/types.ts
+++ b/src/enrollments/types.ts
@@ -39,5 +39,6 @@ export interface UpdateBetaTestersResponse {
   results: {
     identifier: string,
     userDoesNotExist: boolean,
+    isActive: boolean | null,
   }[],
 }

--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -281,13 +281,12 @@ describe('GradingLearnerContent', () => {
   it('disables action buttons when learner or problem is not selected', () => {
     renderWithIntl(<GradingLearnerContent {...defaultProps} />);
 
-    const resetButtons = screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
+    const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
     const rescoreButton = screen.getByRole('button', { name: messages.rescoreSubmissionButtonLabel.defaultMessage });
     const deleteButton = screen.getByRole('button', { name: messages.deleteHistoryButtonLabel.defaultMessage });
     const taskStatusButton = screen.getByRole('button', { name: messages.taskStatusButtonLabel.defaultMessage });
 
-    expect(resetButtons[0]).toBeDisabled();
-    expect(resetButtons[1]).toBeDisabled();
+    expect(resetButton).toBeDisabled();
     expect(rescoreButton).toBeDisabled();
     expect(deleteButton).toBeDisabled();
     expect(taskStatusButton).toBeDisabled();

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -110,7 +110,6 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       description: intl.formatMessage(messages.deleteHistoryDescription),
       customAction: (
         <div className="d-flex flex-column gap-3">
-          <Button disabled={!usernameOrEmail || !blockId} onClick={handleResetAttempts}>{intl.formatMessage(messages.resetAttemptsButtonLabel)}</Button>
           <Button disabled={!usernameOrEmail || !blockId} onClick={handleDeleteHistory}>{intl.formatMessage(messages.deleteHistoryButtonLabel)}</Button>
         </div>
       ),

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClient = new QueryClient();
 
 export const renderWithQueryClient = (ui: React.ReactElement) =>
-  renderWithIntl(
+  renderWithAlertAndIntl(
     <QueryClientProvider client={queryClient}>
       {ui}
     </QueryClientProvider>


### PR DESCRIPTION
## Description
As part of this PR were addressed following fixes:
- Remove duplicated reset attempts button on Grading Tab.
- If a user is inactive and you add it as a beta tester a warning alert should be displayed.
- Add tooltip and don't allow users to edit roles that are not allowed, for example Admins can't remove their own admin role, Discussion Admins can't modify roles different than TA and Discussion roles.

## Supporting information
Closes #187 
Closes #161 

## Testing instructions


## Screenshots
- Remove duplicated reset attempts button on Grading Tab.
Before
<img width="1376" height="577" alt="Screenshot 2026-04-28 at 9 25 52 a m" src="https://github.com/user-attachments/assets/467647ad-38e8-4662-8cd3-55d94d0f0c9b" />

After
<img width="1382" height="649" alt="Screenshot 2026-04-28 at 9 26 35 a m" src="https://github.com/user-attachments/assets/cb18ae5b-6a24-42d7-836d-b0e98118e10f" />

- Add tooltip and don't allow users to edit roles that are not allowed, for example Admins can't remove their own admin role, Discussion Admins can't modify roles different than TA and Discussion roles.
<img width="507" height="371" alt="Screenshot 2026-04-28 at 9 32 13 a m" src="https://github.com/user-attachments/assets/18b52e39-5050-422a-bb6b-85e2d275bf65" />

<img width="655" height="394" alt="Screenshot 2026-04-28 at 9 32 23 a m" src="https://github.com/user-attachments/assets/cf1eea17-edde-4c62-967a-e760917b07cb" />

<img width="593" height="395" alt="Screenshot 2026-04-28 at 9 32 31 a m" src="https://github.com/user-attachments/assets/c24d9148-e923-40d6-a694-17c041c67b7b" />



## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
