### PR TITLE
fix: bulk enrollments

### DIFF
--- a/src/enrollments/components/AddBetaTestersModal.test.tsx
+++ b/src/enrollments/components/AddBetaTestersModal.test.tsx
@@ -158,6 +158,31 @@ describe('AddBetaTestersModal', () => {
     });
   });
 
+  it('splits emails separated by a line break into separate identifiers', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'alice@example.com{Enter}bob@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [
+        'alice@example.com',
+        'bob@example.com',
+      ],
+      action: 'add',
+      autoEnroll: true,
+      emailStudents: true,
+    }, {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+
   it('does not call mutation if textarea is empty', async () => {
     renderComponent();
     const saveBtn = screen.getByRole('button', {

--- a/src/enrollments/components/AddBetaTestersModal.tsx
+++ b/src/enrollments/components/AddBetaTestersModal.tsx
@@ -34,7 +34,7 @@ const AddBetaTestersModal = ({
   };
 
   const handleSave = () => {
-    const identifier = inputValue.split(',').map(email => email.trim()).filter(email => email);
+    const identifier = inputValue.split(/[\n,]+/).map(email => email.trim()).filter(Boolean);
     addBetaTesters({ identifier, action: 'add', autoEnroll, emailStudents }, {
       onSuccess: (data) => {
         const failedUsernames = data.results?.filter(user => user.userDoesNotExist).map(user => user.identifier) || [];

--- a/src/enrollments/components/EnrollLearnersModal.test.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.test.tsx
@@ -148,6 +148,31 @@ describe('EnrollLearnersModal', () => {
     });
   });
 
+  it('splits emails separated by a line break into separate identifiers', async () => {
+    renderComponent();
+    const textarea = screen.getByPlaceholderText(
+      messages.userIdentifierPlaceholder.defaultMessage
+    );
+    const user = userEvent.setup();
+    await user.type(textarea, 'alice@example.com{Enter}bob@example.com');
+    const saveBtn = screen.getByRole('button', {
+      name: messages.saveButton.defaultMessage,
+    });
+    await user.click(saveBtn);
+    expect(mutateMock).toHaveBeenCalledWith({
+      identifier: [
+        'alice@example.com',
+        'bob@example.com',
+      ],
+      action: 'enroll',
+      autoEnroll: true,
+      emailStudents: true,
+    }, {
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    });
+  });
+
   it('does not call onSuccess if textarea is empty', async () => {
     renderComponent();
     const saveBtn = screen.getByRole('button', {

--- a/src/enrollments/components/EnrollLearnersModal.tsx
+++ b/src/enrollments/components/EnrollLearnersModal.tsx
@@ -25,7 +25,7 @@ const EnrollLearnersModal = ({
   const { showModal, addAlert } = useAlert();
 
   const handleSave = () => {
-    const identifier = emails.split(',').map(email => email.trim()).filter(email => email);
+    const identifier = emails.split(/[\n,]+/).map(email => email.trim()).filter(Boolean);
     enrollLearners({ identifier, action: 'enroll', autoEnroll, emailStudents }, {
       onSuccess: (data) => {
         const failedUsernames = data.results?.filter(user => user.invalidIdentifier).map(user => user.identifier) || [];


### PR DESCRIPTION
## Description
The validation to split the users was only checking for commas and missing break lines, so fixed it for enroll learners and add beta testers.

## Supporting information
Fixes https://github.com/openedx/wg-build-test-release/issues/595

## Testing instructions
- Go to enrollments tab
- Click on enroll learners or add beta testers
- add a username or email, press enter to break the line and add another username or email
- Should enroll the 2 diff users

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
