### PR TITLE
feat: opt into the course bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,9 +4917,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.42.tgz",
-      "integrity": "sha512-3qpoazcIqYc9xqujG/MBs4dNpWGOcGC26+UdTcr5Q2+S08NfEyqg0kUOJTVKh6JjW1F3/RuUGDvrxKtmOWgs2g==",
+      "version": "1.0.0-alpha.46",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.46.tgz",
+      "integrity": "sha512-NxmgyTGirG+FlEbp3FM4cdwOMqjMEL465egHrNUjk82+hxxwnGBe3tpHzMEjsbRVQMIEay0+PziLi9Si6nbBvg==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {

--- a/site.config.ci.tsx
+++ b/site.config.ci.tsx
@@ -9,6 +9,7 @@ const siteConfig: SiteConfig = {
   siteName: 'Instructor CI',
   baseUrl: 'http://apps.local.openedx.io',
   lmsBaseUrl: 'http://local.openedx.io',
+  cmsBaseUrl: 'http://studio.local.openedx.io',
   loginUrl: 'http://local.openedx.io/login',
   logoutUrl: 'http://local.openedx.io/logout',
 

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -9,6 +9,7 @@ const siteConfig: SiteConfig = {
   siteName: 'Instructor Dev',
   baseUrl: 'http://apps.local.openedx.io:8080',
   lmsBaseUrl: 'http://local.openedx.io:8000',
+  cmsBaseUrl: 'http://studio.local.openedx.io:8001',
   loginUrl: 'http://local.openedx.io:8000/login',
   logoutUrl: 'http://local.openedx.io:8000/logout',
 
@@ -21,15 +22,15 @@ const siteConfig: SiteConfig = {
   ],
   externalRoutes: [
     {
-      role: 'profile',
+      role: 'org.openedx.frontend.role.profile',
       url: 'http://apps.local.openedx.io:1995/profile/'
     },
     {
-      role: 'account',
+      role: 'org.openedx.frontend.role.account',
       url: 'http://apps.local.openedx.io:1997/account/'
     },
     {
-      role: 'logout',
+      role: 'org.openedx.frontend.role.logout',
       url: 'http://local.openedx.io:8000/logout'
     },
   ],

--- a/site.config.test.tsx
+++ b/site.config.test.tsx
@@ -5,6 +5,7 @@ const siteConfig: SiteConfig = {
   siteName: 'Instructor Test Site',
   baseUrl: 'http://localhost:8080',
   lmsBaseUrl: 'http://localhost:8000',
+  cmsBaseUrl: 'http://localhost:8001',
   loginUrl: 'http://localhost:8000/login',
   logoutUrl: 'http://localhost:8000/logout',
 

--- a/src/provides.ts
+++ b/src/provides.ts
@@ -1,8 +1,9 @@
-import { providesCourseNavigationRolesId } from '@openedx/frontend-base';
+import { providesCourseBarMasqueradeRolesId, providesCourseBarRolesId } from '@openedx/frontend-base';
 import { instructorDashboardRole } from './constants';
 
 const provides = {
-  [providesCourseNavigationRolesId]: instructorDashboardRole
+  [providesCourseBarRolesId]: instructorDashboardRole,
+  [providesCourseBarMasqueradeRolesId]: instructorDashboardRole,
 };
 
 export default provides;


### PR DESCRIPTION
### Description

Declares the instructor-dashboard's route role under the `providesCourseBarRolesId` and `providesCourseBarMasqueradeRolesId` provides ID so the shell's course bar (including both navigation and masquerade) renders on this app's routes.

Depends on the course bar landing in `frontend-base` (openedx/frontend-base#260).

### LLM usage notice

Built with assistance from Claude.