### PR TITLE
fix: grading multiple fixes

### DIFF
--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -18,7 +18,13 @@ const siteConfig: SiteConfig = {
     shellApp,
     headerApp,
     footerApp,
-    instructorDashboardApp
+    {
+      ...instructorDashboardApp,
+      config: {
+        ...instructorDashboardApp.config,
+        SUPPORT_URL: 'https://docs.openedx.org/en/latest/educators/index.html',
+      }
+    }
   ],
   externalRoutes: [
     {

--- a/src/enrollments/components/UpdateBetaTesterModal.test.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.test.tsx
@@ -1,9 +1,8 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UpdateBetaTesterModal from '@src/enrollments/components/UpdateBetaTesterModal';
 import { useUpdateBetaTesters } from '@src/enrollments/data/apiHook';
 import messages from '@src/enrollments/messages';
-import { UpdateBetaTestersParams } from '@src/enrollments/types';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 
 const learnerBetaTester = {
@@ -52,9 +51,10 @@ describe('UpdateBetaTesterModal', () => {
   const mutateMock = jest.fn();
 
   beforeEach(() => {
+    mutateMock.mockResolvedValue({ results: [] });
     (useUpdateBetaTesters as jest.Mock).mockReturnValue({
-      mutate: mutateMock,
-      isPending: false
+      mutateAsync: mutateMock,
+      isPending: false,
     });
     mockShowModal.mockClear();
     mockAddAlert.mockClear();
@@ -99,24 +99,25 @@ describe('UpdateBetaTesterModal', () => {
       expect(mutateMock).toHaveBeenCalledWith({
         identifier: [learnerBetaTester.username],
         action: 'remove',
-      }, {
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
       });
     });
 
     it('calls onClose when Revoke button is clicked', async () => {
+      mutateMock.mockResolvedValue({ results: [] });
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
-      expect(defaultProps.onClose).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
     });
 
     it('disables revoke button when pending', () => {
       (useUpdateBetaTesters as jest.Mock).mockReturnValue({
-        mutate: mutateMock,
-        isPending: true
+        mutateAsync: mutateMock,
+        isPending: true,
       });
 
       renderWithAlertAndIntl(
@@ -159,9 +160,6 @@ describe('UpdateBetaTesterModal', () => {
       expect(mutateMock).toHaveBeenCalledWith({
         identifier: [learnerNonBetaTester.username],
         action: 'add',
-      }, {
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
       });
 
       // Modal should not be rendered
@@ -169,11 +167,15 @@ describe('UpdateBetaTesterModal', () => {
       expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument();
     });
 
-    it('calls onClose when automatically adding beta tester', () => {
+    it('calls onClose when automatically adding beta tester', async () => {
+      mutateMock.mockResolvedValue({ results: [] });
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
-      expect(defaultProps.onClose).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
     });
   });
 
@@ -185,21 +187,19 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'danger',
-        message: messages.failedBetaTesters.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'danger',
+          message: messages.failedBetaTesters.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -209,11 +209,7 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'failed-user', userDoesNotExist: true, isActive: null },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -224,10 +220,12 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'danger',
-        message: messages.failedBetaTesters.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'danger',
+          message: messages.failedBetaTesters.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -238,11 +236,7 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -253,10 +247,12 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'warning',
-        message: messages.inactiveUsers.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'warning',
+          message: messages.inactiveUsers.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -266,63 +262,54 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
     it('does not show alert when results array is empty', async () => {
-      const mockSuccessData = {
-        results: []
-      };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({ results: [] });
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
   });
 
   describe('mutation error scenarios', () => {
     it('shows error modal when removing beta tester fails', async () => {
-      const mutateWithError = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onError();
-      };
-      mutateMock.mockImplementation(mutateWithError);
+      mutateMock.mockRejectedValue(new Error('API error'));
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
-      expect(mockShowModal).toHaveBeenCalledWith({
-        message: messages.removeBetaTesterError.defaultMessage,
-        variant: 'danger',
-        confirmText: messages.closeButton.defaultMessage,
+      await waitFor(() => {
+        expect(mockShowModal).toHaveBeenCalledWith({
+          message: messages.removeBetaTesterError.defaultMessage,
+          variant: 'danger',
+          confirmText: messages.closeButton.defaultMessage,
+        });
       });
     });
 
     it('shows error modal when adding beta tester fails', async () => {
-      const mutateWithError = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onError();
-      };
-      mutateMock.mockImplementation(mutateWithError);
+      mutateMock.mockRejectedValue(new Error('API error'));
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -333,46 +320,42 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockShowModal).toHaveBeenCalledWith({
-        message: messages.addBetaTesterError.defaultMessage,
-        variant: 'danger',
-        confirmText: messages.closeButton.defaultMessage,
+      await waitFor(() => {
+        expect(mockShowModal).toHaveBeenCalledWith({
+          message: messages.addBetaTesterError.defaultMessage,
+          variant: 'danger',
+          confirmText: messages.closeButton.defaultMessage,
+        });
       });
     });
   });
 
   describe('edge cases', () => {
     it('handles success callback with undefined results', async () => {
-      const mockSuccessData = {};
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({});
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
     it('handles success callback with null results', async () => {
-      const mockSuccessData = {
-        results: null
-      };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({ results: null });
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
@@ -383,16 +366,16 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'user2', userDoesNotExist: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
+
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalled();
+      });
 
       const alertCall = mockAddAlert.mock.calls[0][0];
       expect(alertCall.extraContent).toHaveLength(2);

--- a/src/enrollments/components/UpdateBetaTesterModal.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.tsx
@@ -16,51 +16,49 @@ interface UpdateBetaTesterModalProps {
 const UpdateBetaTesterModal = ({ learner, isOpen, onClose }: UpdateBetaTesterModalProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const { mutate: updateBetaTester, isPending } = useUpdateBetaTesters(courseId);
+  // Using mutateAsync avoids mutate callbacks being discarded on useEffect re-runs
+  const { mutateAsync: updateBetaTester, isPending } = useUpdateBetaTesters(courseId);
   const { addAlert, showModal } = useAlert();
 
-  const handleUpdateBetaTester = useCallback(() => {
-    updateBetaTester({
-      identifier: [learner.username],
-      action: learner.isBetaTester ? 'remove' : 'add',
-    }, {
-      onSuccess: (data) => {
-        const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
-        const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
-        if (failedUsernames.length > 0) {
-          addAlert({
-            type: 'danger',
-            message: intl.formatMessage(messages.failedBetaTesters),
-            extraContent: (
-              failedUsernames.map((learner: string) => (
-                <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
-              ))
-            )
-          });
-        }
-        if (inactiveUsernames.length > 0) {
-          addAlert({
-            type: 'warning',
-            message: intl.formatMessage(messages.inactiveUsers),
-            extraContent: (
-              inactiveUsernames.map((learner: string) => (
-                <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
-              ))
-            )
-          });
-        }
-      },
-      onError: () => {
-        showModal({
-          message: learner.isBetaTester ? intl.formatMessage(messages.removeBetaTesterError) : intl.formatMessage(messages.addBetaTesterError),
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.closeButton),
+  const handleUpdateBetaTester = useCallback(async () => {
+    try {
+      const data = await updateBetaTester({
+        identifier: [learner.username],
+        action: learner.isBetaTester ? 'remove' : 'add',
+      });
+      const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
+      const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
+      if (failedUsernames.length > 0) {
+        addAlert({
+          type: 'danger',
+          message: intl.formatMessage(messages.failedBetaTesters),
+          extraContent: (
+            failedUsernames.map((learner: string) => (
+              <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
+            ))
+          )
         });
       }
-    });
-
-    onClose();
-  }, [updateBetaTester, learner.username, learner.isBetaTester, addAlert, intl, showModal, onClose]);
+      if (inactiveUsernames.length > 0) {
+        addAlert({
+          type: 'warning',
+          message: intl.formatMessage(messages.inactiveUsers),
+          extraContent: (
+            inactiveUsernames.map((learner: string) => (
+              <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
+            ))
+          )
+        });
+      }
+      onClose();
+    } catch {
+      showModal({
+        message: learner.isBetaTester ? intl.formatMessage(messages.removeBetaTesterError) : intl.formatMessage(messages.addBetaTesterError),
+        variant: 'danger',
+        confirmText: intl.formatMessage(messages.closeButton),
+      });
+    }
+  }, [updateBetaTester, learner, addAlert, intl, showModal, onClose]);
 
   useEffect(() => {
     if (isOpen && !learner.isBetaTester) {

--- a/src/grading/components/GradingActionRow.tsx
+++ b/src/grading/components/GradingActionRow.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { useToggle, ActionRow, Button, IconButton, ModalPopup, Menu, MenuItem } from '@openedx/paragon';
+import { useToggle, ActionRow, Button, IconButton, Dropdown } from '@openedx/paragon';
 import { TrendingUp, MoreVert, OpenInNew } from '@openedx/paragon/icons';
 import { useCourseInfo } from '@src/data/apiHook';
 import GradingConfigurationModal from '@src/grading/components/GradingConfigurationModal';
@@ -11,41 +10,34 @@ const GradingActionRow = () => {
   const { courseId = '' } = useParams<{ courseId: string }>();
   const intl = useIntl();
   const { data = { gradebookUrl: '', studioGradingUrl: '' } } = useCourseInfo(courseId);
-  const [configurationMenuTarget, setConfigurationMenuTarget] = useState<HTMLButtonElement | null>(null);
-  const [isOpenMenu, openMenu, closeMenu] = useToggle(false);
   const [isOpenConfigModal, openConfigModal, closeConfigModal] = useToggle(false);
-
-  const handleConfigurationMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setConfigurationMenuTarget(event?.currentTarget);
-    openMenu();
-  };
 
   const handleConfigModalOpen = () => {
     openConfigModal();
-    closeMenu();
   };
 
   return (
     <>
       <ActionRow>
         <Button as="a" href={data.gradebookUrl} iconBefore={TrendingUp} variant="outline-primary">{intl.formatMessage(messages.viewGradebook)}</Button>
-        <IconButton
-          alt={intl.formatMessage(messages.configurationAlt)}
-          className="lead"
-          iconAs={MoreVert}
-          onClick={handleConfigurationMenuClick}
-        />
+        <Dropdown>
+          <Dropdown.Toggle
+            as={IconButton}
+            alt={intl.formatMessage(messages.configurationAlt)}
+            className="lead"
+            iconAs={MoreVert}
+          />
+          <Dropdown.Menu>
+            <Dropdown.Item onClick={handleConfigModalOpen}>
+              {intl.formatMessage(messages.viewGradingConfiguration)}
+            </Dropdown.Item>
+            <Dropdown.Item as="a" href={data.studioGradingUrl} target="_blank">
+              {intl.formatMessage(messages.viewCourseGradingSettings)}
+              <OpenInNew className="ml-2" />
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
       </ActionRow>
-      <ModalPopup positionRef={configurationMenuTarget} onClose={closeMenu} isOpen={isOpenMenu}>
-        <Menu>
-          <MenuItem onClick={handleConfigModalOpen}>
-            {intl.formatMessage(messages.viewGradingConfiguration)}
-          </MenuItem>
-          <MenuItem iconAfter={OpenInNew} as="a" href={data.studioGradingUrl} target="_blank">
-            {intl.formatMessage(messages.viewCourseGradingSettings)}
-          </MenuItem>
-        </Menu>
-      </ModalPopup>
       <GradingConfigurationModal isOpen={isOpenConfigModal} onClose={closeConfigModal} />
     </>
   );

--- a/src/grading/components/GradingConfigurationModal.tsx
+++ b/src/grading/components/GradingConfigurationModal.tsx
@@ -18,7 +18,7 @@ const GradingConfigurationModal = ({ isOpen, onClose }: GradingConfigurationModa
   return (
     <ModalDialog size="lg" title={intl.formatMessage(messages.gradingConfiguration)} isOpen={isOpen} onClose={onClose} isOverflowVisible={false}>
       <ModalDialog.Header className="p-3 pl-4 border-bottom">
-        <ModalDialog.Title as="h3" className="m-0">
+        <ModalDialog.Title as="h3" className="m-0 text-primary-500">
           {intl.formatMessage(messages.gradingConfiguration)}
         </ModalDialog.Title>
       </ModalDialog.Header>

--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -2,13 +2,19 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GradingLearnerContent from '@src/grading/components/GradingLearnerContent';
 import { useChangeScore, useDeleteHistory, useRescoreSubmission, useResetAttempts } from '@src/grading/data/apiHook';
-import { usePendingTasks } from '@src/data/apiHook';
+import { useLearner, usePendingTasks, useProblemDetails } from '@src/data/apiHook';
 import messages from '@src/grading/messages';
-import { renderWithIntl } from '@src/testUtils';
+import { renderWithAlertAndIntl } from '@src/testUtils';
 
 // Mock dependencies
 jest.mock('@src/grading/data/apiHook');
-jest.mock('@src/data/apiHook');
+jest.mock('@src/data/apiHook', () => ({
+  ...jest.requireActual('@src/data/apiHook'),
+  usePendingTasks: jest.fn(),
+  useProblemDetails: jest.fn(),
+  useLearner: jest.fn(),
+}));
+
 jest.mock('@src/components/SpecifyLearnerField', () => ({
   __esModule: true,
   default: ({ onClickSelect }: { onClickSelect: (value: string) => void }) => (
@@ -56,6 +62,11 @@ describe('GradingLearnerContent', () => {
   const mockMutateRescore = jest.fn();
   const mockRefetch = jest.fn();
 
+  const axiosError = (msg = 'custom error') => ({
+    isAxiosError: true,
+    response: { data: { error: msg } },
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -64,10 +75,12 @@ describe('GradingLearnerContent', () => {
     mockUseChangeScore.mockReturnValue({ mutate: mockMutateChangeScore } as any);
     mockUseRescoreSubmission.mockReturnValue({ mutate: mockMutateRescore } as any);
     mockUsePendingTasks.mockReturnValue({ refetch: mockRefetch } as any);
+    (useLearner as jest.Mock).mockReturnValue({ data: { username: 'testuser', email: 'testuser@example.com', progressUrl: '/progress' }, isLoading: false, error: null });
+    (useProblemDetails as jest.Mock).mockReturnValue({ data: { currentScore: { score: 0, total: null }, attempts: { current: 1, total: 1 } }, isLoading: false, error: null });
   });
 
   it('renders correctly for single learner mode', () => {
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     expect(screen.getByText(messages.descriptionSingleLearner.defaultMessage)).toBeInTheDocument();
     expect(screen.getByTestId('specify-learner-field')).toBeInTheDocument();
@@ -82,7 +95,7 @@ describe('GradingLearnerContent', () => {
   });
 
   it('renders correctly for all learners mode', () => {
-    renderWithIntl(
+    renderWithAlertAndIntl(
       <GradingLearnerContent
         {...defaultProps}
         toolType="all"
@@ -96,7 +109,7 @@ describe('GradingLearnerContent', () => {
 
   it('handles learner selection correctly', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     const selectLearnerButton = screen.getByText('Select Learner');
     await user.click(selectLearnerButton);
@@ -108,7 +121,7 @@ describe('GradingLearnerContent', () => {
 
   it('handles problem selection correctly', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // First select learner
     const selectLearnerButton = screen.getByText('Select Learner');
@@ -125,7 +138,7 @@ describe('GradingLearnerContent', () => {
 
   it('calls reset attempts when button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -135,15 +148,25 @@ describe('GradingLearnerContent', () => {
     const resetButton = screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0];
     await user.click(resetButton);
 
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+
+    const confirmButton = screen.getByRole('button', { name: messages.resetAttempts.defaultMessage });
+    await user.click(confirmButton);
+
     expect(mockMutateReset).toHaveBeenCalledWith({
       learner: 'testuser@example.com',
       problem: 'block-v1:test+problem',
-    });
+    },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
   });
 
   it('calls rescore submission when button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -153,16 +176,26 @@ describe('GradingLearnerContent', () => {
     const rescoreButton = screen.getByText(messages.rescoreSubmissionButtonLabel.defaultMessage);
     await user.click(rescoreButton);
 
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+
     expect(mockMutateRescore).toHaveBeenCalledWith({
       learner: 'testuser@example.com',
       problem: 'block-v1:test+problem',
       onlyIfHigher: false,
-    });
+    },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
   });
 
   it('calls rescore submission with onlyIfHigher when "only if improves" button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -172,16 +205,26 @@ describe('GradingLearnerContent', () => {
     const rescoreIfImprovesButton = screen.getByText(messages.rescoreIfImprovesScoreButtonLabel.defaultMessage);
     await user.click(rescoreIfImprovesButton);
 
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+
     expect(mockMutateRescore).toHaveBeenCalledWith({
       learner: 'testuser@example.com',
       problem: 'block-v1:test+problem',
       onlyIfHigher: true,
-    });
+    },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
   });
 
   it('handles score input correctly', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -198,16 +241,26 @@ describe('GradingLearnerContent', () => {
     const overrideButton = screen.getByText(messages.overrideScoreButtonLabel.defaultMessage);
     await user.click(overrideButton);
 
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+
     expect(mockMutateChangeScore).toHaveBeenCalledWith({
       learner: 'testuser@example.com',
       problem: 'block-v1:test+problem',
       newScore: 85.5,
-    });
+    },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
   });
 
   it('validates score input to only allow numeric values', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -232,7 +285,7 @@ describe('GradingLearnerContent', () => {
 
   it('calls delete history when button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -242,17 +295,27 @@ describe('GradingLearnerContent', () => {
     const deleteButton = screen.getByText(messages.deleteHistoryButtonLabel.defaultMessage);
     await user.click(deleteButton);
 
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+
+    const confirmButton = screen.getByRole('button', { name: messages.deleteStateButtonLabel.defaultMessage });
+    await user.click(confirmButton);
+
     expect(mockMutateDelete).toHaveBeenCalledWith({
       learner: 'testuser@example.com',
       problem: 'block-v1:test+problem',
-    });
+    },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
   });
 
   it('calls onShowTasks and refetches when task status button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnShowTasks = jest.fn();
 
-    renderWithIntl(
+    renderWithAlertAndIntl(
       <GradingLearnerContent
         {...defaultProps}
         onShowTasks={mockOnShowTasks}
@@ -272,14 +335,14 @@ describe('GradingLearnerContent', () => {
   });
 
   it('disables problem selection when no learner is selected in single mode', () => {
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     const selectProblemButton = screen.getByText('Select Problem');
     expect(selectProblemButton).toBeDisabled();
   });
 
   it('disables action buttons when learner or problem is not selected', () => {
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
     const rescoreButton = screen.getByRole('button', { name: messages.rescoreSubmissionButtonLabel.defaultMessage });
@@ -294,7 +357,7 @@ describe('GradingLearnerContent', () => {
 
   it('disables override score button when no score is entered', async () => {
     const user = userEvent.setup();
-    renderWithIntl(<GradingLearnerContent {...defaultProps} />);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
 
     // Select learner and problem first
     await user.click(screen.getByText('Select Learner'));
@@ -304,10 +367,153 @@ describe('GradingLearnerContent', () => {
     expect(overrideButton).toBeDisabled();
   });
 
+  it('shows custom error from API in modal when resetAttempts fails', async () => {
+    mockUseResetAttempts.mockReturnValue({ mutate: (_data, { onError }) => onError(axiosError('custom error')) } as any);
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0]);
+    const confirmButton = screen.getByRole('button', { name: messages.resetAttempts.defaultMessage });
+    await user.click(confirmButton);
+    expect(screen.getByText('custom error')).toBeInTheDocument();
+  });
+
+  it('calls onSuccess and closes modal when resetAttempts succeeds', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    mockUseResetAttempts.mockReturnValue({ mutate: (_data, { onSuccess: cb }) => {
+      cb();
+      onSuccess();
+    } } as any);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0]);
+    const confirmButton = screen.getByRole('button', { name: messages.resetAttempts.defaultMessage });
+    await user.click(confirmButton);
+    expect(onSuccess).toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onSuccess and closes modal when rescoreSubmission succeeds', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    mockUseRescoreSubmission.mockReturnValue({ mutate: (_data, { onSuccess: cb }) => {
+      cb();
+      onSuccess();
+    } } as any);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getByText(messages.rescoreSubmissionButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+    expect(onSuccess).toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onSuccess and closes modal when deleteHistory succeeds', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    mockUseDeleteHistory.mockReturnValue({ mutate: (_data, { onSuccess: cb }) => {
+      cb();
+      onSuccess();
+    } } as any);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getByText(messages.deleteHistoryButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.deleteStateButtonLabel.defaultMessage });
+    await user.click(confirmButton);
+    expect(onSuccess).toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onSuccess and closes modal when overrideScore succeeds', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    mockUseChangeScore.mockReturnValue({ mutate: (_data, { onSuccess: cb }) => {
+      cb();
+      onSuccess();
+    } } as any);
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    const scoreInput = screen.getByPlaceholderText(messages.overrideScorePlaceholder.defaultMessage);
+    await user.type(scoreInput, '99');
+    await user.click(screen.getByText(messages.overrideScoreButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+    expect(onSuccess).toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows generic error in modal when resetAttempts fails with unknown error', async () => {
+    mockUseResetAttempts.mockReturnValue({ mutate: (_data, { onError }) => onError({}) } as any);
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0]);
+    const confirmButton = screen.getByRole('button', { name: messages.resetAttempts.defaultMessage });
+    await user.click(confirmButton);
+    expect(screen.getByText(messages.unexpectedError.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('shows custom error from API in modal when rescoreSubmission fails', async () => {
+    mockUseRescoreSubmission.mockReturnValue({ mutate: (_data, { onError }) => onError(axiosError('rescore error')) } as any);
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getByText(messages.rescoreSubmissionButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+    expect(screen.getByText('rescore error')).toBeInTheDocument();
+  });
+
+  it('shows custom error from API in modal when deleteHistory fails', async () => {
+    mockUseDeleteHistory.mockReturnValue({ mutate: (_data, { onError }) => onError(axiosError('delete error')) } as any);
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getByText(messages.deleteHistoryButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.deleteStateButtonLabel.defaultMessage });
+    await user.click(confirmButton);
+    expect(screen.getByText('delete error')).toBeInTheDocument();
+  });
+
+  it('shows custom error from API in modal when overrideScore fails', async () => {
+    mockUseChangeScore.mockReturnValue({ mutate: (_data, { onError }) => onError(axiosError('override error')) } as any);
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    const scoreInput = screen.getByPlaceholderText(messages.overrideScorePlaceholder.defaultMessage);
+    await user.type(scoreInput, '99');
+    await user.click(screen.getByText(messages.overrideScoreButtonLabel.defaultMessage));
+    const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+    await user.click(confirmButton);
+    expect(screen.getByText('override error')).toBeInTheDocument();
+  });
+
+  it('closes confirmation modal when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithAlertAndIntl(<GradingLearnerContent {...defaultProps} />);
+    await user.click(screen.getByText('Select Learner'));
+    await user.click(screen.getByText('Select Problem'));
+    await user.click(screen.getAllByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage })[0]);
+    const cancelButton = screen.getByRole('button', { name: messages.close.defaultMessage });
+    await user.click(cancelButton);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
   // Tests for "all learners" mode functionality
   describe('All Learners Mode', () => {
     it('renders all learners specific action cards', () => {
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -326,7 +532,7 @@ describe('GradingLearnerContent', () => {
 
     it('calls reset attempts for all learners when button is clicked', async () => {
       const user = userEvent.setup();
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -340,15 +546,25 @@ describe('GradingLearnerContent', () => {
       const resetButton = screen.getByRole('button', { name: messages.resetAttemptsButtonLabel.defaultMessage });
       await user.click(resetButton);
 
+      const confirmationModal = screen.getByRole('dialog');
+      expect(confirmationModal).toBeInTheDocument();
+
+      const confirmButton = screen.getByRole('button', { name: messages.resetAttempts.defaultMessage });
+      await user.click(confirmButton);
+
       expect(mockMutateReset).toHaveBeenCalledWith({
         problem: 'block-v1:test+problem',
         learner: '',
-      });
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }));
     });
 
     it('calls rescore all submissions when button is clicked', async () => {
       const user = userEvent.setup();
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -362,16 +578,26 @@ describe('GradingLearnerContent', () => {
       const rescoreAllButton = screen.getByRole('button', { name: messages.rescoreAllSubmissionButtonLabel.defaultMessage });
       await user.click(rescoreAllButton);
 
+      const confirmationModal = screen.getByRole('dialog');
+      expect(confirmationModal).toBeInTheDocument();
+
+      const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+      await user.click(confirmButton);
+
       expect(mockMutateRescore).toHaveBeenCalledWith({
         problem: 'block-v1:test+problem',
         onlyIfHigher: false,
         learner: '',
-      });
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }));
     });
 
     it('calls rescore submissions with onlyIfHigher when "if improves" button is clicked', async () => {
       const user = userEvent.setup();
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -385,18 +611,28 @@ describe('GradingLearnerContent', () => {
       const rescoreIfImprovesButton = screen.getByRole('button', { name: messages.rescoreIfImprovesScoreButtonLabel.defaultMessage });
       await user.click(rescoreIfImprovesButton);
 
+      const confirmationModal = screen.getByRole('dialog');
+      expect(confirmationModal).toBeInTheDocument();
+
+      const confirmButton = screen.getByRole('button', { name: messages.rescore.defaultMessage });
+      await user.click(confirmButton);
+
       expect(mockMutateRescore).toHaveBeenCalledWith({
         problem: 'block-v1:test+problem',
         onlyIfHigher: true,
         learner: '',
-      });
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }));
     });
 
     it('calls onShowTasks and refetches when task status button is clicked in all learners mode', async () => {
       const user = userEvent.setup();
       const mockOnShowTasks = jest.fn();
 
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -416,7 +652,7 @@ describe('GradingLearnerContent', () => {
     });
 
     it('disables action buttons when problem is not selected in all learners mode', () => {
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -434,7 +670,7 @@ describe('GradingLearnerContent', () => {
 
     it('enables action buttons when problem is selected in all learners mode', async () => {
       const user = userEvent.setup();
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"
@@ -456,7 +692,7 @@ describe('GradingLearnerContent', () => {
     });
 
     it('task status button is always enabled in all learners mode (does not depend on problem selection)', () => {
-      renderWithIntl(
+      renderWithAlertAndIntl(
         <GradingLearnerContent
           {...defaultProps}
           toolType="all"

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -39,21 +39,23 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
 
   const resetConfirmationModalData = () => setConfirmationModalData({ message: '', confirmButtonLabel: '', action: undefined });
 
+  const manageOnError = (error: Error) => {
+    resetConfirmationModalData();
+    const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
+    showModal({
+      message: errorMessage,
+      variant: 'danger',
+      confirmText: intl.formatMessage(messages.close),
+    });
+  };
+
   const handleResetAttempts = (): void => {
     resetAttempts({ learner: usernameOrEmail, problem: blockId }, {
       onSuccess: () => {
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.resetAttemptsSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: (error) => {
-        resetConfirmationModalData();
-        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
-        showModal({
-          message: errorMessage,
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.close),
-        });
-      }
+      onError: manageOnError
     });
   };
 
@@ -63,15 +65,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.rescoreSubmissionSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: (error) => {
-        resetConfirmationModalData();
-        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
-        showModal({
-          message: errorMessage,
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.close),
-        });
-      }
+      onError: manageOnError
     });
   };
 
@@ -81,15 +75,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.deleteHistorySuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: (error) => {
-        resetConfirmationModalData();
-        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
-        showModal({
-          message: errorMessage,
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.close),
-        });
-      }
+      onError: manageOnError
     });
   };
 
@@ -99,15 +85,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.overrideScoreSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: (error) => {
-        resetConfirmationModalData();
-        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
-        showModal({
-          message: errorMessage,
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.close),
-        });
-      }
+      onError: manageOnError
     });
   };
 

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
+import { isAxiosError } from 'axios';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, FormControl, ModalDialog, Stack } from '@openedx/paragon';
 import ActionCard, { ActionCardProps } from '@src/components/ActionCard';
@@ -44,10 +45,11 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.resetAttemptsSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: () => {
+      onError: (error) => {
         resetConfirmationModalData();
+        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
         showModal({
-          message: intl.formatMessage(messages.unexpectedError),
+          message: errorMessage,
           variant: 'danger',
           confirmText: intl.formatMessage(messages.close),
         });
@@ -61,10 +63,11 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.rescoreSubmissionSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: () => {
+      onError: (error) => {
         resetConfirmationModalData();
+        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
         showModal({
-          message: intl.formatMessage(messages.unexpectedError),
+          message: errorMessage,
           variant: 'danger',
           confirmText: intl.formatMessage(messages.close),
         });
@@ -78,10 +81,11 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.deleteHistorySuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: () => {
+      onError: (error) => {
         resetConfirmationModalData();
+        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
         showModal({
-          message: intl.formatMessage(messages.unexpectedError),
+          message: errorMessage,
           variant: 'danger',
           confirmText: intl.formatMessage(messages.close),
         });
@@ -95,10 +99,11 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         resetConfirmationModalData();
         showToast(intl.formatMessage(messages.overrideScoreSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
-      onError: () => {
+      onError: (error) => {
         resetConfirmationModalData();
+        const errorMessage = isAxiosError(error) && error.response?.data?.error ? error.response.data.error : intl.formatMessage(messages.unexpectedError);
         showModal({
-          message: intl.formatMessage(messages.unexpectedError),
+          message: errorMessage,
           variant: 'danger',
           confirmText: intl.formatMessage(messages.close),
         });

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, FormControl, Stack } from '@openedx/paragon';
+import { Button, FormControl, ModalDialog, Stack } from '@openedx/paragon';
 import ActionCard, { ActionCardProps } from '@src/components/ActionCard';
 import SpecifyLearnerField from '@src/components/SpecifyLearnerField';
 import SpecifyProblemField from '@src/components/SpecifyProblemField';
@@ -24,7 +24,8 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const learnerFieldRef = useRef<{ reset: () => void }>(null);
   const problemFieldRef = useRef<{ reset: () => void }>(null);
   const [showCurrentStatus, setShowCurrentStatus] = useState(false);
-  const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } } } = useProblemDetails(courseId, blockId, usernameOrEmail);
+  const [confirmationModalData, setConfirmationModalData] = useState<{ message: string, confirmButtonLabel: string, action?: () => void }>({ message: '', confirmButtonLabel: '', action: undefined });
+  const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } }, isError: isProblemDataError } = useProblemDetails(courseId, blockId, usernameOrEmail);
   const { data: learnerData = { username: '', progressUrl: '' } } = useLearner(courseId, usernameOrEmail);
 
   const { mutate: resetAttempts } = useResetAttempts(courseId);
@@ -58,6 +59,39 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
     }
   };
 
+  const confirmationInfo = {
+    resetAttempts: {
+      message: messages.resetAttemptsConfirmation,
+      confirmButtonLabel: messages.resetAttempts,
+      action: handleResetAttempts,
+    },
+    deleteState: {
+      message: messages.deleteStateConfirmation,
+      confirmButtonLabel: messages.deleteStateButtonLabel,
+      action: handleDeleteHistory,
+    },
+    overrideScore: {
+      message: messages.overrideScoreConfirmation,
+      confirmButtonLabel: messages.rescore,
+      action: handleOverrideScore,
+    },
+    rescore: {
+      message: messages.rescoreConfirmation,
+      confirmButtonLabel: messages.rescore,
+      action: () => handleRescoreSubmission(),
+    },
+    rescoreIfImproves: {
+      message: messages.rescoreConfirmation,
+      confirmButtonLabel: messages.rescore,
+      action: () => handleRescoreSubmission(true),
+    }
+  };
+
+  const openConfirmationModal = (type: keyof typeof confirmationInfo): void => {
+    const { message, confirmButtonLabel, action } = confirmationInfo[type];
+    setConfirmationModalData({ message: intl.formatMessage(message, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }), confirmButtonLabel: intl.formatMessage(confirmButtonLabel), action });
+  };
+
   const handleTaskStatusClick = (): void => {
     refetchTasks();
     onShowTasks();
@@ -77,7 +111,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       title: intl.formatMessage(messages.resetAttempts),
       description: intl.formatMessage(messages.resetAttemptsDescription),
       customAction: (
-        <Button disabled={!usernameOrEmail || !blockId} onClick={handleResetAttempts}>
+        <Button disabled={!usernameOrEmail || !blockId} onClick={() => openConfirmationModal('resetAttempts')}>
           {intl.formatMessage(messages.resetAttemptsButtonLabel)}
         </Button>
       )
@@ -87,8 +121,12 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       description: intl.formatMessage(messages.rescoreSubmissionDescription),
       customAction: (
         <div className="d-flex flex-column gap-3">
-          <Button disabled={!usernameOrEmail || !blockId} onClick={() => handleRescoreSubmission()}>{intl.formatMessage(messages.rescoreSubmissionButtonLabel)}</Button>
-          <Button disabled={!usernameOrEmail || !blockId} onClick={() => handleRescoreSubmission(true)}>{intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}</Button>
+          <Button disabled={!usernameOrEmail || !blockId} onClick={() => openConfirmationModal('rescore')}>
+            {intl.formatMessage(messages.rescoreSubmissionButtonLabel)}
+          </Button>
+          <Button disabled={!usernameOrEmail || !blockId} onClick={() => openConfirmationModal('rescoreIfImproves')}>
+            {intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}
+          </Button>
         </div>
       ),
     },
@@ -114,7 +152,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       description: intl.formatMessage(messages.deleteHistoryDescription),
       customAction: (
         <div className="d-flex flex-column gap-3">
-          <Button disabled={!usernameOrEmail || !blockId} onClick={handleDeleteHistory}>{intl.formatMessage(messages.deleteHistoryButtonLabel)}</Button>
+          <Button disabled={!usernameOrEmail || !blockId} onClick={() => openConfirmationModal('deleteState')}>{intl.formatMessage(messages.deleteHistoryButtonLabel)}</Button>
         </div>
       ),
     },
@@ -135,7 +173,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       description: intl.formatMessage(messages.resetAllLearnersAttemptsDescription),
       buttonLabel: intl.formatMessage(messages.resetAttemptsButtonLabel),
       customAction: (
-        <Button disabled={!blockId} onClick={handleResetAttempts}>
+        <Button disabled={!blockId} onClick={() => openConfirmationModal('resetAttempts')}>
           {intl.formatMessage(messages.resetAttemptsButtonLabel)}
         </Button>
       )
@@ -145,8 +183,8 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
       description: intl.formatMessage(messages.rescoreSubmissionAllLearnersDescription),
       customAction: (
         <div className="d-flex flex-column gap-3">
-          <Button disabled={!blockId} onClick={() => handleRescoreSubmission()}>{intl.formatMessage(messages.rescoreAllSubmissionButtonLabel)}</Button>
-          <Button disabled={!blockId} onClick={() => handleRescoreSubmission(true)}>{intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}</Button>
+          <Button disabled={!blockId} onClick={() => openConfirmationModal('rescore')}>{intl.formatMessage(messages.rescoreAllSubmissionButtonLabel)}</Button>
+          <Button disabled={!blockId} onClick={() => openConfirmationModal('rescoreIfImproves')}>{intl.formatMessage(messages.rescoreIfImprovesScoreButtonLabel)}</Button>
         </div>
       ),
     },
@@ -207,7 +245,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         </div>
       </div>
       {
-        showCurrentStatus && (
+        showCurrentStatus && learnerData.username && !isProblemDataError && (
           <>
             <p className="text-primary-500 x-small mb-0 mt-3">{intl.formatMessage(messages.currentScore)}</p>
             <Stack direction="horizontal" gap={2} className="align-items-center justify-content-between mr-3.5">
@@ -231,6 +269,25 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
         rows.map(({ title, description, buttonLabel, customAction, onButtonClick }, index) => (
           <ActionCard key={title} buttonLabel={buttonLabel} description={description} title={title} hasBorderBottom={index !== rows.length - 1} customAction={customAction} onButtonClick={onButtonClick} />
         ))
+      }
+      {
+        confirmationModalData.message !== '' && (
+          <ModalDialog
+            title={confirmationModalData.confirmButtonLabel}
+            isOpen={confirmationModalData.message !== ''}
+            onClose={() => setConfirmationModalData({ message: '', confirmButtonLabel: '', action: undefined })}
+            isOverflowVisible={false}
+            hasCloseButton={false}
+          >
+            <ModalDialog.Body>
+              <p>{confirmationModalData.message}</p>
+            </ModalDialog.Body>
+            <ModalDialog.Footer>
+              <Button variant="tertiary" onClick={() => setConfirmationModalData({ message: '', confirmButtonLabel: '', action: undefined })}>{intl.formatMessage(messages.close)}</Button>
+              <Button className="ml-2" onClick={confirmationModalData.action}>{confirmationModalData.confirmButtonLabel}</Button>
+            </ModalDialog.Footer>
+          </ModalDialog>
+        )
       }
     </>
   );

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -1,14 +1,14 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import { useIntl } from '@openedx/frontend-base';
-import { Button, FormControl } from '@openedx/paragon';
+import { Button, FormControl, Stack } from '@openedx/paragon';
 import ActionCard, { ActionCardProps } from '@src/components/ActionCard';
 import SpecifyLearnerField from '@src/components/SpecifyLearnerField';
 import SpecifyProblemField from '@src/components/SpecifyProblemField';
 import { useChangeScore, useDeleteHistory, useRescoreSubmission, useResetAttempts } from '@src/grading/data/apiHook';
 import messages from '@src/grading/messages';
 import { GradingToolsType } from '@src/grading/types';
-import { usePendingTasks } from '@src/data/apiHook';
+import { useLearner, usePendingTasks, useProblemDetails } from '@src/data/apiHook';
 
 interface GradingLearnerContentProps {
   toolType: GradingToolsType,
@@ -23,6 +23,9 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const [score, setScore] = useState('');
   const learnerFieldRef = useRef<{ reset: () => void }>(null);
   const problemFieldRef = useRef<{ reset: () => void }>(null);
+  const [showCurrentStatus, setShowCurrentStatus] = useState(false);
+  const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } } } = useProblemDetails(courseId, blockId, usernameOrEmail);
+  const { data: learnerData = { username: '', progressUrl: '' } } = useLearner(courseId, usernameOrEmail);
 
   const { mutate: resetAttempts } = useResetAttempts(courseId);
   const { mutate: deleteHistory } = useDeleteHistory(courseId);
@@ -64,6 +67,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
     setUsernameOrEmail('');
     setBlockId('');
     setScore('');
+    setShowCurrentStatus(false);
     learnerFieldRef.current?.reset();
     problemFieldRef.current?.reset();
   }, [toolType]);
@@ -161,6 +165,9 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
 
   const handleProblemChange = (location: string): void => {
     setBlockId(location);
+    if (usernameOrEmail && location) {
+      setShowCurrentStatus(true);
+    }
   };
 
   const handleLearnerChange = (usernameOrEmail: string): void => {
@@ -168,6 +175,9 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
     // Reset problem field when learner changes due to progress and attempts change for every learner
     setBlockId('');
     problemFieldRef.current?.reset();
+    if (showCurrentStatus) {
+      setShowCurrentStatus(false);
+    }
   };
 
   return (
@@ -196,6 +206,27 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
           />
         </div>
       </div>
+      {
+        showCurrentStatus && (
+          <>
+            <p className="text-primary-500 x-small mb-0 mt-3">{intl.formatMessage(messages.currentScore)}</p>
+            <Stack direction="horizontal" gap={2} className="align-items-center justify-content-between mr-3.5">
+              <Stack direction="horizontal" gap={5} className="align-items-end">
+                <p className="text-primary-500 mb-0">{learnerData.username}</p>
+                <Stack className="align-items-center">
+                  <p className="x-small mb-0 text-gray-500">{intl.formatMessage(messages.score)}</p>
+                  <p className="lead m-0 text-primary-700">{problemData.currentScore?.score || 0} {problemData.currentScore?.total && `/ ${problemData.currentScore.total}`}</p>
+                </Stack>
+                <Stack className="align-items-center">
+                  <p className="x-small mb-0 text-gray-500">{intl.formatMessage(messages.attempts)}</p>
+                  <p className="lead m-0 text-primary-700">{problemData.attempts?.current || 0} {problemData.attempts?.total && `/ ${problemData.attempts.total}`}</p>
+                </Stack>
+              </Stack>
+              <Button as="a" href={learnerData.progressUrl} className="bg-white" variant="outline-primary">{intl.formatMessage(messages.viewProgress)}</Button>
+            </Stack>
+          </>
+        )
+      }
       {
         rows.map(({ title, description, buttonLabel, customAction, onButtonClick }, index) => (
           <ActionCard key={title} buttonLabel={buttonLabel} description={description} title={title} hasBorderBottom={index !== rows.length - 1} customAction={customAction} onButtonClick={onButtonClick} />

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -9,6 +9,7 @@ import { useChangeScore, useDeleteHistory, useRescoreSubmission, useResetAttempt
 import messages from '@src/grading/messages';
 import { GradingToolsType } from '@src/grading/types';
 import { useLearner, usePendingTasks, useProblemDetails } from '@src/data/apiHook';
+import { useAlert } from '@src/providers/AlertProvider';
 
 interface GradingLearnerContentProps {
   toolType: GradingToolsType,
@@ -27,6 +28,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const [confirmationModalData, setConfirmationModalData] = useState<{ message: string, confirmButtonLabel: string, action?: () => void }>({ message: '', confirmButtonLabel: '', action: undefined });
   const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } }, isError: isProblemDataError } = useProblemDetails(courseId, blockId, usernameOrEmail);
   const { data: learnerData = { username: '', progressUrl: '' } } = useLearner(courseId, usernameOrEmail);
+  const { showModal, showToast } = useAlert();
 
   const { mutate: resetAttempts } = useResetAttempts(courseId);
   const { mutate: deleteHistory } = useDeleteHistory(courseId);
@@ -34,20 +36,74 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const { mutate: rescoreSubmission } = useRescoreSubmission(courseId);
   const { refetch: refetchTasks } = usePendingTasks(courseId);
 
+  const resetConfirmationModalData = () => setConfirmationModalData({ message: '', confirmButtonLabel: '', action: undefined });
+
   const handleResetAttempts = (): void => {
-    resetAttempts({ learner: usernameOrEmail, problem: blockId });
+    resetAttempts({ learner: usernameOrEmail, problem: blockId }, {
+      onSuccess: () => {
+        resetConfirmationModalData();
+        showToast(intl.formatMessage(messages.resetAttemptsSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
+      },
+      onError: () => {
+        resetConfirmationModalData();
+        showModal({
+          message: intl.formatMessage(messages.unexpectedError),
+          variant: 'danger',
+          confirmText: intl.formatMessage(messages.close),
+        });
+      }
+    });
   };
 
   const handleRescoreSubmission = (onlyIfHigher = false): void => {
-    rescoreSubmission({ learner: usernameOrEmail, problem: blockId, onlyIfHigher });
+    rescoreSubmission({ learner: usernameOrEmail, problem: blockId, onlyIfHigher }, {
+      onSuccess: () => {
+        resetConfirmationModalData();
+        showToast(intl.formatMessage(messages.rescoreSubmissionSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
+      },
+      onError: () => {
+        resetConfirmationModalData();
+        showModal({
+          message: intl.formatMessage(messages.unexpectedError),
+          variant: 'danger',
+          confirmText: intl.formatMessage(messages.close),
+        });
+      }
+    });
   };
 
   const handleDeleteHistory = (): void => {
-    deleteHistory({ learner: usernameOrEmail, problem: blockId });
+    deleteHistory({ learner: usernameOrEmail, problem: blockId }, {
+      onSuccess: () => {
+        resetConfirmationModalData();
+        showToast(intl.formatMessage(messages.deleteHistorySuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
+      },
+      onError: () => {
+        resetConfirmationModalData();
+        showModal({
+          message: intl.formatMessage(messages.unexpectedError),
+          variant: 'danger',
+          confirmText: intl.formatMessage(messages.close),
+        });
+      }
+    });
   };
 
   const handleOverrideScore = (): void => {
-    changeScore({ learner: usernameOrEmail, problem: blockId, newScore: Number(score) });
+    changeScore({ learner: usernameOrEmail, problem: blockId, newScore: Number(score) }, {
+      onSuccess: () => {
+        resetConfirmationModalData();
+        showToast(intl.formatMessage(messages.overrideScoreSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
+      },
+      onError: () => {
+        resetConfirmationModalData();
+        showModal({
+          message: intl.formatMessage(messages.unexpectedError),
+          variant: 'danger',
+          confirmText: intl.formatMessage(messages.close),
+        });
+      }
+    });
   };
 
   const handleScoreChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -143,7 +199,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
             value={score}
             onChange={handleScoreChange}
           />
-          <Button disabled={!usernameOrEmail || !blockId || !score} onClick={handleOverrideScore}>{intl.formatMessage(messages.overrideScoreButtonLabel)}</Button>
+          <Button disabled={!usernameOrEmail || !blockId || !score} onClick={() => openConfirmationModal('overrideScore')}>{intl.formatMessage(messages.overrideScoreButtonLabel)}</Button>
         </div>
       )
     },
@@ -279,8 +335,8 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
             isOverflowVisible={false}
             hasCloseButton={false}
           >
-            <ModalDialog.Body>
-              <p>{confirmationModalData.message}</p>
+            <ModalDialog.Body className="pt-4">
+              <p className="text-break">{confirmationModalData.message}</p>
             </ModalDialog.Body>
             <ModalDialog.Footer>
               <Button variant="tertiary" onClick={() => setConfirmationModalData({ message: '', confirmButtonLabel: '', action: undefined })}>{intl.formatMessage(messages.close)}</Button>

--- a/src/grading/messages.ts
+++ b/src/grading/messages.ts
@@ -170,6 +170,26 @@ const messages = defineMessages({
     id: 'instruct.grading.rescoreAllSubmissionButtonLabel',
     defaultMessage: 'Rescore All Learners\' Submissions',
     description: 'Button label for the rescore submission action card in the all learners view'
+  },
+  currentScore: {
+    id: 'instruct.grading.currentScore',
+    defaultMessage: 'Current Score',
+    description: 'Label for the current score displayed in the single learner view'
+  },
+  viewProgress: {
+    id: 'instruct.grading.viewProgress',
+    defaultMessage: 'View Progress Page',
+    description: 'Label for the view progress button displayed next to the current score in the single learner view'
+  },
+  score: {
+    id: 'instruct.grading.score',
+    defaultMessage: 'Score',
+    description: 'Label for the score displayed in the current status section of the single learner view'
+  },
+  attempts: {
+    id: 'instruct.grading.attempts',
+    defaultMessage: 'Attempts',
+    description: 'Label for the attempts displayed in the current status section of the single learner view'
   }
 });
 

--- a/src/grading/messages.ts
+++ b/src/grading/messages.ts
@@ -190,6 +190,36 @@ const messages = defineMessages({
     id: 'instruct.grading.attempts',
     defaultMessage: 'Attempts',
     description: 'Label for the attempts displayed in the current status section of the single learner view'
+  },
+  rescore: {
+    id: 'instruct.grading.rescore',
+    defaultMessage: 'Rescore',
+    description: 'Label for the rescore confirmation action'
+  },
+  resetAttemptsConfirmation: {
+    id: 'instruct.grading.resetAttemptsConfirmation',
+    defaultMessage: 'Reset attempts for {student} on problem \'{blockId}\'?',
+    description: 'Confirmation message for resetting attempts'
+  },
+  overrideScoreConfirmation: {
+    id: 'instruct.grading.overrideScoreConfirmation',
+    defaultMessage: 'Override score for {student} for problem \'{blockId}\'?',
+    description: 'Confirmation message for overriding score'
+  },
+  deleteStateConfirmation: {
+    id: 'instruct.grading.deleteStateConfirmation',
+    defaultMessage: 'Delete state for student \'{student}\' on problem \'{blockId}\'?',
+    description: 'Confirmation message for deleting state'
+  },
+  rescoreConfirmation: {
+    id: 'instruct.grading.rescoreConfirmation',
+    defaultMessage: 'Rescore problem for {student} for \'{blockId}\'?',
+    description: 'Confirmation message for rescoring a submission'
+  },
+  deleteStateButtonLabel: {
+    id: 'instruct.grading.deleteStateButtonLabel',
+    defaultMessage: 'Delete State',
+    description: 'Button label for the delete state confirmation action'
   }
 });
 

--- a/src/grading/messages.ts
+++ b/src/grading/messages.ts
@@ -198,28 +198,53 @@ const messages = defineMessages({
   },
   resetAttemptsConfirmation: {
     id: 'instruct.grading.resetAttemptsConfirmation',
-    defaultMessage: 'Reset attempts for {student} on problem \'{blockId}\'?',
+    defaultMessage: 'Reset attempts for {student} on problem "{blockId}"?',
     description: 'Confirmation message for resetting attempts'
   },
   overrideScoreConfirmation: {
     id: 'instruct.grading.overrideScoreConfirmation',
-    defaultMessage: 'Override score for {student} for problem \'{blockId}\'?',
+    defaultMessage: 'Override score for {student} for problem "{blockId}"?',
     description: 'Confirmation message for overriding score'
   },
   deleteStateConfirmation: {
     id: 'instruct.grading.deleteStateConfirmation',
-    defaultMessage: 'Delete state for student \'{student}\' on problem \'{blockId}\'?',
+    defaultMessage: 'Delete state for student "{student}" on problem "{blockId}"?',
     description: 'Confirmation message for deleting state'
   },
   rescoreConfirmation: {
     id: 'instruct.grading.rescoreConfirmation',
-    defaultMessage: 'Rescore problem for {student} for \'{blockId}\'?',
+    defaultMessage: 'Rescore problem for {student} for "{blockId}"?',
     description: 'Confirmation message for rescoring a submission'
   },
   deleteStateButtonLabel: {
     id: 'instruct.grading.deleteStateButtonLabel',
     defaultMessage: 'Delete State',
     description: 'Button label for the delete state confirmation action'
+  },
+  resetAttemptsSuccess: {
+    id: 'instruct.grading.resetAttemptsSuccess',
+    defaultMessage: 'Successfully reset problem attempts for {student} on problem "{blockId}".',
+    description: 'Success message for resetting attempts'
+  },
+  overrideScoreSuccess: {
+    id: 'instruct.grading.overrideScoreSuccess',
+    defaultMessage: 'Started task to override the score for {student} on problem "{blockId}". \n \n Click the \'Show Task Status\' button to see the status of the task.',
+    description: 'Success message for overriding score'
+  },
+  rescoreSubmissionSuccess: {
+    id: 'instruct.grading.rescoreSubmissionSuccess',
+    defaultMessage: 'Successfully started task to rescore problem "{blockId}" for {student}. \n \n Click the \'Show Task Status\' button to see the status of the task.',
+    description: 'Success message for rescoring submission'
+  },
+  deleteHistorySuccess: {
+    id: 'instruct.grading.deleteHistorySuccess',
+    defaultMessage: 'State for student "{student}" successfully deleted.',
+    description: 'Success message for deleting history'
+  },
+  unexpectedError: {
+    id: 'instruct.grading.unexpectedError',
+    defaultMessage: 'An unexpected error occurred. Please try again.',
+    description: 'Message to display when an unexpected error occurs'
   }
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,3 +52,14 @@ export interface SelectedLearner extends Learner {
   progressUrl: string,
   isEnrolled: boolean,
 }
+
+export interface ProblemDetails {
+  currentScore: {
+    score: number,
+    total: number | null,
+  },
+  attempts: {
+    current: number | null,
+    total: number,
+  },
+}


### PR DESCRIPTION
## Description
On grading tab was added/changed:
- confirmation modals
-  success toasts
- error modals
- current score info and progress button
- configuration menu to use dropdown instead of prev implementation

## Supporting information
Closes #193 

## Testing instructions
- Go to grading tab and fill needed info, click on any button you should see the confirmation modals

## Other information
Grading configuration menu
<img width="320" height="183" alt="Screenshot 2026-05-08 at 2 14 04 p m" src="https://github.com/user-attachments/assets/2c735115-91fd-4eff-b67b-a8708f96a545" />

Score info
<img width="1398" height="441" alt="Screenshot 2026-05-08 at 2 13 12 p m" src="https://github.com/user-attachments/assets/b13b79e6-c9c1-4f88-9493-a7f8ec509275" />

Confirmation modal
<img width="578" height="288" alt="Screenshot 2026-05-08 at 2 14 40 p m" src="https://github.com/user-attachments/assets/84d625f0-2565-4e26-9942-1c866cd54274" />

Success toast
<img width="468" height="189" alt="Screenshot 2026-05-08 at 2 15 15 p m" src="https://github.com/user-attachments/assets/3ef11d3e-e926-43c2-be62-0f14834cb7ae" />

Error modal
<img width="585" height="298" alt="Screenshot 2026-05-08 at 2 14 54 p m" src="https://github.com/user-attachments/assets/ec870377-df3f-45a6-a868-c502a9145631" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
