### PR TITLE
fix: add authloader

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import SpecialExamsPage from '@src/specialExams/SpecialExamsPage';
 import PageNotFound from '@src/components/PageNotFound';
 import { useWidgetProps } from './slots/SlotUtils';
 import { instructorDashboardRole } from './constants';
+import { authenticatedLoader } from '@openedx/frontend-base';
 
 interface InstructorRouteProps {
   tabId: string,
@@ -51,6 +52,7 @@ const routes = [
   {
     id: 'org.openedx.frontend.route.instructorDashboard.main',
     path: 'instructor-dashboard/:courseId',
+    loader: authenticatedLoader,
     handle: {
       roles: [instructorDashboardRole]
     },


### PR DESCRIPTION
## Description
Add authenticated loader, so if a user is not logged in and lands into instructor dashboard page it should redirect to login page.

## Demo

https://github.com/user-attachments/assets/7911f53c-5898-472a-b3af-0484fd1b3c56


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
