### PR TITLE
fix: update attempts on UI after reset

### DIFF
--- a/src/grading/components/GradingLearnerContent.test.tsx
+++ b/src/grading/components/GradingLearnerContent.test.tsx
@@ -76,7 +76,7 @@ describe('GradingLearnerContent', () => {
     mockUseRescoreSubmission.mockReturnValue({ mutate: mockMutateRescore } as any);
     mockUsePendingTasks.mockReturnValue({ refetch: mockRefetch } as any);
     (useLearner as jest.Mock).mockReturnValue({ data: { username: 'testuser', email: 'testuser@example.com', progressUrl: '/progress' }, isLoading: false, error: null });
-    (useProblemDetails as jest.Mock).mockReturnValue({ data: { currentScore: { score: 0, total: null }, attempts: { current: 1, total: 1 } }, isLoading: false, error: null });
+    (useProblemDetails as jest.Mock).mockReturnValue({ data: { currentScore: { score: 0, total: null }, attempts: { current: 1, total: 1 } }, isLoading: false, error: null, refetch: jest.fn() });
   });
 
   it('renders correctly for single learner mode', () => {

--- a/src/grading/components/GradingLearnerContent.tsx
+++ b/src/grading/components/GradingLearnerContent.tsx
@@ -27,7 +27,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
   const problemFieldRef = useRef<{ reset: () => void }>(null);
   const [showCurrentStatus, setShowCurrentStatus] = useState(false);
   const [confirmationModalData, setConfirmationModalData] = useState<{ message: string, confirmButtonLabel: string, action?: () => void }>({ message: '', confirmButtonLabel: '', action: undefined });
-  const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } }, isError: isProblemDataError } = useProblemDetails(courseId, blockId, usernameOrEmail);
+  const { data: problemData = { currentScore: { score: 0, total: null }, attempts: { current: null, total: 0 } }, isError: isProblemDataError, refetch: refetchProblemData } = useProblemDetails(courseId, blockId, usernameOrEmail);
   const { data: learnerData = { username: '', progressUrl: '' } } = useLearner(courseId, usernameOrEmail);
   const { showModal, showToast } = useAlert();
 
@@ -53,6 +53,7 @@ const GradingLearnerContent = ({ toolType, onShowTasks }: GradingLearnerContentP
     resetAttempts({ learner: usernameOrEmail, problem: blockId }, {
       onSuccess: () => {
         resetConfirmationModalData();
+        refetchProblemData();
         showToast(intl.formatMessage(messages.resetAttemptsSuccess, { student: usernameOrEmail || intl.formatMessage(messages.allLearners), blockId }));
       },
       onError: manageOnError


### PR DESCRIPTION
## Description
When using grading tab, reset attempts on a single learner UI wasn't updating attempts until refresh.

## Supporting information
Addresses point 3 of https://github.com/openedx/wg-build-test-release/issues/608

## Testing instructions
- Go to grading tab
- Select a username 
- Select a valid problem id
- click on reset attempts
- You should see attempts updated to 0 on the displayed info

### Demo
https://github.com/user-attachments/assets/ed6a84b8-d9ee-4f03-8be4-2e0b21502cdf


## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
