### PR TITLE
fix: grant beta tester role

### DIFF
--- a/src/enrollments/EnrollmentsPage.test.tsx
+++ b/src/enrollments/EnrollmentsPage.test.tsx
@@ -91,7 +91,7 @@ describe('EnrollmentsPage', () => {
 
     // Verify dialog is opened and popup is closed
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(checkEnrollmentStatusOption).not.toBeInTheDocument();
+    expect(checkEnrollmentStatusOption).not.toHaveClass('show');
   });
 
   it('closes enrollment status modal', async () => {

--- a/src/enrollments/EnrollmentsPage.tsx
+++ b/src/enrollments/EnrollmentsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useIntl } from '@openedx/frontend-base';
-import { ActionRow, Button, IconButton, Menu, MenuItem, ModalPopup, useToggle } from '@openedx/paragon';
+import { ActionRow, Button, Dropdown, IconButton } from '@openedx/paragon';
 import { MoreVert } from '@openedx/paragon/icons';
 import messages from '@src/enrollments/messages';
 import AddBetaTestersModal from '@src/enrollments/components/AddBetaTestersModal';
@@ -20,13 +20,10 @@ const EnrollmentsPage = () => {
   const [isUnenrollModalOpen, setIsUnenrollModalOpen] = useState(false);
   const [isUpdateBetaTesterModalOpen, setIsUpdateBetaTesterModalOpen] = useState(false);
   const [selectedLearner, setSelectedLearner] = useState<EnrolledLearner | null>(null);
-  const [statusMenuTarget, setStatusMenuTarget] = useState<HTMLButtonElement | null>(null);
-  const [isOpenMenu, openMenu, closeMenu] = useToggle(false);
   const { clearAlerts } = useAlert();
 
   const handleOpenEnrollmentStatusModal = () => {
     setIsEnrollmentStatusModalOpen(true);
-    closeMenu();
   };
 
   const handleUnenroll = (learner: EnrolledLearner) => {
@@ -67,33 +64,28 @@ const EnrollmentsPage = () => {
     setSelectedLearner(null);
   };
 
-  const handleStatusMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setStatusMenuTarget(event?.currentTarget);
-    openMenu();
-  };
-
   return (
     <>
       <div className="d-flex justify-content-between align-items-center">
         <h3 className="text-primary-700">{intl.formatMessage(messages.enrollmentsPageTitle)}</h3>
         <ActionRow>
-          <IconButton
-            alt={intl.formatMessage(messages.checkEnrollmentStatus)}
-            className="lead"
-            iconAs={MoreVert}
-            onClick={handleStatusMenuClick}
-          />
+          <Dropdown>
+            <Dropdown.Toggle
+              as={IconButton}
+              src={MoreVert}
+              alt={intl.formatMessage(messages.checkEnrollmentStatus)}
+              id="check-enrollment-status-menu"
+            />
+            <Dropdown.Menu>
+              <Dropdown.Item onClick={handleOpenEnrollmentStatusModal}>
+                {intl.formatMessage(messages.checkEnrollmentStatus)}
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
           <Button variant="outline-primary" onClick={handleAddBetaTesters}>+ {intl.formatMessage(messages.addBetaTesters)}</Button>
           <Button onClick={handleEnrollLearners}>+ {intl.formatMessage(messages.enrollLearners)}</Button>
         </ActionRow>
       </div>
-      <ModalPopup positionRef={statusMenuTarget} onClose={closeMenu} isOpen={isOpenMenu}>
-        <Menu>
-          <MenuItem onClick={handleOpenEnrollmentStatusModal}>
-            {intl.formatMessage(messages.checkEnrollmentStatus)}
-          </MenuItem>
-        </Menu>
-      </ModalPopup>
       <AlertOutlet />
       <EnrollmentsList onUnenroll={handleUnenroll} onBetaTesterChange={handleBetaTesterChange} />
       <EnrollmentStatusModal isOpen={isEnrollmentStatusModalOpen} onClose={handleCloseEnrollmentStatusModal} />

--- a/src/enrollments/components/UpdateBetaTesterModal.test.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.test.tsx
@@ -1,9 +1,8 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UpdateBetaTesterModal from '@src/enrollments/components/UpdateBetaTesterModal';
 import { useUpdateBetaTesters } from '@src/enrollments/data/apiHook';
 import messages from '@src/enrollments/messages';
-import { UpdateBetaTestersParams } from '@src/enrollments/types';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 
 const learnerBetaTester = {
@@ -52,9 +51,10 @@ describe('UpdateBetaTesterModal', () => {
   const mutateMock = jest.fn();
 
   beforeEach(() => {
+    mutateMock.mockResolvedValue({ results: [] });
     (useUpdateBetaTesters as jest.Mock).mockReturnValue({
-      mutate: mutateMock,
-      isPending: false
+      mutateAsync: mutateMock,
+      isPending: false,
     });
     mockShowModal.mockClear();
     mockAddAlert.mockClear();
@@ -99,24 +99,25 @@ describe('UpdateBetaTesterModal', () => {
       expect(mutateMock).toHaveBeenCalledWith({
         identifier: [learnerBetaTester.username],
         action: 'remove',
-      }, {
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
       });
     });
 
     it('calls onClose when Revoke button is clicked', async () => {
+      mutateMock.mockResolvedValue({ results: [] });
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
-      expect(defaultProps.onClose).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
     });
 
     it('disables revoke button when pending', () => {
       (useUpdateBetaTesters as jest.Mock).mockReturnValue({
-        mutate: mutateMock,
-        isPending: true
+        mutateAsync: mutateMock,
+        isPending: true,
       });
 
       renderWithAlertAndIntl(
@@ -159,9 +160,6 @@ describe('UpdateBetaTesterModal', () => {
       expect(mutateMock).toHaveBeenCalledWith({
         identifier: [learnerNonBetaTester.username],
         action: 'add',
-      }, {
-        onSuccess: expect.any(Function),
-        onError: expect.any(Function),
       });
 
       // Modal should not be rendered
@@ -169,11 +167,15 @@ describe('UpdateBetaTesterModal', () => {
       expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument();
     });
 
-    it('calls onClose when automatically adding beta tester', () => {
+    it('calls onClose when automatically adding beta tester', async () => {
+      mutateMock.mockResolvedValue({ results: [] });
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
-      expect(defaultProps.onClose).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
     });
   });
 
@@ -185,21 +187,19 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'danger',
-        message: messages.failedBetaTesters.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'danger',
+          message: messages.failedBetaTesters.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -209,11 +209,7 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'failed-user', userDoesNotExist: true, isActive: null },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -224,10 +220,12 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'danger',
-        message: messages.failedBetaTesters.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'danger',
+          message: messages.failedBetaTesters.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -238,11 +236,7 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -253,10 +247,12 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockAddAlert).toHaveBeenCalledWith({
-        type: 'warning',
-        message: messages.inactiveUsers.defaultMessage,
-        extraContent: expect.any(Array),
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalledWith({
+          type: 'warning',
+          message: messages.inactiveUsers.defaultMessage,
+          extraContent: expect.any(Array),
+        });
       });
     });
 
@@ -266,63 +262,54 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'jane.doe', userDoesNotExist: false, isActive: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
     it('does not show alert when results array is empty', async () => {
-      const mockSuccessData = {
-        results: []
-      };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({ results: [] });
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
   });
 
   describe('mutation error scenarios', () => {
     it('shows error modal when removing beta tester fails', async () => {
-      const mutateWithError = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onError();
-      };
-      mutateMock.mockImplementation(mutateWithError);
+      mutateMock.mockRejectedValue(new Error('API error'));
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
-      expect(mockShowModal).toHaveBeenCalledWith({
-        message: messages.removeBetaTesterError.defaultMessage,
-        variant: 'danger',
-        confirmText: messages.closeButton.defaultMessage,
+      await waitFor(() => {
+        expect(mockShowModal).toHaveBeenCalledWith({
+          message: messages.removeBetaTesterError.defaultMessage,
+          variant: 'danger',
+          confirmText: messages.closeButton.defaultMessage,
+        });
       });
     });
 
     it('shows error modal when adding beta tester fails', async () => {
-      const mutateWithError = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onError();
-      };
-      mutateMock.mockImplementation(mutateWithError);
+      mutateMock.mockRejectedValue(new Error('API error'));
 
       const nonBetaTesterProps = {
         ...defaultProps,
@@ -333,46 +320,42 @@ describe('UpdateBetaTesterModal', () => {
         <UpdateBetaTesterModal {...nonBetaTesterProps} />
       );
 
-      expect(mockShowModal).toHaveBeenCalledWith({
-        message: messages.addBetaTesterError.defaultMessage,
-        variant: 'danger',
-        confirmText: messages.closeButton.defaultMessage,
+      await waitFor(() => {
+        expect(mockShowModal).toHaveBeenCalledWith({
+          message: messages.addBetaTesterError.defaultMessage,
+          variant: 'danger',
+          confirmText: messages.closeButton.defaultMessage,
+        });
       });
     });
   });
 
   describe('edge cases', () => {
     it('handles success callback with undefined results', async () => {
-      const mockSuccessData = {};
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({});
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
     it('handles success callback with null results', async () => {
-      const mockSuccessData = {
-        results: null
-      };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue({ results: null });
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
 
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalled();
+      });
       expect(mockAddAlert).not.toHaveBeenCalled();
     });
 
@@ -383,16 +366,16 @@ describe('UpdateBetaTesterModal', () => {
           { identifier: 'user2', userDoesNotExist: true },
         ]
       };
-
-      const mutateWithSuccess = (_params: UpdateBetaTestersParams, callbacks: any) => {
-        callbacks.onSuccess(mockSuccessData);
-      };
-      mutateMock.mockImplementation(mutateWithSuccess);
+      mutateMock.mockResolvedValue(mockSuccessData);
 
       renderWithAlertAndIntl(
         <UpdateBetaTesterModal {...defaultProps} />
       );
       await userEvent.click(screen.getByRole('button', { name: /revoke/i }));
+
+      await waitFor(() => {
+        expect(mockAddAlert).toHaveBeenCalled();
+      });
 
       const alertCall = mockAddAlert.mock.calls[0][0];
       expect(alertCall.extraContent).toHaveLength(2);

--- a/src/enrollments/components/UpdateBetaTesterModal.tsx
+++ b/src/enrollments/components/UpdateBetaTesterModal.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, ModalDialog } from '@openedx/paragon';
 import { useAlert } from '@src/providers/AlertProvider';
@@ -16,54 +16,55 @@ interface UpdateBetaTesterModalProps {
 const UpdateBetaTesterModal = ({ learner, isOpen, onClose }: UpdateBetaTesterModalProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams<{ courseId: string }>();
-  const { mutate: updateBetaTester, isPending } = useUpdateBetaTesters(courseId);
+  // Using mutateAsync avoids mutate callbacks being discarded on useEffect re-runs
+  const { mutateAsync: updateBetaTester, isPending } = useUpdateBetaTesters(courseId);
   const { addAlert, showModal } = useAlert();
+  // Avoid duplicate calls to mutate
+  const hasFired = useRef(false);
 
-  const handleUpdateBetaTester = useCallback(() => {
-    updateBetaTester({
-      identifier: [learner.username],
-      action: learner.isBetaTester ? 'remove' : 'add',
-    }, {
-      onSuccess: (data) => {
-        const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
-        const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
-        if (failedUsernames.length > 0) {
-          addAlert({
-            type: 'danger',
-            message: intl.formatMessage(messages.failedBetaTesters),
-            extraContent: (
-              failedUsernames.map((learner: string) => (
-                <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
-              ))
-            )
-          });
-        }
-        if (inactiveUsernames.length > 0) {
-          addAlert({
-            type: 'warning',
-            message: intl.formatMessage(messages.inactiveUsers),
-            extraContent: (
-              inactiveUsernames.map((learner: string) => (
-                <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
-              ))
-            )
-          });
-        }
-      },
-      onError: () => {
-        showModal({
-          message: learner.isBetaTester ? intl.formatMessage(messages.removeBetaTesterError) : intl.formatMessage(messages.addBetaTesterError),
-          variant: 'danger',
-          confirmText: intl.formatMessage(messages.closeButton),
+  const handleUpdateBetaTester = useCallback(async () => {
+    try {
+      const data = await updateBetaTester({
+        identifier: [learner.username],
+        action: learner.isBetaTester ? 'remove' : 'add',
+      });
+      const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];
+      const inactiveUsernames = data.results?.filter(user => !user.isActive && user.isActive !== null && !user.userDoesNotExist).map(user => user.identifier) || [];
+      if (failedUsernames.length > 0) {
+        addAlert({
+          type: 'danger',
+          message: intl.formatMessage(messages.failedBetaTesters),
+          extraContent: (
+            failedUsernames.map((learner: string) => (
+              <p key={learner} className="mb-0">• {intl.formatMessage(messages.unknownLearner, { learner })}</p>
+            ))
+          )
         });
       }
-    });
-
-    onClose();
-  }, [updateBetaTester, learner.username, learner.isBetaTester, addAlert, intl, showModal, onClose]);
+      if (inactiveUsernames.length > 0) {
+        addAlert({
+          type: 'warning',
+          message: intl.formatMessage(messages.inactiveUsers),
+          extraContent: (
+            inactiveUsernames.map((learner: string) => (
+              <p key={learner} className="mb-0">• {intl.formatMessage(messages.inactiveLearner, { learner })}</p>
+            ))
+          )
+        });
+      }
+      onClose();
+    } catch {
+      showModal({
+        message: learner.isBetaTester ? intl.formatMessage(messages.removeBetaTesterError) : intl.formatMessage(messages.addBetaTesterError),
+        variant: 'danger',
+        confirmText: intl.formatMessage(messages.closeButton),
+      });
+    }
+  }, [updateBetaTester, learner, addAlert, intl, showModal, onClose]);
 
   useEffect(() => {
-    if (isOpen && !learner.isBetaTester) {
+    if (isOpen && !learner.isBetaTester && !hasFired.current) {
+      hasFired.current = true;
       handleUpdateBetaTester();
     }
   }, [handleUpdateBetaTester, isOpen, learner.isBetaTester]);


### PR DESCRIPTION
## Description
Alert wasn't getting triggered correctly on grant beta tester role, due to useEffect, resolve of the promise was lost due to re-render

## Other information
Related to https://github.com/openedx/frontend-app-instructor-dashboard/issues/161
<img width="1450" height="262" alt="Screenshot 2026-05-08 at 4 51 04 p m" src="https://github.com/user-attachments/assets/4b47785d-8dc5-42a4-83b3-3cf4624fb2ac" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
