### PR TITLE
fix: specify learner, warning message on grant beta tester role, ordering in special exams

### DIFF
--- a/src/components/SpecifyLearnerField.test.tsx
+++ b/src/components/SpecifyLearnerField.test.tsx
@@ -214,7 +214,7 @@ describe('SpecifyLearnerField', () => {
       (useCourseInfo as jest.Mock).mockReturnValue({ data: { permissions: { admin: true, dataResearcher: false } } });
       (useLearner as jest.Mock).mockReturnValue({
         data: {},
-        refetch: jest.fn().mockResolvedValue({ data: {} }),
+        refetch: jest.fn().mockResolvedValue({ data: {}, error: { isAxiosError: true, response: { status: 404 } } }),
         error: { isAxiosError: true, response: { status: 404 } },
       });
     });

--- a/src/components/SpecifyLearnerField.tsx
+++ b/src/components/SpecifyLearnerField.tsx
@@ -18,6 +18,24 @@ interface SpecifyLearnerFieldRef {
   reset: () => void,
 }
 
+type ErrorState = 'not_enrolled' | 'not_found' | 'generic_error' | null;
+
+const errorMessages = {
+  not_found: messages.learnerNotFound,
+  generic_error: messages.learnerGenericError,
+  not_enrolled: messages.learnerNotEnrolled,
+};
+
+const getErrorState = (error: Error | null, data?: SelectedLearner): ErrorState => {
+  const isNotFoundError = isAxiosError(error)
+    && (error.response?.status === 404 || error.response?.status === 400);
+
+  if (isNotFoundError) return 'not_found';
+  if (data && !data.isEnrolled) return 'not_enrolled';
+  if (error && !isNotFoundError) return 'generic_error';
+  return null;
+};
+
 const initialLearnerState = {
   username: '',
   fullName: '',
@@ -30,18 +48,20 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
   const { courseId = '' } = useParams<{ courseId: string }>();
   const [identifier, setIdentifier] = useState('');
   const [showLearner, enableShowLearner, disableShowLearner] = useToggle(!!learner);
+  const [errorState, setErrorState] = useState<ErrorState>(null);
   const { data: courseInfo } = useCourseInfo(courseId);
   const permissions = courseInfo?.permissions || { admin: false, dataResearcher: false };
   const { inputValue, handleChange, resetFilter } = useDebouncedFilter({
     filterValue: identifier,
     setFilter: setIdentifier,
   });
-  const { data, refetch, error } = useLearner(courseId, inputValue);
+  const { data, refetch } = useLearner(courseId, inputValue);
 
   const resetState = () => {
     resetFilter();
     onClickSelect('');
     disableShowLearner();
+    setErrorState(null);
   };
 
   useImperativeHandle(ref, () => ({
@@ -52,6 +72,10 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     handleChange(event.target.value);
+
+    if (errorState) {
+      setErrorState(null);
+    }
 
     if (showLearner) {
       disableShowLearner();
@@ -64,6 +88,8 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
         // Need to pass empty value if learner is not valid to clear out any previously selected learner
         // We could have other conditions/fields depending on valid learner
         const formValue = !result.error && result.data?.isEnrolled ? inputValue : '';
+
+        setErrorState(getErrorState(result.error, result?.data));
         onClickSelect(formValue);
         enableShowLearner();
       });
@@ -102,20 +128,11 @@ const SpecifyLearnerField = forwardRef<SpecifyLearnerFieldRef, SpecifyLearnerFie
           <Button onClick={handleClickSelect} disabled={!inputValue}>{intl.formatMessage(messages.select)}</Button>
         )}
       </div>
-      {showLearner && error
-      && isAxiosError(error)
-      && error.response?.status === 404 && (
+      {showLearner && errorState && (
         <p className="text-danger-500 mb-0 x-small mt-2">
-          {intl.formatMessage(messages.learnerNotFound, { identifier })}
+          {intl.formatMessage(errorMessages[errorState], { identifier: inputValue })}
         </p>
       )}
-      {
-        showLearner && !error && !selectedLearner?.isEnrolled && (
-          <p className="text-danger-500 mb-0 x-small mt-2">
-            {intl.formatMessage(messages.learnerNotEnrolled, { identifier })}
-          </p>
-        )
-      }
     </FormGroup>
   );
 });

--- a/src/components/SpecifyProblemField.tsx
+++ b/src/components/SpecifyProblemField.tsx
@@ -127,7 +127,7 @@ const SpecifyProblemField = forwardRef<SpecifyProblemFieldRef, SpecifyProblemFie
       </div>
       {showSelectedLocation && error
       && isAxiosError(error)
-      && (error.response?.status === 400) && (
+      && ((error.response?.status === 400) || (error.response?.status === 404)) && (
         <p className="text-danger-500 mb-0 x-small mt-2">
           {intl.formatMessage(messages.problemNotFound, { identifier: inputValue })}
         </p>

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -156,6 +156,11 @@ const messages = defineMessages({
     defaultMessage: 'Selected Learner:',
     description: 'Label for specify learner field when a learner has been selected',
   },
+  learnerGenericError: {
+    id: 'instruct.specifyLearner.learnerGenericError',
+    defaultMessage: 'An error occurred while looking up {identifier}. Please try again.',
+    description: 'Generic error message displayed when there is an error looking up a learner based on the provided identifier (email or username)',
+  }
 });
 
 export default messages;

--- a/src/enrollments/components/UpdateBetaTesterModal.test.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.test.tsx
@@ -181,8 +181,8 @@ describe('UpdateBetaTesterModal', () => {
     it('shows alert with failed usernames when some users fail (remove action)', async () => {
       const mockSuccessData = {
         results: [
-          { identifier: 'failed-user', userDoesNotExist: true },
-          { identifier: 'jane.doe', userDoesNotExist: false },
+          { identifier: 'failed-user', userDoesNotExist: true, isActive: true },
+          { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
 
@@ -206,7 +206,7 @@ describe('UpdateBetaTesterModal', () => {
     it('shows alert with failed usernames when some users fail (add action)', async () => {
       const mockSuccessData = {
         results: [
-          { identifier: 'failed-user', userDoesNotExist: true },
+          { identifier: 'failed-user', userDoesNotExist: true, isActive: null },
         ]
       };
 
@@ -231,10 +231,39 @@ describe('UpdateBetaTesterModal', () => {
       });
     });
 
+    it('shows alert with inactive usernames when some users are inactive', async () => {
+      const mockSuccessData = {
+        results: [
+          { identifier: 'inactive-user', userDoesNotExist: false, isActive: false },
+          { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
+        ]
+      };
+
+      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
+        callbacks.onSuccess(mockSuccessData);
+      };
+      mutateMock.mockImplementation(mutateWithSuccess);
+
+      const nonBetaTesterProps = {
+        ...defaultProps,
+        learner: learnerNonBetaTester,
+      };
+
+      renderWithAlertAndIntl(
+        <UpdateBetaTesterModal {...nonBetaTesterProps} />
+      );
+
+      expect(mockAddAlert).toHaveBeenCalledWith({
+        type: 'warning',
+        message: messages.inactiveUsers.defaultMessage,
+        extraContent: expect.any(Array),
+      });
+    });
+
     it('does not show alert when all users succeed', async () => {
       const mockSuccessData = {
         results: [
-          { identifier: 'jane.doe', userDoesNotExist: false },
+          { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
 

--- a/src/enrollments/components/UpdateBetaTesterModal.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.tsx
@@ -26,6 +26,7 @@ const UpdateBetaTesterModal = ({ learner, isOpen, onClose }: UpdateBetaTesterMod
     }, {
       onSuccess: (data) => {
         const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
+        const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
         if (failedUsernames.length > 0) {
           addAlert({
             type: 'danger',
@@ -33,6 +34,17 @@ const UpdateBetaTesterModal = ({ learner, isOpen, onClose }: UpdateBetaTesterMod
             extraContent: (
               failedUsernames.map((learner: string) => (
                 <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
+              ))
+            )
+          });
+        }
+        if (inactiveUsernames.length > 0) {
+          addAlert({
+            type: 'warning',
+            message: intl.formatMessage(messages.inactiveUsers),
+            extraContent: (
+              inactiveUsernames.map((learner: string) => (
+                <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
               ))
             )
           });

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -165,6 +165,9 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
 
   const handleLearnerChange = (usernameOrEmail: string): void => {
     setUsernameOrEmail(usernameOrEmail);
+    // Reset problem field when learner changes due to progress and attempts change for every learner
+    setBlockId('');
+    problemFieldRef.current?.reset();
   };
 
   return (

--- a/src/slots.tsx
+++ b/src/slots.tsx
@@ -1,9 +1,15 @@
-import { helpButtonSlotOperation, SlotOperation } from '@openedx/frontend-base';
-
-import { appId, instructorDashboardRole } from './constants';
+import { helpButtonSlotOperation, SlotOperation, WidgetOperationTypes } from '@openedx/frontend-base';
+import CourseInfoSlot from '@src/slots/CourseInfoSlot/CourseInfoSlot';
+import { appId, instructorDashboardRole } from '@src/constants';
 
 const slots: SlotOperation[] = [
   helpButtonSlotOperation({ appId, role: instructorDashboardRole }),
+  {
+    slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+    id: 'org.openedx.frontend.widget.slotShowcase.headerLink',
+    op: WidgetOperationTypes.APPEND,
+    element: <CourseInfoSlot />,
+  },
 ];
 
 export default slots;

--- a/src/slots/CourseInfoSlot/CourseInfoSlot.test.tsx
+++ b/src/slots/CourseInfoSlot/CourseInfoSlot.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import CourseInfoSlot from '@src/slots/CourseInfoSlot/CourseInfoSlot';
+import { renderWithQueryClient } from '@src/testUtils';
+
+jest.mock('@src/data/apiHook', () => ({
+  useCourseInfo: () => ({
+    data: {
+      displayName: 'My Test Course',
+      org: 'edX',
+      courseNumber: '40-800',
+    },
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({
+    courseId: 'course-v1:edX+Test+2023',
+  }),
+}));
+
+describe('CourseInfoSlot', () => {
+  it('renders org and course name', () => {
+    renderWithQueryClient(<CourseInfoSlot />);
+    expect(screen.getByText('My Test Course')).toBeInTheDocument();
+    expect(screen.getByText('edX 40-800')).toBeInTheDocument();
+  });
+});

--- a/src/slots/CourseInfoSlot/CourseInfoSlot.tsx
+++ b/src/slots/CourseInfoSlot/CourseInfoSlot.tsx
@@ -9,7 +9,7 @@ const CourseInfoSlot = () => {
     return null;
   }
 
-  const { org = '', courseNumber, displayName = '' } = data;
+  const { org = '', courseNumber = '', displayName = '' } = data;
 
   return (
     <div style={{ minWidth: 0, lineHeight: '1' }}>

--- a/src/slots/CourseInfoSlot/CourseInfoSlot.tsx
+++ b/src/slots/CourseInfoSlot/CourseInfoSlot.tsx
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom';
+import { useCourseInfo } from '@src/data/apiHook';
+
+const CourseInfoSlot = () => {
+  const { courseId = '' } = useParams();
+  const { data } = useCourseInfo(courseId);
+
+  if (!data) {
+    return null;
+  }
+
+  const { org = '', courseNumber, displayName = '' } = data;
+
+  return (
+    <div style={{ minWidth: 0, lineHeight: '1' }}>
+      <span className="d-block small m-0">{org} {courseNumber}</span>
+      <span className="d-block m-0 font-weight-bold course-title">{displayName}</span>
+    </div>
+  );
+};
+
+export default CourseInfoSlot;

--- a/src/specialExams/components/AllowancesList.tsx
+++ b/src/specialExams/components/AllowancesList.tsx
@@ -19,7 +19,7 @@ interface AllowanceList {
 const AllowancesList = ({ onClickAdd, onEdit, onDelete }: AllowanceList) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '' });
+  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '', ordering: '' });
   const { data = { results: [], count: 0, numPages: 1 }, isLoading = false } = useAllowances(courseId, {
     pageSize: ALLOWANCES_PAGE_SIZE,
     ...filters,
@@ -91,8 +91,10 @@ const AllowancesList = ({ onClickAdd, onEdit, onDelete }: AllowanceList) => {
   const handleFetchData = (data: DataTableFetchDataProps) => {
     const emailOrUsernameFilter = data.filters?.find((f) => f.id === 'user.username');
     const newEmailOrUsername = emailOrUsernameFilter ? emailOrUsernameFilter.value : '';
-    if (filters.emailOrUsername !== newEmailOrUsername) {
-      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: newEmailOrUsername, page: 0 }));
+    const newOrdering = data.sortBy?.[0] ? `${data.sortBy[0].desc ? '-' : ''}${data.sortBy[0].id}` : '';
+    const filtersChanged = newEmailOrUsername !== filters.emailOrUsername || newOrdering !== filters.ordering;
+    if (filtersChanged) {
+      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: newEmailOrUsername, ordering: newOrdering, page: 0 }));
       return;
     }
     if (data.pageIndex !== filters.page) {
@@ -111,6 +113,9 @@ const AllowancesList = ({ onClickAdd, onEdit, onDelete }: AllowanceList) => {
         pageSize: ALLOWANCES_PAGE_SIZE,
         filters: [
           { id: 'emailOrUsername', value: filters.emailOrUsername }
+        ],
+        sortBy: [
+          { id: filters.ordering.replace(/^-/, ''), desc: filters.ordering.startsWith('-') }
         ]
       }}
       fetchData={handleFetchData}

--- a/src/specialExams/components/AttemptsList.tsx
+++ b/src/specialExams/components/AttemptsList.tsx
@@ -12,7 +12,7 @@ export const ATTEMPTS_PAGE_SIZE = 25;
 const AttemptsList = () => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
-  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '' });
+  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '', ordering: '' });
   const { data = { results: [], count: 0, numPages: 0 }, isLoading = false } = useAttempts(courseId, {
     ...filters,
     pageSize: ATTEMPTS_PAGE_SIZE
@@ -31,8 +31,10 @@ const AttemptsList = () => {
   const handleFetchData = (data: DataTableFetchDataProps) => {
     const emailOrUsernameFilter = data.filters?.find((f) => f.id === 'user.username');
     const newEmailOrUsername = emailOrUsernameFilter ? emailOrUsernameFilter.value : '';
-    if (filters.emailOrUsername !== newEmailOrUsername) {
-      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: newEmailOrUsername, page: 0 }));
+    const newOrdering = data.sortBy?.[0] ? `${data.sortBy[0].desc ? '-' : ''}${data.sortBy[0].id}` : '';
+    const filtersChanged = newEmailOrUsername !== filters.emailOrUsername || newOrdering !== filters.ordering;
+    if (filtersChanged) {
+      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: newEmailOrUsername, ordering: newOrdering, page: 0 }));
       return;
     }
     if (data.pageIndex !== filters.page) {
@@ -50,6 +52,9 @@ const AttemptsList = () => {
         pageSize: ATTEMPTS_PAGE_SIZE,
         filters: [
           { id: 'emailOrUsername', value: filters.emailOrUsername }
+        ],
+        sortBy: [
+          { id: filters.ordering.replace(/^-/, ''), desc: filters.ordering.startsWith('-') }
         ]
       }}
       fetchData={handleFetchData}

--- a/src/specialExams/components/EditAllowanceModal.tsx
+++ b/src/specialExams/components/EditAllowanceModal.tsx
@@ -81,7 +81,7 @@ const EditAllowanceModal = ({ isOpen, onClose, allowance }: EditAllowanceModalPr
           </Form.Group>
           <Form.Group controlId="select-exam-type">
             <Form.Label className="text-primary-500 x-small">{intl.formatMessage(messages.selectExamType)}:</Form.Label>
-            <Form.Control as="select" disabled>
+            <Form.Control as="select" disabled controlClassName="text-capitalize">
               <option value="">{allowance.proctoredExam.examType}</option>
             </Form.Control>
           </Form.Group>

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -103,7 +103,7 @@ describe('specialExams api', () => {
       ],
     };
 
-    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '' };
+    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '', ordering: '' };
 
     beforeEach(() => {
       mockHttpClient.get.mockResolvedValue({ data: mockAttemptsData });
@@ -125,7 +125,7 @@ describe('specialExams api', () => {
 
     it('handles search parameter correctly', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const paramsWithSearch: AttemptsParams = { page: 0, pageSize: 10, emailOrUsername: 'student1' };
+      const paramsWithSearch: AttemptsParams = { page: 0, pageSize: 10, emailOrUsername: 'student1', ordering: '' };
 
       await getAttempts(courseId, paramsWithSearch);
 
@@ -136,7 +136,7 @@ describe('specialExams api', () => {
 
     it('handles different page and pageSize parameters', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const customParams: AttemptsParams = { page: 5, pageSize: 50, emailOrUsername: '' };
+      const customParams: AttemptsParams = { page: 5, pageSize: 50, emailOrUsername: '', ordering: '' };
 
       await getAttempts(courseId, customParams);
 
@@ -147,7 +147,7 @@ describe('specialExams api', () => {
 
     it('handles empty emailOrUsername parameter', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const paramsWithEmptySearch: AttemptsParams = { page: 2, pageSize: 25, emailOrUsername: '' };
+      const paramsWithEmptySearch: AttemptsParams = { page: 2, pageSize: 25, emailOrUsername: '', ordering: '' };
 
       await getAttempts(courseId, paramsWithEmptySearch);
 
@@ -168,7 +168,7 @@ describe('specialExams api', () => {
 
     it('handles special characters in courseId and search', async () => {
       const courseId = 'course-v1:edX+Special%20Course+2023';
-      const paramsWithSpecialChars: AttemptsParams = { page: 0, pageSize: 20, emailOrUsername: 'user@example.com' };
+      const paramsWithSpecialChars: AttemptsParams = { page: 0, pageSize: 20, emailOrUsername: 'user@example.com', ordering: '' };
 
       await getAttempts(courseId, paramsWithSpecialChars);
 
@@ -179,7 +179,7 @@ describe('specialExams api', () => {
   });
 
   describe('getAllowances', () => {
-    const params: AttemptsParams = { page: 1, pageSize: 25, emailOrUsername: '' };
+    const params: AttemptsParams = { page: 1, pageSize: 25, emailOrUsername: '', ordering: '' };
 
     it('makes correct API call and returns camelCase data', async () => {
       const courseId = 'course-v1:edX+Test+2023';
@@ -220,7 +220,7 @@ describe('specialExams api', () => {
 
     it('handles search parameter correctly', async () => {
       const courseId = 'course-v1:edX+Test+2023';
-      const paramsWithSearch: AttemptsParams = { page: 0, pageSize: 20, emailOrUsername: 'john@example.com' };
+      const paramsWithSearch: AttemptsParams = { page: 0, pageSize: 20, emailOrUsername: 'john@example.com', ordering: '' };
       const mockResponseData = { count: 0, num_pages: 0, results: [] };
 
       mockHttpClient.get.mockResolvedValue({ data: mockResponseData });

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -176,6 +176,38 @@ describe('specialExams api', () => {
         'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Special%20Course+2023/special_exams/attempts?page=1&page_size=20&search=user%40example.com'
       );
     });
+
+    it('handles ordering parameter correctly', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const paramsWithOrdering: AttemptsParams = {
+        page: 0,
+        pageSize: 20,
+        emailOrUsername: '',
+        ordering: '-examType'
+      };
+
+      await getAttempts(courseId, paramsWithOrdering);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=1&page_size=20&ordering=-exam_type'
+      );
+    });
+
+    it('handles complex ordering parameter with multiple parts', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const paramsWithComplexOrdering: AttemptsParams = {
+        page: 1,
+        pageSize: 10,
+        emailOrUsername: 'test@example.com',
+        ordering: 'proctoringExam.examName'
+      };
+
+      await getAttempts(courseId, paramsWithComplexOrdering);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/attempts?page=2&page_size=10&search=test%40example.com&ordering=proctoring_exam.exam_name'
+      );
+    });
   });
 
   describe('getAllowances', () => {

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -1,4 +1,5 @@
 import { getAuthenticatedHttpClient, camelCaseObject, snakeCaseObject } from '@openedx/frontend-base';
+import { snakeCase } from 'lodash';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
 import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, SpecialExam } from '../types';
@@ -11,6 +12,11 @@ const getQueryParams = (params: AttemptsParams) => {
 
   if (params.emailOrUsername) {
     queryParams.append('search', params.emailOrUsername);
+  }
+
+  if (params.ordering) {
+    const orderingParam = params.ordering.split('.').map((part) => snakeCase(part)).join('.');
+    queryParams.append('ordering', orderingParam);
   }
 
   return queryParams;

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -15,8 +15,11 @@ const getQueryParams = (params: AttemptsParams) => {
   }
 
   if (params.ordering) {
+    const hasNegativePrefix = params.ordering.startsWith('-');
+
     const orderingParam = params.ordering.split('.').map((part) => snakeCase(part)).join('.');
-    queryParams.append('ordering', orderingParam);
+
+    queryParams.append('ordering', `${hasNegativePrefix ? '-' : ''}${orderingParam}`);
   }
 
   return queryParams;

--- a/src/specialExams/data/apiHook.test.tsx
+++ b/src/specialExams/data/apiHook.test.tsx
@@ -106,7 +106,7 @@ describe('specialExams api hooks', () => {
 
   describe('useAttempts', () => {
     const courseId = 'course-v1:edX+Test+2023';
-    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '' };
+    const params: AttemptsParams = { page: 1, pageSize: 20, emailOrUsername: '', ordering: '' };
 
     it('fetches attempts successfully', async () => {
       mockGetAttempts.mockResolvedValue(mockAttemptsData);
@@ -144,7 +144,7 @@ describe('specialExams api hooks', () => {
     });
 
     it('handles different params parameters', async () => {
-      const customParams: AttemptsParams = { page: 3, pageSize: 50, emailOrUsername: 'student1' };
+      const customParams: AttemptsParams = { page: 3, pageSize: 50, emailOrUsername: 'student1', ordering: '' };
       mockGetAttempts.mockResolvedValue(mockAttemptsData);
 
       const { result } = renderHook(() => useAttempts(courseId, customParams), {
@@ -203,7 +203,7 @@ describe('specialExams api hooks', () => {
       expect(mockGetAttempts).toHaveBeenCalledWith(courseId, params);
 
       // Change params
-      const newParams: AttemptsParams = { page: 2, pageSize: 10, emailOrUsername: 'student2' };
+      const newParams: AttemptsParams = { page: 2, pageSize: 10, emailOrUsername: 'student2', ordering: '' };
       rerender({ params: newParams });
 
       await waitFor(() => {
@@ -245,7 +245,7 @@ describe('specialExams api hooks', () => {
 
   describe('useAllowances', () => {
     const courseId = 'course-v1:edX+Test+2023';
-    const params: AttemptsParams = { page: 0, pageSize: 25, emailOrUsername: '' };
+    const params: AttemptsParams = { page: 0, pageSize: 25, emailOrUsername: '', ordering: '' };
 
     it('fetches allowances successfully', async () => {
       mockGetAllowances.mockResolvedValue(mockAllowancesData);

--- a/src/specialExams/data/queryKeys.ts
+++ b/src/specialExams/data/queryKeys.ts
@@ -4,7 +4,7 @@ import { AttemptsParams } from '../types';
 export const specialExamsQueryKeys = {
   all: [appId, 'specialExams'] as const,
   byCourse: (courseId: string) => [...specialExamsQueryKeys.all, courseId] as const,
-  attempts: (courseId: string, params: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'attempts', params.page, params.emailOrUsername] as const,
-  allowances: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'allowances', params?.page || 1, params?.emailOrUsername || ''] as const,
+  attempts: (courseId: string, params: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'attempts', params.page, params.emailOrUsername, params.ordering] as const,
+  allowances: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'allowances', params?.page || 1, params?.emailOrUsername || '', params?.ordering || ''] as const,
   specialExams: (courseId: string, examType: string) => [...specialExamsQueryKeys.byCourse(courseId), 'specialExams', examType] as const,
 };

--- a/src/specialExams/types.ts
+++ b/src/specialExams/types.ts
@@ -16,6 +16,7 @@ export interface Attempt {
 
 export interface AttemptsParams extends PaginationParams {
   emailOrUsername: string,
+  ordering: string,
 }
 
 export interface Allowance {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export interface PendingTask {
 export interface DataTableFetchDataProps {
   filters: { id: string, value: string }[],
   pageIndex: number,
+  sortBy: { id: string, desc: boolean }[],
 }
 
 export interface Learner {


### PR DESCRIPTION
## Description
As part of this PR we include the following fixes:
- Specify Learner error message was just appearing for some secs and was removed
- Added Course org, name and number on the header as a slot
- Fix ordering in tables for special exams
- Warning message for beta testers was missing when granted from actions button

## Screenshots
<img width="1412" height="249" alt="Screenshot 2026-04-29 at 11 38 44 p m" src="https://github.com/user-attachments/assets/f039e9cf-7cc6-4ed3-ad11-6cb20ebc5bf6" />

<img width="1532" height="270" alt="Screenshot 2026-04-29 at 11 37 41 p m" src="https://github.com/user-attachments/assets/669c411a-448a-4fea-8e50-b824b90d764b" />

<img width="1414" height="413" alt="Screenshot 2026-04-29 at 11 38 04 p m" src="https://github.com/user-attachments/assets/388fc54f-bc02-4582-be8e-9bd8b0b9d7a0" />

<img width="1460" height="580" alt="Screenshot 2026-04-29 at 9 14 36 p m" src="https://github.com/user-attachments/assets/25c39513-fe83-408e-aace-e2f8011c84c4" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
