### PR TITLE
fix: change enrollment status modal message

### DIFF
--- a/src/enrollments/components/EnrollmentStatusModal.tsx
+++ b/src/enrollments/components/EnrollmentStatusModal.tsx
@@ -32,7 +32,7 @@ const EnrollmentStatusModal = ({ isOpen, onClose }: EnrollmentStatusModalProps) 
       </ModalDialog.Header>
       <ModalDialog.Body className="border-bottom border-top border-light-700">
         <div className="my-2">
-          <p>{intl.formatMessage(messages.addLearnerInstructions)}</p>
+          <p>{intl.formatMessage(messages.enrollmentStatusInstructions)}</p>
           <FormControl
             placeholder={intl.formatMessage(messages.enrollmentStatusPlaceholder)}
             value={learnerIdentifier}

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -68,7 +68,7 @@ const messages = defineMessages({
   },
   enrollmentStatusInstructions: {
     id: 'instruct.enrollments.modals.checkEnrollmentStatus.enrollmentStatusInstructions',
-    defaultMessage: 'Enter email address or username. You will not get correct status for emails that bounce, so please double-check spelling.',
+    defaultMessage: 'Enter email address or username. An incorrect or misspelled email address may result in an inaccurate status, please double-check spelling.',
     description: 'Instructions for checking enrollment status of a learner in the course',
   },
   enrollmentStatusPlaceholder: {

--- a/src/enrollments/messages.ts
+++ b/src/enrollments/messages.ts
@@ -64,7 +64,12 @@ const messages = defineMessages({
   addLearnerInstructions: {
     id: 'instruct.enrollments.modals.checkEnrollmentStatus.addLearnerInstructions',
     defaultMessage: 'Enter email addresses and/or usernames separated by new lines or commas. You will not get notification for emails that bounce, so please double-check spelling.',
-    description: 'Instructions for enroll learners to the course',
+    description: 'Instructions for enrolling learners to the course',
+  },
+  enrollmentStatusInstructions: {
+    id: 'instruct.enrollments.modals.checkEnrollmentStatus.enrollmentStatusInstructions',
+    defaultMessage: 'Enter email address or username. You will not get correct status for emails that bounce, so please double-check spelling.',
+    description: 'Instructions for checking enrollment status of a learner in the course',
   },
   enrollmentStatusPlaceholder: {
     id: 'instruct.enrollments.modals.checkEnrollmentStatus.enrollmentStatusPlaceholder',


### PR DESCRIPTION
## Description
Enrollment status modal only supports to give info of one learner at a time, but the instructions/descripiton message suggest that it can be added multiple usernames, so we updated the message.

## Supporting information
Fixes https://github.com/openedx/wg-build-test-release/issues/596

## Testing instructions
- Go to enrollments tab
- Click on 3 dots 
- Click on check enrollment status
- You should see the message

## Other information
Before
<img width="516" height="396" alt="Screenshot 2026-06-23 at 9 00 57 a m" src="https://github.com/user-attachments/assets/b1fcf9f9-82a1-43d1-b7e8-130c2549863e" />

After
<img width="527" height="398" alt="Screenshot 2026-06-23 at 9 01 48 a m" src="https://github.com/user-attachments/assets/5350933b-d82d-4e30-8cc8-79f551a97246" />


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
