### PR TITLE
feat: add actions to attempts and fix missing attributes on table

### DIFF
--- a/src/specialExams/SpecialExamsPage.test.tsx
+++ b/src/specialExams/SpecialExamsPage.test.tsx
@@ -10,9 +10,9 @@ jest.mock('./components/Allowances', () => {
   }
   return MockedAllowances;
 });
-jest.mock('./components/AttemptsList', () => {
+jest.mock('./components/Attempts', () => {
   function MockedAttemptsList() {
-    return <div>AttemptsList Component</div>;
+    return <div>Attempts Component</div>;
   }
   return MockedAttemptsList;
 });
@@ -26,7 +26,7 @@ describe('SpecialExamsPage', () => {
   it('renders the attempts tab and its content by default', () => {
     renderWithIntl(<SpecialExamsPage />);
     expect(screen.getByText('Exam Attempts')).toBeInTheDocument();
-    expect(screen.getByText('AttemptsList Component')).toBeInTheDocument();
+    expect(screen.getByText('Attempts Component')).toBeInTheDocument();
     expect(screen.queryByText('Allowances Component')).not.toBeInTheDocument();
   });
 
@@ -43,7 +43,7 @@ describe('SpecialExamsPage', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Allowances'));
     await user.click(screen.getByText('Exam Attempts'));
-    expect(screen.getByText('AttemptsList Component')).toBeInTheDocument();
+    expect(screen.getByText('Attempts Component')).toBeInTheDocument();
     expect(screen.queryByText('Allowances Component')).not.toBeInTheDocument();
   });
 

--- a/src/specialExams/SpecialExamsPage.tsx
+++ b/src/specialExams/SpecialExamsPage.tsx
@@ -3,7 +3,7 @@ import { useIntl } from '@openedx/frontend-base';
 import { Button, ButtonGroup, Card } from '@openedx/paragon';
 import messages from './messages';
 import Allowances from './components/Allowances';
-import AttemptsList from './components/AttemptsList';
+import Attempts from './components/Attempts';
 
 const SPECIAL_EXAMS_TAB = {
   ATTEMPTS: 'attempts',
@@ -31,7 +31,7 @@ const SpecialExamsPage = () => {
           </Button>
         </ButtonGroup>
         {
-          selectedTab === SPECIAL_EXAMS_TAB.ATTEMPTS ? <AttemptsList /> : <Allowances />
+          selectedTab === SPECIAL_EXAMS_TAB.ATTEMPTS ? <Attempts /> : <Allowances />
         }
       </Card>
     </>

--- a/src/specialExams/components/Attempts.test.tsx
+++ b/src/specialExams/components/Attempts.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AxiosError } from 'axios';
 import Attempts from './Attempts';
-import { useAttempts, useResetAttempt } from '../data/apiHook';
+import { useAttempts, useResetAttempt, useResumeAttempt } from '../data/apiHook';
 import { Attempt } from '../types';
 import { renderWithAlertAndIntl } from '@src/testUtils';
 import messages from '../messages';
@@ -15,44 +15,86 @@ jest.mock('react-router-dom', () => ({
 jest.mock('../data/apiHook', () => ({
   useAttempts: jest.fn(),
   useResetAttempt: jest.fn(),
+  useResumeAttempt: jest.fn(),
 }));
 
-const mockAttempt: Attempt = {
+const mockAttempts: Attempt[] = [{
   id: 1,
-  user: { username: 'testuser' },
+  user: { username: 'testuser', id: 1 },
   examId: 42,
   examName: 'Midterm Exam',
   allowedTimeLimitMins: 60,
-  type: 'proctored',
+  examType: 'proctored',
   startTime: '2024-01-01T00:00:00Z',
   endTime: '2024-01-01T01:00:00Z',
   status: 'started',
   readyToResume: false,
-};
+}, {
+  id: 2,
+  user: { username: 'testuser2', id: 2 },
+  examId: 43,
+  examName: 'Final Exam',
+  allowedTimeLimitMins: 120,
+  examType: 'proctored',
+  startTime: '2024-01-02T00:00:00Z',
+  endTime: null,
+  status: 'error',
+  readyToResume: false,
+},
+{
+  id: 3,
+  user: { username: 'testuser3', id: 3 },
+  examId: 44,
+  examName: 'Quiz',
+  allowedTimeLimitMins: 30,
+  examType: 'timed',
+  startTime: '2024-01-03T00:00:00Z',
+  endTime: null,
+  status: 'error',
+  readyToResume: true,
+}
+];
 
 describe('Attempts', () => {
   const mockResetAttempt = jest.fn();
+  const mockResumeAttempt = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useResetAttempt as jest.Mock).mockReturnValue({ mutate: mockResetAttempt });
+    (useResumeAttempt as jest.Mock).mockReturnValue({ mutate: mockResumeAttempt });
     (useAttempts as jest.Mock).mockReturnValue({
-      data: { results: [mockAttempt] },
+      data: { results: mockAttempts },
       isLoading: false,
       isError: false,
     });
   });
 
-  const clickReset = async () => {
-    const actionsButton = screen.getByRole('button', { name: messages.actions.defaultMessage });
-    await userEvent.click(actionsButton);
+  const clickReset = async (index = 0) => {
+    const actionsButton = screen.getAllByRole('button', { name: messages.actions.defaultMessage });
+    await userEvent.click(actionsButton[index]);
     const resetButton = screen.getByRole('button', { name: messages.reset.defaultMessage });
     await userEvent.click(resetButton);
+    const confirmationModal = screen.getByRole('dialog', { name: messages.confirmationModal.defaultMessage });
+    expect(confirmationModal).toBeInTheDocument();
+    const confirmReset = screen.getByRole('button', { name: messages.reset.defaultMessage });
+    await userEvent.click(confirmReset);
+  };
+
+  const clickResume = async (index = 0) => {
+    const actionsButton = screen.getAllByRole('button', { name: messages.actions.defaultMessage });
+    await userEvent.click(actionsButton[index]);
+    const resumeButton = screen.getByRole('button', { name: messages.resume.defaultMessage });
+    await userEvent.click(resumeButton);
+    const confirmationModal = screen.getByRole('dialog', { name: messages.confirmationModal.defaultMessage });
+    expect(confirmationModal).toBeInTheDocument();
+    const confirmResume = screen.getByRole('button', { name: messages.resume.defaultMessage });
+    await userEvent.click(confirmResume);
   };
 
   it('renders AttemptsList component', () => {
     renderWithAlertAndIntl(<Attempts />);
-    const usernameCell = screen.getByRole('cell', { name: mockAttempt.user.username });
+    const usernameCell = screen.getByRole('cell', { name: mockAttempts[0].user.username });
     expect(usernameCell).toBeInTheDocument();
   });
 
@@ -82,7 +124,7 @@ describe('Attempts', () => {
     renderWithAlertAndIntl(<Attempts />);
     await clickReset();
 
-    const successMessage = screen.getByText(messages.successOnReset.defaultMessage.replace('{student}', mockAttempt.user.username).replace('{examName}', mockAttempt.examName));
+    const successMessage = screen.getByText(messages.successOnReset.defaultMessage.replace('{student}', mockAttempts[0].user.username).replace('{examName}', mockAttempts[0].examName));
 
     await waitFor(() => {
       expect(successMessage).toBeInTheDocument();
@@ -124,6 +166,84 @@ describe('Attempts', () => {
 
     await waitFor(() => {
       expect(screen.getByText(messages.errorOnReset.defaultMessage)).toBeInTheDocument();
+    });
+    expect(screen.getByText(messages.close.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('calls useResumeAttempt with courseId from route params', () => {
+    renderWithAlertAndIntl(<Attempts />);
+    expect(useResumeAttempt).toHaveBeenCalledWith('course-v1:edX+Test+2024');
+  });
+
+  it('calls resumeAttempt with attemptId and userId when onResume is triggered', async () => {
+    renderWithAlertAndIntl(<Attempts />);
+    const studentIndexToTest = 1;
+    await clickResume(studentIndexToTest);
+
+    expect(mockResumeAttempt).toHaveBeenCalledWith(
+      { attemptId: mockAttempts[studentIndexToTest].id, userId: mockAttempts[studentIndexToTest].user.id },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it('shows a success toast when resume succeeds', async () => {
+    mockResumeAttempt.mockImplementation((_params, options) => {
+      options.onSuccess();
+    });
+
+    renderWithAlertAndIntl(<Attempts />);
+    const studentIndexToTest = 1;
+    await clickResume(studentIndexToTest);
+
+    const successMessage = screen.getByText(messages.successOnResume.defaultMessage.replace('{student}', mockAttempts[studentIndexToTest].user.username));
+
+    await waitFor(() => {
+      expect(successMessage).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error modal with API detail when resume fails with AxiosError', async () => {
+    const axiosError = new AxiosError('Request failed');
+    axiosError.response = {
+      data: { detail: 'Cannot resume this attempt.' },
+      status: 400,
+      statusText: 'Bad Request',
+      headers: {},
+      config: {} as any,
+    };
+
+    mockResumeAttempt.mockImplementation((_params, options) => {
+      options.onError(axiosError);
+    });
+
+    renderWithAlertAndIntl(<Attempts />);
+
+    const studentIndexToTest = 1;
+    await clickResume(studentIndexToTest);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cannot resume this attempt.')).toBeInTheDocument();
+    });
+    expect(screen.getByText(messages.close.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('shows a generic error modal when resume fails with a non-Axios error', async () => {
+    const genericError = new Error('Something went wrong');
+
+    mockResumeAttempt.mockImplementation((_params, options) => {
+      options.onError(genericError);
+    });
+
+    renderWithAlertAndIntl(<Attempts />);
+
+    const studentIndexToTest = 1;
+    await clickResume(studentIndexToTest);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.errorOnResume.defaultMessage)).toBeInTheDocument();
     });
     expect(screen.getByText(messages.close.defaultMessage)).toBeInTheDocument();
   });

--- a/src/specialExams/components/Attempts.test.tsx
+++ b/src/specialExams/components/Attempts.test.tsx
@@ -1,9 +1,10 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { AxiosError } from 'axios';
 import Attempts from './Attempts';
 import { useAttempts, useResetAttempt } from '../data/apiHook';
 import { Attempt } from '../types';
-import { renderWithIntl } from '@src/testUtils';
+import { renderWithAlertAndIntl } from '@src/testUtils';
 import messages from '../messages';
 
 jest.mock('react-router-dom', () => ({
@@ -42,27 +43,88 @@ describe('Attempts', () => {
     });
   });
 
+  const clickReset = async () => {
+    const actionsButton = screen.getByRole('button', { name: messages.actions.defaultMessage });
+    await userEvent.click(actionsButton);
+    const resetButton = screen.getByRole('button', { name: messages.reset.defaultMessage });
+    await userEvent.click(resetButton);
+  };
+
   it('renders AttemptsList component', () => {
-    renderWithIntl(<Attempts />);
+    renderWithAlertAndIntl(<Attempts />);
     const usernameCell = screen.getByRole('cell', { name: mockAttempt.user.username });
     expect(usernameCell).toBeInTheDocument();
   });
 
   it('calls useResetAttempt with courseId from route params', () => {
-    renderWithIntl(<Attempts />);
+    renderWithAlertAndIntl(<Attempts />);
     expect(useResetAttempt).toHaveBeenCalledWith('course-v1:edX+Test+2024');
   });
 
   it('calls resetAttempt with username and examId when onReset is triggered', async () => {
-    renderWithIntl(<Attempts />);
-    const actionsButton = screen.getByRole('button', { name: messages.actions.defaultMessage });
-    await userEvent.click(actionsButton);
-    const resetButton = screen.getByRole('button', { name: messages.reset.defaultMessage });
-    await userEvent.click(resetButton);
+    renderWithAlertAndIntl(<Attempts />);
+    await clickReset();
 
-    expect(mockResetAttempt).toHaveBeenCalledWith({
-      username: 'testuser',
-      examId: 42,
+    expect(mockResetAttempt).toHaveBeenCalledWith(
+      { username: 'testuser', examId: 42 },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it('shows a success toast when reset succeeds', async () => {
+    mockResetAttempt.mockImplementation((_params, options) => {
+      options.onSuccess();
     });
+
+    renderWithAlertAndIntl(<Attempts />);
+    await clickReset();
+
+    const successMessage = screen.getByText(messages.successOnReset.defaultMessage.replace('{student}', mockAttempt.user.username).replace('{examName}', mockAttempt.examName));
+
+    await waitFor(() => {
+      expect(successMessage).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error modal with API detail when reset fails with AxiosError', async () => {
+    const axiosError = new AxiosError('Request failed');
+    axiosError.response = {
+      data: { detail: 'Student has no active attempt.' },
+      status: 400,
+      statusText: 'Bad Request',
+      headers: {},
+      config: {} as any,
+    };
+
+    mockResetAttempt.mockImplementation((_params, options) => {
+      options.onError(axiosError);
+    });
+
+    renderWithAlertAndIntl(<Attempts />);
+    await clickReset();
+
+    await waitFor(() => {
+      expect(screen.getByText('Student has no active attempt.')).toBeInTheDocument();
+    });
+    expect(screen.getByText(messages.close.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('shows a generic error modal when reset fails with a non-Axios error', async () => {
+    const genericError = new Error('Something went wrong');
+
+    mockResetAttempt.mockImplementation((_params, options) => {
+      options.onError(genericError);
+    });
+
+    renderWithAlertAndIntl(<Attempts />);
+    await clickReset();
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.errorOnReset.defaultMessage)).toBeInTheDocument();
+    });
+    expect(screen.getByText(messages.close.defaultMessage)).toBeInTheDocument();
   });
 });

--- a/src/specialExams/components/Attempts.test.tsx
+++ b/src/specialExams/components/Attempts.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Attempts from './Attempts';
+import { useAttempts, useResetAttempt } from '../data/apiHook';
+import { Attempt } from '../types';
+import { renderWithIntl } from '@src/testUtils';
+import messages from '../messages';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useAttempts: jest.fn(),
+  useResetAttempt: jest.fn(),
+}));
+
+const mockAttempt: Attempt = {
+  id: 1,
+  user: { username: 'testuser' },
+  examId: 42,
+  examName: 'Midterm Exam',
+  allowedTimeLimitMins: 60,
+  type: 'proctored',
+  startTime: '2024-01-01T00:00:00Z',
+  endTime: '2024-01-01T01:00:00Z',
+  status: 'started',
+  readyToResume: false,
+};
+
+describe('Attempts', () => {
+  const mockResetAttempt = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useResetAttempt as jest.Mock).mockReturnValue({ mutate: mockResetAttempt });
+    (useAttempts as jest.Mock).mockReturnValue({
+      data: { results: [mockAttempt] },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it('renders AttemptsList component', () => {
+    renderWithIntl(<Attempts />);
+    const usernameCell = screen.getByRole('cell', { name: mockAttempt.user.username });
+    expect(usernameCell).toBeInTheDocument();
+  });
+
+  it('calls useResetAttempt with courseId from route params', () => {
+    renderWithIntl(<Attempts />);
+    expect(useResetAttempt).toHaveBeenCalledWith('course-v1:edX+Test+2024');
+  });
+
+  it('calls resetAttempt with username and examId when onReset is triggered', async () => {
+    renderWithIntl(<Attempts />);
+    const actionsButton = screen.getByRole('button', { name: messages.actions.defaultMessage });
+    await userEvent.click(actionsButton);
+    const resetButton = screen.getByRole('button', { name: messages.reset.defaultMessage });
+    await userEvent.click(resetButton);
+
+    expect(mockResetAttempt).toHaveBeenCalledWith({
+      username: 'testuser',
+      examId: 42,
+    });
+  });
+});

--- a/src/specialExams/components/Attempts.tsx
+++ b/src/specialExams/components/Attempts.tsx
@@ -1,24 +1,41 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { isAxiosError } from 'axios';
-import { Attempt } from '../types';
-import AttemptsList from './AttemptsList';
-import { useResetAttempt } from '../data/apiHook';
-import messages from '../messages';
-import { useAlert } from '@src/providers/AlertProvider';
 import { useIntl } from '@openedx/frontend-base';
+import { ActionRow, Button, ModalDialog, useToggle } from '@openedx/paragon';
+import AttemptsList from '@src/specialExams/components/AttemptsList';
+import { useResetAttempt, useResumeAttempt } from '@src/specialExams/data/apiHook';
+import messages from '@src/specialExams/messages';
+import { Attempt, AttemptAction } from '@src/specialExams/types';
+import { useAlert } from '@src/providers/AlertProvider';
 
 const Attempts = () => {
   const { courseId = '' } = useParams<{ courseId: string }>();
   const intl = useIntl();
   const { mutate: resetAttempt } = useResetAttempt(courseId);
+  const { mutate: resumeAttempt } = useResumeAttempt(courseId);
   const { showModal, showToast } = useAlert();
+  const [isOpenConfirmationModal, openConfirmationModal, closeConfirmationModal] = useToggle(false);
+  const [attemptAction, setAttemptAction] = useState<AttemptAction>('reset');
+  const [attempt, setAttempt] = useState<Attempt | null>(null);
 
-  const handleResume = (attempt: Attempt) => {
-    // Implement resume logic here
-    console.log('Resume attempt:', courseId, attempt);
+  const handleResume = () => {
+    if (!attempt) return;
+    const { user, id } = attempt;
+    resumeAttempt({ attemptId: id, userId: user.id }, {
+      onSuccess: () => {
+        showToast(intl.formatMessage(messages.successOnResume, { student: attempt.user.username }));
+      },
+      onError: (error) => {
+        const errorMessage = (isAxiosError(error) && error?.response?.data?.detail) || intl.formatMessage(messages.errorOnResume);
+        showModal({ variant: 'danger', message: errorMessage, confirmText: intl.formatMessage(messages.close) });
+      }
+    });
+    closeConfirmationModal();
   };
 
-  const handleReset = (attempt: Attempt) => {
+  const handleReset = () => {
+    if (!attempt) return;
     const { user, examId, examName } = attempt;
     resetAttempt({ username: user.username, examId }, {
       onSuccess: () => {
@@ -26,13 +43,51 @@ const Attempts = () => {
       },
       onError: (error) => {
         const errorMessage = (isAxiosError(error) && error?.response?.data?.detail) || intl.formatMessage(messages.errorOnReset, { examName, student: user.username });
-        showModal({ message: errorMessage, confirmText: intl.formatMessage(messages.close) });
+        showModal({ variant: 'danger', message: errorMessage, confirmText: intl.formatMessage(messages.close) });
       }
     });
+    closeConfirmationModal();
+  };
+
+  const openAndSetConfirmationModal = (action: AttemptAction, attempt: Attempt) => {
+    openConfirmationModal();
+    setAttemptAction(action);
+    setAttempt(attempt);
   };
 
   return (
-    <AttemptsList onResume={handleResume} onReset={handleReset} />
+    <>
+      <AttemptsList
+        onResume={(attempt: Attempt) => openAndSetConfirmationModal('resume', attempt)}
+        onReset={(attempt: Attempt) => openAndSetConfirmationModal('reset', attempt)}
+      />
+      { attempt && (
+        <ModalDialog
+          title={intl.formatMessage(messages.confirmationModal)}
+          isOpen={isOpenConfirmationModal}
+          onClose={closeConfirmationModal}
+          isOverflowVisible={false}
+          hasCloseButton={false}
+        >
+          <ModalDialog.Body>
+            {attemptAction === 'reset' ? intl.formatMessage(messages.confirmationMessageReset) : intl.formatMessage(messages.confirmationMessageResume)}
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <ActionRow>
+              <Button variant="tertiary" onClick={closeConfirmationModal}>
+                {intl.formatMessage(messages.cancel)}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => attemptAction === 'reset' ? handleReset() : handleResume()}
+              >
+                {attemptAction === 'reset' ? intl.formatMessage(messages.reset) : intl.formatMessage(messages.resume)}
+              </Button>
+            </ActionRow>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      )}
+    </>
   );
 };
 

--- a/src/specialExams/components/Attempts.tsx
+++ b/src/specialExams/components/Attempts.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router-dom';
+import { Attempt } from '../types';
+import AttemptsList from './AttemptsList';
+import { useResetAttempt } from '../data/apiHook';
+
+const Attempts = () => {
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { mutate: resetAttempt } = useResetAttempt(courseId);
+
+  const handleResume = (attempt: Attempt) => {
+    // Implement resume logic here
+    console.log('Resume attempt:', courseId, attempt);
+  };
+
+  const handleReset = (attempt: Attempt) => {
+    const { user, examId } = attempt;
+    resetAttempt({ username: user.username, examId });
+  };
+
+  return (
+    <AttemptsList onResume={handleResume} onReset={handleReset} />
+  );
+};
+
+export default Attempts;

--- a/src/specialExams/components/Attempts.tsx
+++ b/src/specialExams/components/Attempts.tsx
@@ -1,11 +1,17 @@
 import { useParams } from 'react-router-dom';
+import { isAxiosError } from 'axios';
 import { Attempt } from '../types';
 import AttemptsList from './AttemptsList';
 import { useResetAttempt } from '../data/apiHook';
+import messages from '../messages';
+import { useAlert } from '@src/providers/AlertProvider';
+import { useIntl } from '@openedx/frontend-base';
 
 const Attempts = () => {
   const { courseId = '' } = useParams<{ courseId: string }>();
+  const intl = useIntl();
   const { mutate: resetAttempt } = useResetAttempt(courseId);
+  const { showModal, showToast } = useAlert();
 
   const handleResume = (attempt: Attempt) => {
     // Implement resume logic here
@@ -13,8 +19,16 @@ const Attempts = () => {
   };
 
   const handleReset = (attempt: Attempt) => {
-    const { user, examId } = attempt;
-    resetAttempt({ username: user.username, examId });
+    const { user, examId, examName } = attempt;
+    resetAttempt({ username: user.username, examId }, {
+      onSuccess: () => {
+        showToast(intl.formatMessage(messages.successOnReset, { examName, student: user.username }));
+      },
+      onError: (error) => {
+        const errorMessage = (isAxiosError(error) && error?.response?.data?.detail) || intl.formatMessage(messages.errorOnReset, { examName, student: user.username });
+        showModal({ message: errorMessage, confirmText: intl.formatMessage(messages.close) });
+      }
+    });
   };
 
   return (

--- a/src/specialExams/components/AttemptsList.test.tsx
+++ b/src/specialExams/components/AttemptsList.test.tsx
@@ -16,8 +16,10 @@ jest.mock('../data/apiHook', () => ({
 const mockExamAttempts = {
   results: [
     {
+      id: 1,
       user: {
         username: 'user1',
+        id: 1,
       },
       examName: 'Midterm',
       allowedTimeLimitMins: 60,
@@ -25,6 +27,31 @@ const mockExamAttempts = {
       startTime: '2024-01-01',
       endTime: '2024-01-02',
       status: 'completed',
+      readyToResume: false,
+    },
+    {
+      id: 2,
+      user: { username: 'testuser2', id: 2 },
+      examId: 43,
+      examName: 'Final Exam',
+      allowedTimeLimitMins: 120,
+      examType: 'timed',
+      startTime: '2024-01-03T00:00:00Z',
+      endTime: null,
+      status: 'error',
+      readyToResume: false,
+    },
+    {
+      id: 3,
+      user: { username: 'testuser3', id: 3 },
+      examId: 44,
+      examName: 'Quiz',
+      allowedTimeLimitMins: 30,
+      examType: 'timed',
+      startTime: '2024-01-04T00:00:00Z',
+      endTime: null,
+      status: 'error',
+      readyToResume: true,
     },
   ],
   count: 1,
@@ -105,5 +132,44 @@ describe('AttemptsList', () => {
 
     renderComponent();
     expect(useAttempts).toHaveBeenCalledWith('course-v1:edX+Test+2024', expect.any(Object));
+  });
+
+  describe('Resume option visibility', () => {
+    beforeEach(() => {
+      (useAttempts as jest.Mock).mockReturnValue({
+        data: mockExamAttempts,
+        isLoading: false,
+      });
+    });
+
+    it('does not show Resume option when status is not "error"', async () => {
+      renderComponent();
+
+      const user = userEvent.setup();
+      const actionsButton = screen.getAllByRole('button', { name: 'Actions' });
+      await user.click(actionsButton[0]);
+
+      expect(screen.queryByText('Resume')).not.toBeInTheDocument();
+    });
+
+    it('shows Resume option when status is "error" and readyToResume is false', async () => {
+      renderComponent();
+
+      const user = userEvent.setup();
+      const actionsButton = screen.getAllByRole('button', { name: 'Actions' });
+      await user.click(actionsButton[1]);
+
+      expect(screen.getByText('Resume')).toBeInTheDocument();
+    });
+
+    it('does not show Resume option when readyToResume is true', async () => {
+      renderComponent();
+
+      const user = userEvent.setup();
+      const actionsButton = screen.getAllByRole('button', { name: 'Actions' });
+      await user.click(actionsButton[2]);
+
+      expect(screen.queryByText('Resume')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/specialExams/components/AttemptsList.test.tsx
+++ b/src/specialExams/components/AttemptsList.test.tsx
@@ -21,7 +21,7 @@ const mockExamAttempts = {
       },
       examName: 'Midterm',
       allowedTimeLimitMins: 60,
-      type: 'proctored',
+      examType: 'proctored',
       startTime: '2024-01-01',
       endTime: '2024-01-02',
       status: 'completed',
@@ -35,6 +35,10 @@ describe('AttemptsList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+  const mockReset = jest.fn();
+  const mockResume = jest.fn();
+
+  const renderComponent = () => renderWithIntl(<AttemptsList onReset={mockReset} onResume={mockResume} />);
 
   it('renders DataTable with correct columns and empty data', () => {
     (useAttempts as jest.Mock).mockReturnValue({
@@ -42,7 +46,7 @@ describe('AttemptsList', () => {
       isLoading: false,
     });
 
-    renderWithIntl(<AttemptsList />);
+    renderComponent();
 
     expect(screen.getByText('No exam attempts found')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Search By Username or Email')).toBeInTheDocument();
@@ -54,7 +58,7 @@ describe('AttemptsList', () => {
       isLoading: true,
     });
 
-    renderWithIntl(<AttemptsList />);
+    renderComponent();
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
@@ -64,13 +68,13 @@ describe('AttemptsList', () => {
       isLoading: false,
     });
 
-    renderWithIntl(<AttemptsList />);
+    renderComponent();
     expect(screen.getByText(mockExamAttempts.results[0].user.username)).toBeInTheDocument();
     expect(screen.getByText(mockExamAttempts.results[0].examName)).toBeInTheDocument();
     expect(screen.getByText(mockExamAttempts.results[0].allowedTimeLimitMins.toString())).toBeInTheDocument();
-    expect(screen.getByText(mockExamAttempts.results[0].type)).toBeInTheDocument();
-    expect(screen.getByText(mockExamAttempts.results[0].startTime)).toBeInTheDocument();
-    expect(screen.getByText(mockExamAttempts.results[0].endTime)).toBeInTheDocument();
+    expect(screen.getByText(mockExamAttempts.results[0].examType)).toBeInTheDocument();
+    expect(screen.getByText(/01\/01\/2024.*UTC/)).toBeInTheDocument();
+    expect(screen.getByText(/01\/02\/2024.*UTC/)).toBeInTheDocument();
     expect(screen.getByText(mockExamAttempts.results[0].status)).toBeInTheDocument();
   });
 
@@ -80,7 +84,7 @@ describe('AttemptsList', () => {
       isLoading: false,
     });
 
-    renderWithIntl(<AttemptsList />);
+    renderComponent();
 
     const input = screen.getByRole('textbox');
     const user = userEvent.setup();
@@ -99,7 +103,7 @@ describe('AttemptsList', () => {
       isLoading: false,
     });
 
-    renderWithIntl(<AttemptsList />);
+    renderComponent();
     expect(useAttempts).toHaveBeenCalledWith('course-v1:edX+Test+2024', expect.any(Object));
   });
 });

--- a/src/specialExams/components/AttemptsList.tsx
+++ b/src/specialExams/components/AttemptsList.tsx
@@ -1,15 +1,22 @@
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
-import { DataTable } from '@openedx/paragon';
+import { DataTable, IconButton, OverlayTrigger, Popover } from '@openedx/paragon';
+import { MoreVert } from '@openedx/paragon/icons';
 import UsernameFilter from '@src/components/UsernameFilter';
-import messages from '@src/specialExams/messages';
 import { useAttempts } from '@src/specialExams/data/apiHook';
-import { DataTableFetchDataProps } from '@src/types';
+import messages from '@src/specialExams/messages';
+import { Attempt } from '@src/specialExams/types';
+import { DataTableFetchDataProps, TableCellValue } from '@src/types';
 
 export const ATTEMPTS_PAGE_SIZE = 25;
 
-const AttemptsList = () => {
+interface AttemptsListProps {
+  onResume: (attempt: Attempt) => void,
+  onReset: (attempt: Attempt) => void,
+}
+
+const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
   const intl = useIntl();
   const { courseId = '' } = useParams();
   const [filters, setFilters] = useState({ page: 0, emailOrUsername: '', ordering: '' });
@@ -18,15 +25,106 @@ const AttemptsList = () => {
     pageSize: ATTEMPTS_PAGE_SIZE
   });
 
+  const ActionCustomCell = ({ row: { original } }: TableCellValue<Attempt>) => {
+    const popoverContent = (
+      <Popover
+        id={`popover-${original.user.username}-${original.examName}`}
+        className="border-0 shadow-sm"
+      >
+        <Popover.Content className="p-0 border-0">
+          <div className="dropdown-menu show position-static border shadow-sm">
+            <button
+              type="button"
+              className="dropdown-item"
+              onClick={() => original.readyToResume ? onResume(original) : onReset(original)}
+            >
+              {original.readyToResume ? intl.formatMessage(messages.resume) : intl.formatMessage(messages.reset)}
+            </button>
+          </div>
+        </Popover.Content>
+      </Popover>
+    );
+    return (
+      <>
+        <OverlayTrigger
+          trigger="click"
+          placement="bottom-end"
+          overlay={popoverContent}
+          rootClose
+        >
+          <IconButton
+            alt={intl.formatMessage(messages.actions)}
+            className="lead"
+            iconAs={MoreVert}
+          />
+        </OverlayTrigger>
+      </>
+    );
+  };
+
   const columns = useMemo(() => [
     { accessor: 'user.username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter, },
     { accessor: 'examName', Header: intl.formatMessage(messages.examName), disableFilters: true, },
     { accessor: 'allowedTimeLimitMins', Header: intl.formatMessage(messages.timeLimit), disableFilters: true, },
-    { accessor: 'type', Header: intl.formatMessage(messages.type), disableFilters: true, },
-    { accessor: 'startTime', Header: intl.formatMessage(messages.startedAt), disableFilters: true, },
-    { accessor: 'endTime', Header: intl.formatMessage(messages.completedAt), disableFilters: true, },
-    { accessor: 'status', Header: intl.formatMessage(messages.status), disableFilters: true, },
+    {
+      accessor: 'examType',
+      Cell: ({ row }: TableCellValue<any>) => <span className="text-capitalize">{row.original.examType}</span>,
+      disableFilters: true,
+      Header: intl.formatMessage(messages.type),
+    },
+    {
+      accessor: 'startTime',
+      Cell: ({ row }: TableCellValue<any>) => (
+        <span>{ row.original.startTime ? `${intl.formatDate(new Date(row.original.startTime), {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: 'UTC',
+        })} UTC` : ''}
+        </span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.startedAt),
+    },
+    {
+      accessor: 'endTime',
+      Cell: ({ row }: TableCellValue<any>) => (
+        <span>{row.original.endTime ? `${intl.formatDate(new Date(row.original.endTime), {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: 'UTC',
+        })} UTC` : ''}
+        </span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.completedAt),
+    },
+    {
+      accessor: 'status',
+      Cell: ({ row }: TableCellValue<any>) => <span className="text-capitalize">{row.original.status}</span>,
+      disableFilters: true,
+      Header: intl.formatMessage(messages.status),
+    },
+    {
+      accessor: 'readyToResume',
+      Cell: ({ row }: TableCellValue<any>) => (
+        <span className="text-capitalize">{row.original.readyToResume ? intl.formatMessage(messages.true) : ''}</span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.readyForResume),
+    }
   ], [intl]);
+
+  const additionalColumns = [{
+    id: 'actions',
+    Header: '',
+    Cell: ActionCustomCell,
+  }];
 
   const handleFetchData = (data: DataTableFetchDataProps) => {
     const emailOrUsernameFilter = data.filters?.find((f) => f.id === 'user.username');
@@ -44,6 +142,7 @@ const AttemptsList = () => {
 
   return (
     <DataTable
+      additionalColumns={additionalColumns}
       className="mt-3"
       columns={columns}
       data={data.results}

--- a/src/specialExams/components/AttemptsList.tsx
+++ b/src/specialExams/components/AttemptsList.tsx
@@ -6,7 +6,7 @@ import { MoreVert } from '@openedx/paragon/icons';
 import UsernameFilter from '@src/components/UsernameFilter';
 import { useAttempts } from '@src/specialExams/data/apiHook';
 import messages from '@src/specialExams/messages';
-import { Attempt } from '@src/specialExams/types';
+import { Attempt, AttemptAction } from '@src/specialExams/types';
 import { DataTableFetchDataProps, TableCellValue } from '@src/types';
 
 export const ATTEMPTS_PAGE_SIZE = 25;
@@ -26,6 +26,17 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
   });
 
   const ActionCustomCell = ({ row: { original } }: TableCellValue<Attempt>) => {
+    const [showPopover, setShowPopover] = useState(false);
+
+    const handleAction = (action: AttemptAction) => {
+      setShowPopover(false);
+      if (action === 'resume') {
+        onResume(original);
+      } else {
+        onReset(original);
+      }
+    };
+
     const popoverContent = (
       <Popover
         id={`popover-${original.user.username}-${original.examName}`}
@@ -36,10 +47,19 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
             <button
               type="button"
               className="dropdown-item"
-              onClick={() => original.readyToResume ? onResume(original) : onReset(original)}
+              onClick={() => handleAction('reset')}
             >
-              {original.readyToResume ? intl.formatMessage(messages.resume) : intl.formatMessage(messages.reset)}
+              {intl.formatMessage(messages.reset)}
             </button>
+            {!original.readyToResume && original.status === 'error' && (
+              <button
+                type="button"
+                className="dropdown-item"
+                onClick={() => handleAction('resume')}
+              >
+                {intl.formatMessage(messages.resume)}
+              </button>
+            )}
           </div>
         </Popover.Content>
       </Popover>
@@ -51,6 +71,8 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
           placement="bottom-end"
           overlay={popoverContent}
           rootClose
+          show={showPopover}
+          onToggle={setShowPopover}
         >
           <IconButton
             alt={intl.formatMessage(messages.actions)}
@@ -68,13 +90,13 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
     { accessor: 'allowedTimeLimitMins', Header: intl.formatMessage(messages.timeLimit), disableFilters: true, },
     {
       accessor: 'examType',
-      Cell: ({ row }: TableCellValue<any>) => <span className="text-capitalize">{row.original.examType}</span>,
+      Cell: ({ row }: TableCellValue<Attempt>) => <span className="text-capitalize">{row.original.examType}</span>,
       disableFilters: true,
       Header: intl.formatMessage(messages.type),
     },
     {
       accessor: 'startTime',
-      Cell: ({ row }: TableCellValue<any>) => (
+      Cell: ({ row }: TableCellValue<Attempt>) => (
         <span>{ row.original.startTime ? `${intl.formatDate(new Date(row.original.startTime), {
           year: 'numeric',
           month: '2-digit',
@@ -90,7 +112,7 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
     },
     {
       accessor: 'endTime',
-      Cell: ({ row }: TableCellValue<any>) => (
+      Cell: ({ row }: TableCellValue<Attempt>) => (
         <span>{row.original.endTime ? `${intl.formatDate(new Date(row.original.endTime), {
           year: 'numeric',
           month: '2-digit',
@@ -106,13 +128,13 @@ const AttemptsList = ({ onResume, onReset }: AttemptsListProps) => {
     },
     {
       accessor: 'status',
-      Cell: ({ row }: TableCellValue<any>) => <span className="text-capitalize">{row.original.status}</span>,
+      Cell: ({ row }: TableCellValue<Attempt>) => <span className="text-capitalize">{row.original.status}</span>,
       disableFilters: true,
       Header: intl.formatMessage(messages.status),
     },
     {
       accessor: 'readyToResume',
-      Cell: ({ row }: TableCellValue<any>) => (
+      Cell: ({ row }: TableCellValue<Attempt>) => (
         <span className="text-capitalize">{row.original.readyToResume ? intl.formatMessage(messages.true) : ''}</span>
       ),
       disableFilters: true,

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams } from '@src/specialExams/data/api';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
 import { AttemptsParams, Attempt, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
 import { DataList } from '@src/types';
 
@@ -86,6 +86,7 @@ describe('specialExams api', () => {
           startTime: '2023-01-01T10:00:00Z',
           endTime: '2023-01-01T13:00:00Z',
           status: 'completed',
+          readyToResume: false
         },
         {
           id: 2,
@@ -99,6 +100,7 @@ describe('specialExams api', () => {
           startTime: '2023-01-02T14:00:00Z',
           endTime: '2023-01-02T16:00:00Z',
           status: 'completed',
+          readyToResume: true
         },
       ],
     };
@@ -390,6 +392,38 @@ describe('specialExams api', () => {
       mockHttpClient.get.mockRejectedValue(error);
 
       await expect(getSpecialExams(courseId, examType)).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('resetAttempt', () => {
+    it('makes correct API call and returns camelCase data', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const examId = 1;
+      const username = 'testuser';
+      const mockResponseData = { detail: 'Attempt reset successfully' };
+
+      mockHttpClient.post.mockResolvedValue({ data: mockResponseData });
+      mockCamelCaseObject.mockReturnValue(mockResponseData);
+
+      const result = await resetAttempt(courseId, { examId, username });
+
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        `https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/special_exams/${examId}/reset/${username}`
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockResponseData);
+      expect(result).toBe(mockResponseData);
+    });
+
+    it('handles API error', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const examId = 1;
+      const username = 'testuser';
+      const error = new Error('Failed to reset attempt');
+
+      mockHttpClient.post.mockRejectedValue(error);
+
+      await expect(resetAttempt(courseId, { examId, username })).rejects.toThrow('Failed to reset attempt');
     });
   });
 });

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
 import { AttemptsParams, Attempt, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
 import { DataList } from '@src/types';
 
@@ -25,6 +25,7 @@ describe('specialExams api', () => {
     get: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    put: jest.fn()
   };
 
   beforeEach(() => {
@@ -46,10 +47,11 @@ describe('specialExams api', () => {
           exam_id: 101,
           user: {
             username: 'student1',
+            id: 1,
           },
           exam_name: 'Final Exam',
           allowed_time_limit_mins: 180,
-          type: 'proctored',
+          exam_type: 'proctored',
           start_time: '2023-01-01T10:00:00Z',
           end_time: '2023-01-01T13:00:00Z',
           status: 'completed',
@@ -59,10 +61,11 @@ describe('specialExams api', () => {
           exam_id: 102,
           user: {
             username: 'student2',
+            id: 2
           },
           exam_name: 'Midterm Exam',
           allowed_time_limit_mins: 120,
-          type: 'timed',
+          exam_type: 'timed',
           start_time: '2023-01-02T14:00:00Z',
           end_time: '2023-01-02T16:00:00Z',
           status: 'completed',
@@ -79,10 +82,11 @@ describe('specialExams api', () => {
           examId: 101,
           user: {
             username: 'student1',
+            id: 1,
           },
           examName: 'Final Exam',
           allowedTimeLimitMins: 180,
-          type: 'proctored',
+          examType: 'proctored',
           startTime: '2023-01-01T10:00:00Z',
           endTime: '2023-01-01T13:00:00Z',
           status: 'completed',
@@ -93,10 +97,11 @@ describe('specialExams api', () => {
           examId: 102,
           user: {
             username: 'student2',
+            id: 2,
           },
           examName: 'Midterm Exam',
           allowedTimeLimitMins: 120,
-          type: 'timed',
+          examType: 'timed',
           startTime: '2023-01-02T14:00:00Z',
           endTime: '2023-01-02T16:00:00Z',
           status: 'completed',
@@ -424,6 +429,37 @@ describe('specialExams api', () => {
       mockHttpClient.post.mockRejectedValue(error);
 
       await expect(resetAttempt(courseId, { examId, username })).rejects.toThrow('Failed to reset attempt');
+    });
+  });
+
+  describe('resumeAttempt', () => {
+    it('makes correct API call and returns camelCase data', async () => {
+      const attemptId = 1;
+      const userId = 2;
+      const mockResponseData = { detail: 'Attempt resumed successfully' };
+
+      mockHttpClient.put.mockResolvedValue({ data: mockResponseData });
+      mockCamelCaseObject.mockReturnValue(mockResponseData);
+
+      const result = await resumeAttempt({ attemptId, userId });
+
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.put).toHaveBeenCalledWith(
+        `https://test-lms.com/api/edx_proctoring/v1/proctored_exam/attempt/${attemptId}`,
+        expect.any(FormData)
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockResponseData);
+      expect(result).toBe(mockResponseData);
+    });
+
+    it('handles API error', async () => {
+      const attemptId = 1;
+      const userId = 2;
+      const error = new Error('Failed to resume attempt');
+
+      mockHttpClient.put.mockRejectedValue(error);
+
+      await expect(resumeAttempt({ attemptId, userId })).rejects.toThrow('Failed to resume attempt');
     });
   });
 });

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient, camelCaseObject, snakeCaseObject } from '@o
 import { snakeCase } from 'lodash';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
-import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, SpecialExam } from '../types';
+import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, ResumeAttemptParams, SpecialExam } from '@src/specialExams/types';
 
 const getQueryParams = (params: AttemptsParams) => {
   const queryParams = new URLSearchParams({
@@ -73,6 +73,18 @@ export const getSpecialExams = async (courseId: string, examType: string): Promi
 export const resetAttempt = async (courseId: string, params: ResetAttemptParams) => {
   const { data } = await getAuthenticatedHttpClient().post(
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/special_exams/${params.examId}/reset/${params.username}`
+  );
+  return camelCaseObject(data);
+};
+
+export const resumeAttempt = async (params: ResumeAttemptParams) => {
+  const { userId, attemptId } = params;
+  const formData = new FormData();
+  formData.append('user_id', userId.toString());
+  formData.append('action', 'mark_ready_to_resume');
+  const { data } = await getAuthenticatedHttpClient().put(
+    `${getApiBaseUrl()}/api/edx_proctoring/v1/proctored_exam/attempt/${attemptId}`,
+    formData
   );
   return camelCaseObject(data);
 };

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient, camelCaseObject, snakeCaseObject } from '@o
 import { snakeCase } from 'lodash';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
-import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, SpecialExam } from '../types';
+import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, SpecialExam } from '../types';
 
 const getQueryParams = (params: AttemptsParams) => {
   const queryParams = new URLSearchParams({
@@ -66,6 +66,13 @@ export const getSpecialExams = async (courseId: string, examType: string): Promi
     `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/special_exams`, {
       params: { exam_type: examType }
     }
+  );
+  return camelCaseObject(data);
+};
+
+export const resetAttempt = async (courseId: string, params: ResetAttemptParams) => {
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/special_exams/${params.examId}/reset/${params.username}`
   );
   return camelCaseObject(data);
 };

--- a/src/specialExams/data/apiHook.test.tsx
+++ b/src/specialExams/data/apiHook.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
-import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams, useResetAttempt } from '@src/specialExams/data/apiHook';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
+import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams, useResetAttempt, useResumeAttempt } from '@src/specialExams/data/apiHook';
 import { AttemptsParams, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
 
 jest.mock('@src/specialExams/data/api');
@@ -12,6 +12,7 @@ const mockAddAllowance = addAllowance as jest.MockedFunction<typeof addAllowance
 const mockDeleteAllowance = deleteAllowance as jest.MockedFunction<typeof deleteAllowance>;
 const mockGetSpecialExams = getSpecialExams as jest.MockedFunction<typeof getSpecialExams>;
 const mockResetAttempt = resetAttempt as jest.MockedFunction<typeof resetAttempt>;
+const mockResumeAttempt = resumeAttempt as jest.MockedFunction<typeof resumeAttempt>;
 
 const mockAttemptsData = {
   count: 2,
@@ -22,10 +23,11 @@ const mockAttemptsData = {
       examId: 101,
       user: {
         username: 'student1',
+        id: 1
       },
       examName: 'Final Exam',
       allowedTimeLimitMins: 180,
-      type: 'proctored',
+      examType: 'proctored',
       startTime: '2023-01-01T10:00:00Z',
       endTime: '2023-01-01T13:00:00Z',
       status: 'completed',
@@ -36,10 +38,11 @@ const mockAttemptsData = {
       examId: 102,
       user: {
         username: 'student2',
+        id: 2
       },
       examName: 'Midterm Exam',
       allowedTimeLimitMins: 120,
-      type: 'timed',
+      examType: 'timed',
       startTime: '2023-01-02T14:00:00Z',
       endTime: '2023-01-02T16:00:00Z',
       status: 'completed',
@@ -483,6 +486,31 @@ describe('specialExams api hooks', () => {
       });
 
       expect(mockResetAttempt).toHaveBeenCalledWith(courseId, params);
+    });
+  });
+
+  describe('useResumeAttempt', () => {
+    it('handles resume attempt successfully', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const params = {
+        userId: 2,
+        attemptId: 3
+      };
+      mockResumeAttempt.mockResolvedValue({});
+
+      const { result } = renderHook(() => useResumeAttempt(courseId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        result.current.mutate(params);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockResumeAttempt).toHaveBeenCalledWith(params);
     });
   });
 });

--- a/src/specialExams/data/apiHook.test.tsx
+++ b/src/specialExams/data/apiHook.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams } from '@src/specialExams/data/api';
-import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams } from '@src/specialExams/data/apiHook';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
+import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams, useResetAttempt } from '@src/specialExams/data/apiHook';
 import { AttemptsParams, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
 
 jest.mock('@src/specialExams/data/api');
@@ -11,6 +11,7 @@ const mockGetAllowances = getAllowances as jest.MockedFunction<typeof getAllowan
 const mockAddAllowance = addAllowance as jest.MockedFunction<typeof addAllowance>;
 const mockDeleteAllowance = deleteAllowance as jest.MockedFunction<typeof deleteAllowance>;
 const mockGetSpecialExams = getSpecialExams as jest.MockedFunction<typeof getSpecialExams>;
+const mockResetAttempt = resetAttempt as jest.MockedFunction<typeof resetAttempt>;
 
 const mockAttemptsData = {
   count: 2,
@@ -28,6 +29,7 @@ const mockAttemptsData = {
       startTime: '2023-01-01T10:00:00Z',
       endTime: '2023-01-01T13:00:00Z',
       status: 'completed',
+      readyToResume: false
     },
     {
       id: 2,
@@ -41,6 +43,7 @@ const mockAttemptsData = {
       startTime: '2023-01-02T14:00:00Z',
       endTime: '2023-01-02T16:00:00Z',
       status: 'completed',
+      readyToResume: true
     },
   ],
 };
@@ -454,6 +457,32 @@ describe('specialExams api hooks', () => {
       });
 
       expect(result.current.error).toBe(mockError);
+    });
+  });
+
+  describe('useResetAttempt', () => {
+    const courseId = 'course-v1:edX+Test+2023';
+    const params = {
+      username: 'testuser',
+      examId: 3
+    };
+
+    it('resets attempt successfully', async () => {
+      mockResetAttempt.mockResolvedValue({});
+
+      const { result } = renderHook(() => useResetAttempt(courseId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        result.current.mutate(params);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockResetAttempt).toHaveBeenCalledWith(courseId, params);
     });
   });
 });

--- a/src/specialExams/data/apiHook.ts
+++ b/src/specialExams/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { addAllowance, deleteAllowance, getAllowances, getAttempts, getSpecialExams } from './api';
-import { specialExamsQueryKeys } from './queryKeys';
-import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams } from '../types';
+import { addAllowance, deleteAllowance, getAllowances, getAttempts, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
+import { specialExamsQueryKeys } from '@src/specialExams/data/queryKeys';
+import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams } from '@src/specialExams/types';
 
 export const useAttempts = (courseId: string, params: AttemptsParams, enabled = true) => (
   useQuery({
@@ -47,3 +47,13 @@ export const useSpecialExams = (courseId: string, examType: string) => (
     enabled: !!courseId && !!examType,
   })
 );
+
+export const useResetAttempt = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: ResetAttemptParams) => resetAttempt(courseId, params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: specialExamsQueryKeys.attempts(courseId), exact: false });
+    },
+  });
+};

--- a/src/specialExams/data/apiHook.ts
+++ b/src/specialExams/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { addAllowance, deleteAllowance, getAllowances, getAttempts, getSpecialExams, resetAttempt } from '@src/specialExams/data/api';
+import { addAllowance, deleteAllowance, getAllowances, getAttempts, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
 import { specialExamsQueryKeys } from '@src/specialExams/data/queryKeys';
-import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams } from '@src/specialExams/types';
+import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, ResumeAttemptParams } from '@src/specialExams/types';
 
 export const useAttempts = (courseId: string, params: AttemptsParams, enabled = true) => (
   useQuery({
@@ -52,6 +52,16 @@ export const useResetAttempt = (courseId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: ResetAttemptParams) => resetAttempt(courseId, params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: specialExamsQueryKeys.attempts(courseId), exact: false });
+    },
+  });
+};
+
+export const useResumeAttempt = (courseId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: ResumeAttemptParams) => resumeAttempt(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: specialExamsQueryKeys.attempts(courseId), exact: false });
     },

--- a/src/specialExams/data/queryKeys.ts
+++ b/src/specialExams/data/queryKeys.ts
@@ -4,7 +4,7 @@ import { AttemptsParams } from '../types';
 export const specialExamsQueryKeys = {
   all: [appId, 'specialExams'] as const,
   byCourse: (courseId: string) => [...specialExamsQueryKeys.all, courseId] as const,
-  attempts: (courseId: string, params: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'attempts', params.page, params.emailOrUsername, params.ordering] as const,
+  attempts: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'attempts', params?.page || 1, params?.emailOrUsername || '', params?.ordering || ''] as const,
   allowances: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'allowances', params?.page || 1, params?.emailOrUsername || '', params?.ordering || ''] as const,
   specialExams: (courseId: string, examType: string) => [...specialExamsQueryKeys.byCourse(courseId), 'specialExams', examType] as const,
 };

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -260,6 +260,31 @@ const messages = defineMessages({
     id: 'instruct.specialExams.close',
     defaultMessage: 'Close',
     description: 'Label for close button'
+  },
+  confirmationModal: {
+    id: 'instruct.specialExams.confirmationModal',
+    defaultMessage: 'Confirmation Modal',
+    description: 'Confirmation modal title'
+  },
+  confirmationMessageReset: {
+    id: 'instruct.specialExams.confirmationMessageReset',
+    defaultMessage: 'Are you sure you want to remove this student\'s exam attempt?',
+    description: 'Confirmation message shown when resetting an exam attempt'
+  },
+  confirmationMessageResume: {
+    id: 'instruct.specialExams.confirmationMessageResume',
+    defaultMessage: 'Are you sure you want to resume this exam attempt?',
+    description: 'Confirmation message shown when resuming an exam attempt'
+  },
+  errorOnResume: {
+    id: 'instruct.specialExams.errorOnResume',
+    defaultMessage: 'An error occurred while resuming the attempt. Please try again.',
+    description: 'Error message shown when resuming an exam attempt fails'
+  },
+  successOnResume: {
+    id: 'instruct.specialExams.successOnResume',
+    defaultMessage: 'Successfully resumed attempt for {student}.',
+    description: 'Success message shown after resuming an exam attempt'
   }
 });
 

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -245,6 +245,21 @@ const messages = defineMessages({
     id: 'instruct.specialExams.true',
     defaultMessage: 'True',
     description: 'Display value for a boolean true value'
+  },
+  successOnReset: {
+    id: 'instruct.specialExams.successOnReset',
+    defaultMessage: 'Successfully reset attempt on {examName} for {student}.',
+    description: 'Success message shown after resetting an exam attempt'
+  },
+  errorOnReset: {
+    id: 'instruct.specialExams.errorOnReset',
+    defaultMessage: 'An error occurred while resetting the attempt. Please try again.',
+    description: 'Error message shown when resetting an exam attempt fails'
+  },
+  close: {
+    id: 'instruct.specialExams.close',
+    defaultMessage: 'Close',
+    description: 'Label for close button'
   }
 });
 

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -225,6 +225,26 @@ const messages = defineMessages({
     id: 'instruct.specialExams.cannotModifyAllowance',
     defaultMessage: 'Cannot {action} allowance: {username} has already attempted the exam',
     description: 'Warning message shown when trying to edit or delete an allowance for a student who has already attempted the exam'
+  },
+  readyForResume: {
+    id: 'instruct.specialExams.readyForResume',
+    defaultMessage: 'Ready to Resume?',
+    description: 'Label for whether the exam attempt is ready to be resumed in the exam attempts list',
+  },
+  resume: {
+    id: 'instruct.specialExams.resume',
+    defaultMessage: 'Resume',
+    description: 'Label for resume action in exam attempts list',
+  },
+  reset: {
+    id: 'instruct.specialExams.reset',
+    defaultMessage: 'Reset',
+    description: 'Label for reset action in exam attempts list',
+  },
+  true: {
+    id: 'instruct.specialExams.true',
+    defaultMessage: 'True',
+    description: 'Display value for a boolean true value'
   }
 });
 

--- a/src/specialExams/types.ts
+++ b/src/specialExams/types.ts
@@ -4,13 +4,14 @@ export interface Attempt {
   id: number,
   user: {
     username: string,
+    id: number,
   },
   examId: number,
   examName: string,
   allowedTimeLimitMins: number,
-  type: string,
+  examType: string,
   startTime: string,
-  endTime: string,
+  endTime: string | null,
   status: string,
   readyToResume: boolean,
 }
@@ -18,6 +19,18 @@ export interface Attempt {
 export interface AttemptsParams extends PaginationParams {
   emailOrUsername: string,
   ordering: string,
+}
+
+export type AttemptAction = 'reset' | 'resume';
+
+export interface ResetAttemptParams {
+  username: string,
+  examId: number,
+}
+
+export interface ResumeAttemptParams {
+  attemptId: number,
+  userId: number,
 }
 
 export interface Allowance {
@@ -70,9 +83,4 @@ export interface DeleteAllowanceParams {
   examId: number,
   userIds: number[],
   allowanceType: string,
-}
-
-export interface ResetAttemptParams {
-  username: string,
-  examId: number,
 }

--- a/src/specialExams/types.ts
+++ b/src/specialExams/types.ts
@@ -12,6 +12,7 @@ export interface Attempt {
   startTime: string,
   endTime: string,
   status: string,
+  readyToResume: boolean,
 }
 
 export interface AttemptsParams extends PaginationParams {
@@ -69,4 +70,9 @@ export interface DeleteAllowanceParams {
   examId: number,
   userIds: number[],
   allowanceType: string,
+}
+
+export interface ResetAttemptParams {
+  username: string,
+  examId: number,
 }


### PR DESCRIPTION
## Description
As part of this PR were fixed:
- Missing actions button with menu for resume/reset
- Reset action when clicked
- Missing type and exam name
- Resume action shows up on error status

## Supporting information
Closes #195 

## Screenshots
<img width="1526" height="815" alt="Screenshot 2026-05-12 at 5 26 30 p m" src="https://github.com/user-attachments/assets/1da6890d-7730-406a-b84d-2115037d13c0" />
<img width="596" height="253" alt="Screenshot 2026-05-13 at 2 44 18 p m" src="https://github.com/user-attachments/assets/cad72821-d617-4b43-a1c0-42c41ec07a5c" />
<img width="623" height="245" alt="Screenshot 2026-05-13 at 2 44 11 p m" src="https://github.com/user-attachments/assets/b05cd203-439d-4ee1-9c29-ec1a9685d76a" />
<img width="1529" height="615" alt="Screenshot 2026-05-13 at 2 44 07 p m" src="https://github.com/user-attachments/assets/c388849b-57e8-4eab-85b2-aeada5317b2a" />

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
