### PR TITLE
fix: set document title via Helmet on the dashboard route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "dependencies": {
         "@edx/openedx-atlas": "^0.7.0",
         "codemirror": "^6.0.2",
-        "lodash": "^4.17.23"
+        "lodash": "^4.17.23",
+        "react-helmet": "^6.1.0"
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.5.0",
@@ -15372,7 +15373,6 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16075,7 +16075,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17791,7 +17790,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17823,8 +17821,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -18483,8 +18480,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-focus-lock": {
       "version": "2.13.7",
@@ -18535,6 +18531,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/react-imask": {
@@ -18827,6 +18838,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "dependencies": {
     "@edx/openedx-atlas": "^0.7.0",
     "codemirror": "^6.0.2",
-    "lodash": "^4.17.23"
+    "lodash": "^4.17.23",
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -1,0 +1,36 @@
+import { waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderWithIntl } from '@src/testUtils';
+import Main from './Main';
+
+jest.mock('./pageWrapper/PageWrapper', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('Main', () => {
+  const renderComponent = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Main />
+        </BrowserRouter>
+      </QueryClientProvider>
+    );
+  };
+
+  it('sets the document title from the page-title message and site name', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(document.title).toBe('Instructor Dashboard | Instructor Test Site');
+    });
+  });
+});

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,21 +1,33 @@
-import { CurrentAppProvider } from '@openedx/frontend-base';
+import { CurrentAppProvider, getSiteConfig, useIntl } from '@openedx/frontend-base';
+import { Helmet } from 'react-helmet';
 import { Outlet } from 'react-router-dom';
 import { AlertProvider } from './providers/AlertProvider';
 import { appId } from './constants';
+import messages from './messages';
 import PageWrapper from './pageWrapper/PageWrapper';
 
 import './style.scss';
 
-const Main = () => (
-  <CurrentAppProvider appId={appId}>
-    <AlertProvider>
-      <main className="d-flex flex-column flex-grow-1">
-        <PageWrapper>
-          <Outlet />
-        </PageWrapper>
-      </main>
-    </AlertProvider>
-  </CurrentAppProvider>
-);
+const Main = () => {
+  const { formatMessage } = useIntl();
+  return (
+    <CurrentAppProvider appId={appId}>
+      <Helmet>
+        <title>
+          {formatMessage(messages['instructor-dashboard.page.title'], {
+            siteName: getSiteConfig().siteName,
+          })}
+        </title>
+      </Helmet>
+      <AlertProvider>
+        <main className="d-flex flex-column flex-grow-1">
+          <PageWrapper>
+            <Outlet />
+          </PageWrapper>
+        </main>
+      </AlertProvider>
+    </CurrentAppProvider>
+  );
+};
 
 export default Main;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from '@openedx/frontend-base';
+
+const messages = defineMessages({
+  'instructor-dashboard.page.title': {
+    id: 'instructor-dashboard.page.title',
+    defaultMessage: 'Instructor Dashboard | {siteName}',
+    description: 'Document title for the instructor dashboard page',
+  },
+});
+
+export default messages;


### PR DESCRIPTION
### Description

Refs openedx/frontend-base#250.

Adopts the per-page document title pattern set out in [frontend-base ADR 0015](https://github.com/openedx/frontend-base/blob/main/docs/decisions/0015-page-titles-via-helmet.rst).  Because all frontend-base apps share a single `index.html`, the document title only changes if a page sets it.  Authn does, but the instructor dashboard didn't, so after navigating in from another app the browser tab kept reading the previous page's title.

The dashboard's `Main` route component now renders a `<Helmet>` block that sets `<title>` from a new localized message (`instructor-dashboard.page.title`, default `Instructor Dashboard | {siteName}`), with `siteName` pulled from `getSiteConfig()` and passed as an i18n parameter so localizers can re-order the segments.  `react-helmet` is added to the app's runtime dependencies.

### LLM usage notice

Built with assistance from Claude.