### PR TITLE
feat: adds pending tasks and close modal button

### DIFF
--- a/src/certificates/CertificatesPage.test.tsx
+++ b/src/certificates/CertificatesPage.test.tsx
@@ -28,6 +28,17 @@ jest.mock('@src/data/apiHook', () => ({
   usePendingTasks: jest.fn(),
 }));
 
+jest.mock('@src/components/PendingTasks', () => ({
+  PendingTasks: function MockPendingTasks({ isOpen, onToggle }: { isOpen: boolean, onToggle: () => void }) {
+    return (
+      <div data-testid="pending-tasks">
+        Pending Tasks
+        <button onClick={onToggle}>Toggle</button>
+      </div>
+    );
+  },
+}));
+
 const mockUseCourseInfo = useCourseInfo as jest.MockedFunction<typeof useCourseInfo>;
 const mockUsePendingTasks = usePendingTasks as jest.MockedFunction<typeof usePendingTasks>;
 const mockUseCertificateGenerationHistory = useCertificateGenerationHistory as jest.MockedFunction<typeof useCertificateGenerationHistory>;
@@ -187,6 +198,12 @@ describe('CertificatesPage', () => {
 
     expect(screen.getByText(messages.issuedCertificatesTab.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.generationHistoryTab.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('renders pending tasks component', () => {
+    renderWithAlertAndIntl(<CertificatesPage />);
+
+    expect(screen.getByTestId('pending-tasks')).toBeInTheDocument();
   });
 
   it('renders issued certificates tab by default', () => {

--- a/src/certificates/CertificatesPage.test.tsx
+++ b/src/certificates/CertificatesPage.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@src/data/apiHook', () => ({
 }));
 
 jest.mock('@src/components/PendingTasks', () => ({
-  PendingTasks: function MockPendingTasks({ isOpen, onToggle }: { isOpen: boolean, onToggle: () => void }) {
+  PendingTasks: function MockPendingTasks({ onToggle }: { isOpen: boolean, onToggle: () => void }) {
     return (
       <div data-testid="pending-tasks">
         Pending Tasks

--- a/src/certificates/CertificatesPage.test.tsx
+++ b/src/certificates/CertificatesPage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CertificatesPage from '@src/certificates/CertificatesPage';
 import { renderWithAlertAndIntl } from '@src/testUtils';
-import { useCourseInfo } from '@src/data/apiHook';
+import { useCourseInfo, usePendingTasks } from '@src/data/apiHook';
 import {
   useCertificateGenerationHistory,
   useGrantBulkExceptions,
@@ -25,9 +25,11 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@src/certificates/data/apiHook');
 jest.mock('@src/data/apiHook', () => ({
   useCourseInfo: jest.fn(),
+  usePendingTasks: jest.fn(),
 }));
 
 const mockUseCourseInfo = useCourseInfo as jest.MockedFunction<typeof useCourseInfo>;
+const mockUsePendingTasks = usePendingTasks as jest.MockedFunction<typeof usePendingTasks>;
 const mockUseCertificateGenerationHistory = useCertificateGenerationHistory as jest.MockedFunction<typeof useCertificateGenerationHistory>;
 const mockUseInstructorTasks = useInstructorTasks as jest.MockedFunction<typeof useInstructorTasks>;
 const mockUseIssuedCertificates = useIssuedCertificates as jest.MockedFunction<typeof useIssuedCertificates>;
@@ -54,6 +56,12 @@ describe('CertificatesPage', () => {
       data: { certificatesEnabled: true },
       isLoading: false,
       error: null,
+    } as any);
+
+    mockUsePendingTasks.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
     } as any);
 
     mockUseCertificateGenerationHistory.mockReturnValue({

--- a/src/certificates/CertificatesPage.test.tsx
+++ b/src/certificates/CertificatesPage.test.tsx
@@ -200,10 +200,15 @@ describe('CertificatesPage', () => {
     expect(screen.getByText(messages.generationHistoryTab.defaultMessage)).toBeInTheDocument();
   });
 
-  it('renders pending tasks component', () => {
+  it('renders pending tasks component', async () => {
     renderWithAlertAndIntl(<CertificatesPage />);
+    const user = userEvent.setup();
 
     expect(screen.getByTestId('pending-tasks')).toBeInTheDocument();
+
+    // Test toggle functionality
+    const toggleButton = screen.getByText('Toggle');
+    await user.click(toggleButton);
   });
 
   it('renders issued certificates tab by default', () => {

--- a/src/certificates/CertificatesPage.tsx
+++ b/src/certificates/CertificatesPage.tsx
@@ -4,6 +4,7 @@ import { Card, Container, Button, ButtonGroup, Alert } from '@openedx/paragon';
 import { useIntl } from '@openedx/frontend-base';
 import { useAlert } from '@src/providers/AlertProvider';
 import { useCourseInfo } from '@src/data/apiHook';
+import { PendingTasks } from '@src/components/PendingTasks';
 import CertificatesPageHeader from '@src/certificates/components/CertificatesPageHeader';
 import IssuedCertificatesTab from '@src/certificates/components/IssuedCertificatesTab';
 import GenerationHistoryTable from '@src/certificates/components/GenerationHistoryTable';
@@ -53,6 +54,7 @@ const CertificatesPage = () => {
   const [isDisableCertificatesOpen, setIsDisableCertificatesOpen] = useState(false);
   const [isRegenerateModalOpen, setIsRegenerateModalOpen] = useState(false);
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
+  const [isPendingTasksOpen, setIsPendingTasksOpen] = useState(false);
 
   const {
     data: certificatesData,
@@ -150,6 +152,7 @@ const CertificatesPage = () => {
               title: intl.formatMessage(messages.errorModalTitle),
               message: `Some invalidations failed:\n${errorMessages}`,
               variant: ALERT_VARIANTS.WARNING,
+              confirmText: intl.formatMessage(messages.close),
             });
           }
           if (data.success && data.success.length > 0) {
@@ -504,6 +507,7 @@ const CertificatesPage = () => {
         isSubmitting={false}
         learnerCount={certificatesData?.count || 0}
       />
+      <PendingTasks isOpen={isPendingTasksOpen} onToggle={() => setIsPendingTasksOpen(prev => !prev)} />
     </Container>
   );
 };

--- a/src/providers/AlertProvider.tsx
+++ b/src/providers/AlertProvider.tsx
@@ -229,7 +229,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({ children }) => {
                 {modal.confirmText && (
                   <Button
                     variant={modal.variant === 'danger' ? 'danger' : 'primary'}
-                    onClick={() => confirmModal(modal.id)}
+                    onClick={() => modal.onConfirm ? confirmModal(modal.id) : closeModal(modal.id, false)}
                   >
                     {modal.confirmText}
                   </Button>


### PR DESCRIPTION
Closes: https://github.com/openedx/frontend-app-instructor-dashboard/issues/107
Closes: https://github.com/openedx/frontend-app-instructor-dashboard/issues/109

## Description

Fixes certificate invalidation error modal by adding a close button, allowing users to dismiss validation error messages.

**Issue:** When certificate invalidation partially failed (e.g., some learners had validation errors), the error modal displayed without any way to close it, forcing users to refresh the page.

https://github.com/user-attachments/assets/a5bea95d-18bb-4599-88fc-fb101225102c

**Changes:**
- Added `confirmText: "Close"` parameter to the invalidation error modal in CertificatesPage
- Fixed AlertProvider to properly handle modals with only a confirm button (no onConfirm callback)
- Added PendingTasks component to Certificates page to display background task status

**User Impact:** Course Authors using the Instructor Dashboard Certificates tool can now properly dismiss error messages when certificate invalidation encounters validation errors.

## Supporting information

Related to certificate invalidation workflow improvements in the Instructor Dashboard.

## Testing instructions

1. Navigate to Instructor Dashboard � Certificates
2. Click "Invalidate Certificate"
3. Enter a username that will trigger a validation error (e.g., `testeststest` - a user that doesn't exist)
4. Click "Save"
5. Verify the error modal appears with message "Some invalidations failed: testeststest: User matching query does not exist."
6. **Verify a "Close" button is visible in the modal footer**
7. Click the "Close" button
8. Verify the modal dismisses properly
9. Scroll down below the data table and verify the Pending Tasks collapsible section is present

## Other information

- No dependencies or migrations required
- The PendingTasks component follows the same pattern used in the Grading page

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
