### PR TITLE
feat: add Student Onboarding Status and Review Dashboard to Special Exams

### DIFF
--- a/src/specialExams/SpecialExamsPage.test.tsx
+++ b/src/specialExams/SpecialExamsPage.test.tsx
@@ -2,6 +2,16 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithIntl } from '@src/testUtils';
 import SpecialExamsPage from './SpecialExamsPage';
+import { useProctoringSettings } from './data/apiHook';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:test+test+test' }),
+}));
+
+jest.mock('./data/apiHook', () => ({
+  useProctoringSettings: jest.fn(),
+}));
 
 // Mock child components
 jest.mock('./components/Allowances', () => {
@@ -16,8 +26,28 @@ jest.mock('./components/Attempts', () => {
   }
   return MockedAttemptsList;
 });
+jest.mock('./components/OnboardingList', () => {
+  function MockedOnboardingList() {
+    return <div>Onboarding Component</div>;
+  }
+  return MockedOnboardingList;
+});
+jest.mock('./components/ReviewDashboard', () => {
+  function MockedReviewDashboard() {
+    return <div>Review Dashboard Component</div>;
+  }
+  return MockedReviewDashboard;
+});
+
+const mockUseProctoringSettings = useProctoringSettings as jest.Mock;
 
 describe('SpecialExamsPage', () => {
+  beforeEach(() => {
+    mockUseProctoringSettings.mockReturnValue({
+      data: { supportsOnboarding: false, reviewDashboardAvailable: false },
+    });
+  });
+
   it('renders the page title', () => {
     renderWithIntl(<SpecialExamsPage />);
     expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
@@ -57,5 +87,37 @@ describe('SpecialExamsPage', () => {
     await user.click(allowancesButton);
     expect(allowancesButton).toHaveClass('btn-primary');
     expect(attemptsButton).toHaveClass('btn-outline-primary');
+  });
+
+  it('hides onboarding and review dashboard tabs when the provider does not support them', () => {
+    renderWithIntl(<SpecialExamsPage />);
+    expect(screen.queryByText('Onboarding')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review Dashboard')).not.toBeInTheDocument();
+  });
+
+  it('shows and switches to the onboarding tab when supported', async () => {
+    mockUseProctoringSettings.mockReturnValue({
+      data: { supportsOnboarding: true, reviewDashboardAvailable: false },
+    });
+    renderWithIntl(<SpecialExamsPage />);
+    const onboardingButton = screen.getByText('Onboarding');
+    expect(onboardingButton).toBeInTheDocument();
+    expect(screen.queryByText('Review Dashboard')).not.toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(onboardingButton);
+    expect(screen.getByText('Onboarding Component')).toBeInTheDocument();
+  });
+
+  it('shows and switches to the review dashboard tab when supported', async () => {
+    mockUseProctoringSettings.mockReturnValue({
+      data: { supportsOnboarding: false, reviewDashboardAvailable: true },
+    });
+    renderWithIntl(<SpecialExamsPage />);
+    const reviewButton = screen.getByText('Review Dashboard');
+    expect(reviewButton).toBeInTheDocument();
+    expect(screen.queryByText('Onboarding')).not.toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(reviewButton);
+    expect(screen.getByText('Review Dashboard Component')).toBeInTheDocument();
   });
 });

--- a/src/specialExams/SpecialExamsPage.tsx
+++ b/src/specialExams/SpecialExamsPage.tsx
@@ -1,18 +1,42 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useIntl } from '@openedx/frontend-base';
 import { Button, ButtonGroup, Card } from '@openedx/paragon';
 import messages from './messages';
 import Allowances from './components/Allowances';
 import Attempts from './components/Attempts';
+import OnboardingList from './components/OnboardingList';
+import ReviewDashboard from './components/ReviewDashboard';
+import { useProctoringSettings } from './data/apiHook';
 
 const SPECIAL_EXAMS_TAB = {
   ATTEMPTS: 'attempts',
   ALLOWANCES: 'allowances',
+  ONBOARDING: 'onboarding',
+  REVIEW_DASHBOARD: 'reviewDashboard',
 };
 
 const SpecialExamsPage = () => {
   const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const { data: proctoringSettings } = useProctoringSettings(courseId);
   const [selectedTab, setSelectedTab] = useState<(typeof SPECIAL_EXAMS_TAB)[keyof typeof SPECIAL_EXAMS_TAB]>(SPECIAL_EXAMS_TAB.ATTEMPTS);
+
+  const showOnboarding = !!proctoringSettings?.supportsOnboarding;
+  const showReviewDashboard = !!proctoringSettings?.reviewDashboardAvailable;
+
+  const renderTabContent = () => {
+    switch (selectedTab) {
+      case SPECIAL_EXAMS_TAB.ALLOWANCES:
+        return <Allowances />;
+      case SPECIAL_EXAMS_TAB.ONBOARDING:
+        return showOnboarding ? <OnboardingList /> : <Attempts />;
+      case SPECIAL_EXAMS_TAB.REVIEW_DASHBOARD:
+        return showReviewDashboard ? <ReviewDashboard /> : <Attempts />;
+      default:
+        return <Attempts />;
+    }
+  };
 
   return (
     <>
@@ -29,10 +53,22 @@ const SpecialExamsPage = () => {
             onClick={() => setSelectedTab(SPECIAL_EXAMS_TAB.ALLOWANCES)}
           >{intl.formatMessage(messages.allowances)}
           </Button>
+          {showOnboarding && (
+            <Button
+              variant={selectedTab === SPECIAL_EXAMS_TAB.ONBOARDING ? 'primary' : 'outline-primary'}
+              onClick={() => setSelectedTab(SPECIAL_EXAMS_TAB.ONBOARDING)}
+            >{intl.formatMessage(messages.onboarding)}
+            </Button>
+          )}
+          {showReviewDashboard && (
+            <Button
+              variant={selectedTab === SPECIAL_EXAMS_TAB.REVIEW_DASHBOARD ? 'primary' : 'outline-primary'}
+              onClick={() => setSelectedTab(SPECIAL_EXAMS_TAB.REVIEW_DASHBOARD)}
+            >{intl.formatMessage(messages.reviewDashboard)}
+            </Button>
+          )}
         </ButtonGroup>
-        {
-          selectedTab === SPECIAL_EXAMS_TAB.ATTEMPTS ? <Attempts /> : <Allowances />
-        }
+        {renderTabContent()}
       </Card>
     </>
   );

--- a/src/specialExams/components/OnboardingList.test.tsx
+++ b/src/specialExams/components/OnboardingList.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react';
+import OnboardingList from './OnboardingList';
+import { renderWithIntl } from '@src/testUtils';
+import { useOnboardingStatuses } from '@src/specialExams/data/apiHook';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
+}));
+
+jest.mock('../data/apiHook', () => ({
+  useOnboardingStatuses: jest.fn(),
+}));
+
+const mockUseOnboardingStatuses = useOnboardingStatuses as jest.Mock;
+
+const mockOnboardingData = {
+  results: [
+    { username: 'user1', enrollmentMode: 'verified', status: 'verified', modified: '2024-01-01T10:00:00Z' },
+    { username: 'user2', enrollmentMode: 'audit', status: 'not_started', modified: null },
+  ],
+  count: 2,
+  numPages: 1,
+};
+
+describe('OnboardingList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the onboarding statuses with humanized status text', () => {
+    mockUseOnboardingStatuses.mockReturnValue({ data: mockOnboardingData, isLoading: false });
+    renderWithIntl(<OnboardingList />);
+
+    expect(screen.getByText('Onboarding Status')).toBeInTheDocument();
+    expect(screen.getByText('Enrollment Mode')).toBeInTheDocument();
+    expect(screen.getByText('user1')).toBeInTheDocument();
+    expect(screen.getByText('user2')).toBeInTheDocument();
+    // 'not_started' should be rendered with the underscore replaced by a space
+    expect(screen.getByText('not started')).toBeInTheDocument();
+  });
+
+  it('renders the empty message when there are no statuses', () => {
+    mockUseOnboardingStatuses.mockReturnValue({
+      data: { results: [], count: 0, numPages: 0 },
+      isLoading: false,
+    });
+    renderWithIntl(<OnboardingList />);
+
+    expect(screen.getByText('No onboarding statuses found')).toBeInTheDocument();
+  });
+
+  it('requests onboarding statuses for the current course', () => {
+    mockUseOnboardingStatuses.mockReturnValue({ data: mockOnboardingData, isLoading: false });
+    renderWithIntl(<OnboardingList />);
+
+    expect(mockUseOnboardingStatuses).toHaveBeenCalledWith(
+      'course-v1:edX+Test+2024',
+      expect.objectContaining({ page: 0, emailOrUsername: '' }),
+    );
+  });
+});

--- a/src/specialExams/components/OnboardingList.tsx
+++ b/src/specialExams/components/OnboardingList.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { DataTable } from '@openedx/paragon';
+import UsernameFilter from '@src/components/UsernameFilter';
+import { useOnboardingStatuses } from '@src/specialExams/data/apiHook';
+import messages from '@src/specialExams/messages';
+import { OnboardingStatus } from '@src/specialExams/types';
+import { DataTableFetchDataProps, TableCellValue } from '@src/types';
+
+export const ONBOARDING_PAGE_SIZE = 25;
+
+const OnboardingList = () => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+  const [filters, setFilters] = useState({ page: 0, emailOrUsername: '' });
+  const { data = { results: [], count: 0, numPages: 0 }, isLoading = false } = useOnboardingStatuses(courseId, filters);
+
+  const columns = useMemo(() => [
+    { accessor: 'username', Header: intl.formatMessage(messages.username), Filter: UsernameFilter, },
+    {
+      accessor: 'enrollmentMode',
+      Cell: ({ row }: TableCellValue<OnboardingStatus>) => (
+        <span className="text-capitalize">{row.original.enrollmentMode || ''}</span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.enrollmentMode),
+    },
+    {
+      accessor: 'status',
+      Cell: ({ row }: TableCellValue<OnboardingStatus>) => (
+        <span className="text-capitalize">{(row.original.status || '').replace(/_/g, ' ')}</span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.onboardingStatus),
+    },
+    {
+      accessor: 'modified',
+      Cell: ({ row }: TableCellValue<OnboardingStatus>) => (
+        <span>{row.original.modified ? `${intl.formatDate(new Date(row.original.modified), {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: 'UTC',
+        })} UTC` : ''}
+        </span>
+      ),
+      disableFilters: true,
+      Header: intl.formatMessage(messages.lastUpdated),
+    },
+  ], [intl]);
+
+  const handleFetchData = (tableData: DataTableFetchDataProps) => {
+    const usernameFilter = tableData.filters?.find((f) => f.id === 'username');
+    const newEmailOrUsername = usernameFilter ? usernameFilter.value : '';
+    if (newEmailOrUsername !== filters.emailOrUsername) {
+      setFilters((prevFilters) => ({ ...prevFilters, emailOrUsername: newEmailOrUsername, page: 0 }));
+      return;
+    }
+    if (tableData.pageIndex !== filters.page) {
+      setFilters((prevFilters) => ({ ...prevFilters, page: tableData.pageIndex }));
+    }
+  };
+
+  return (
+    <DataTable
+      className="mt-3"
+      columns={columns}
+      data={data.results}
+      state={{
+        pageIndex: filters.page,
+        pageSize: ONBOARDING_PAGE_SIZE,
+        filters: [
+          { id: 'emailOrUsername', value: filters.emailOrUsername }
+        ],
+      }}
+      fetchData={handleFetchData}
+      isFilterable
+      isLoading={isLoading}
+      isPaginated
+      itemCount={data.count}
+      manualFilters
+      manualPagination
+      pageSize={ONBOARDING_PAGE_SIZE}
+      pageCount={data.numPages}
+      FilterStatusComponent={() => null}
+    >
+      <DataTable.TableControlBar className="bg-light-200 py-3 px-4" />
+      <DataTable.Table />
+      <DataTable.EmptyTable content={intl.formatMessage(messages.noOnboardingStatuses)} />
+      <DataTable.TableFooter />
+    </DataTable>
+  );
+};
+
+export default OnboardingList;

--- a/src/specialExams/components/ReviewDashboard.test.tsx
+++ b/src/specialExams/components/ReviewDashboard.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import ReviewDashboard from './ReviewDashboard';
+import { renderWithIntl } from '@src/testUtils';
+import { getReviewDashboardUrl } from '@src/specialExams/data/api';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ courseId: 'course-v1:edX+Test+2024' }),
+}));
+
+jest.mock('../data/api', () => ({
+  getReviewDashboardUrl: jest.fn(),
+}));
+
+const mockGetReviewDashboardUrl = getReviewDashboardUrl as jest.MockedFunction<typeof getReviewDashboardUrl>;
+
+describe('ReviewDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetReviewDashboardUrl.mockReturnValue(
+      'https://test-lms.com/api/edx_proctoring/v1/instructor/course-v1:edX+Test+2024'
+    );
+  });
+
+  it('renders an iframe pointing at the review dashboard URL for the course', () => {
+    renderWithIntl(<ReviewDashboard />);
+
+    expect(mockGetReviewDashboardUrl).toHaveBeenCalledWith('course-v1:edX+Test+2024');
+    const iframe = screen.getByTitle('Proctoring Review Dashboard');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://test-lms.com/api/edx_proctoring/v1/instructor/course-v1:edX+Test+2024'
+    );
+  });
+});

--- a/src/specialExams/components/ReviewDashboard.tsx
+++ b/src/specialExams/components/ReviewDashboard.tsx
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom';
+import { useIntl } from '@openedx/frontend-base';
+import { getReviewDashboardUrl } from '@src/specialExams/data/api';
+import messages from '@src/specialExams/messages';
+
+const ReviewDashboard = () => {
+  const intl = useIntl();
+  const { courseId = '' } = useParams<{ courseId: string }>();
+
+  return (
+    <div className="mt-3">
+      <iframe
+        title={intl.formatMessage(messages.reviewDashboardTitle)}
+        src={getReviewDashboardUrl(courseId)}
+        className="w-100 border-0"
+        style={{ height: '80vh' }}
+      />
+    </div>
+  );
+};
+
+export default ReviewDashboard;

--- a/src/specialExams/data/api.test.ts
+++ b/src/specialExams/data/api.test.ts
@@ -1,6 +1,6 @@
 import { camelCaseObject, getAuthenticatedHttpClient, snakeCaseObject } from '@openedx/frontend-base';
 import { getApiBaseUrl } from '@src/data/api';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt, getProctoringSettings, getOnboardingStatuses, getReviewDashboardUrl } from '@src/specialExams/data/api';
 import { AttemptsParams, Attempt, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
 import { DataList } from '@src/types';
 
@@ -460,6 +460,94 @@ describe('specialExams api', () => {
       mockHttpClient.put.mockRejectedValue(error);
 
       await expect(resumeAttempt({ attemptId, userId })).rejects.toThrow('Failed to resume attempt');
+    });
+  });
+
+  describe('getProctoringSettings', () => {
+    it('makes correct API call and returns camelCase data', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const mockResponseData = {
+        proctoring_provider: 'proctortrack',
+        proctoring_escalation_email: 'proctor@example.com',
+        create_zendesk_tickets: true,
+        enable_proctored_exams: true,
+        supports_onboarding: true,
+        review_dashboard_available: true,
+      };
+
+      mockHttpClient.get.mockResolvedValue({ data: mockResponseData });
+      mockCamelCaseObject.mockReturnValue(mockResponseData);
+
+      const result = await getProctoringSettings(courseId);
+
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/instructor/v2/courses/course-v1:edX+Test+2023/proctoring_settings'
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockResponseData);
+      expect(result).toBe(mockResponseData);
+    });
+
+    it('handles API error', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      mockHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+      await expect(getProctoringSettings(courseId)).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getOnboardingStatuses', () => {
+    const params = { page: 0, emailOrUsername: '' };
+
+    it('makes correct API call and returns camelCase data', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const mockResponseData = {
+        count: 1,
+        num_pages: 1,
+        results: [
+          { username: 'student1', enrollment_mode: 'verified', status: 'verified', modified: '2023-01-01T10:00:00Z' },
+        ],
+      };
+
+      mockHttpClient.get.mockResolvedValue({ data: mockResponseData });
+      mockCamelCaseObject.mockReturnValue(mockResponseData);
+
+      const result = await getOnboardingStatuses(courseId, params);
+
+      expect(mockGetAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/edx_proctoring/v1/user_onboarding/status/course_id/course-v1:edX+Test+2023?page=1'
+      );
+      expect(mockCamelCaseObject).toHaveBeenCalledWith(mockResponseData);
+      expect(result).toBe(mockResponseData);
+    });
+
+    it('passes the search term as text_search and increments the page', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      const paramsWithSearch = { page: 2, emailOrUsername: 'student@example.com' };
+      mockHttpClient.get.mockResolvedValue({ data: { count: 0, num_pages: 0, results: [] } });
+
+      await getOnboardingStatuses(courseId, paramsWithSearch);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'https://test-lms.com/api/edx_proctoring/v1/user_onboarding/status/course_id/course-v1:edX+Test+2023?page=3&text_search=student%40example.com'
+      );
+    });
+
+    it('handles API error', async () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      mockHttpClient.get.mockRejectedValue(new Error('Network error'));
+
+      await expect(getOnboardingStatuses(courseId, params)).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getReviewDashboardUrl', () => {
+    it('builds the edx_proctoring instructor dashboard URL for the course', () => {
+      const courseId = 'course-v1:edX+Test+2023';
+      expect(getReviewDashboardUrl(courseId)).toBe(
+        'https://test-lms.com/api/edx_proctoring/v1/instructor/course-v1:edX+Test+2023'
+      );
     });
   });
 });

--- a/src/specialExams/data/api.ts
+++ b/src/specialExams/data/api.ts
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient, camelCaseObject, snakeCaseObject } from '@o
 import { snakeCase } from 'lodash';
 import { getApiBaseUrl } from '@src/data/api';
 import { DataList } from '@src/types';
-import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, ResumeAttemptParams, SpecialExam } from '@src/specialExams/types';
+import { AddAllowanceParams, Allowance, Attempt, AttemptsParams, DeleteAllowanceParams, OnboardingParams, OnboardingStatus, ProctoringSettings, ResetAttemptParams, ResumeAttemptParams, SpecialExam } from '@src/specialExams/types';
 
 const getQueryParams = (params: AttemptsParams) => {
   const queryParams = new URLSearchParams({
@@ -88,3 +88,40 @@ export const resumeAttempt = async (params: ResumeAttemptParams) => {
   );
   return camelCaseObject(data);
 };
+
+export const getProctoringSettings = async (courseId: string): Promise<ProctoringSettings> => {
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getApiBaseUrl()}/api/instructor/v2/courses/${courseId}/proctoring_settings`
+  );
+  return camelCaseObject(data);
+};
+
+/**
+ * Fetch student onboarding statuses for a course from the edx-proctoring v1 API.
+ *
+ * This endpoint paginates at a fixed server-side page size (edx-proctoring's
+ * ATTEMPTS_PER_PAGE, currently 25) and ignores any `page_size` query param, so we
+ * intentionally do not send one. The client-side ONBOARDING_PAGE_SIZE must stay in
+ * sync with that server constant for the table's page-count math to line up.
+ */
+export const getOnboardingStatuses = async (courseId: string, params: OnboardingParams): Promise<DataList<OnboardingStatus>> => {
+  const queryParams = new URLSearchParams({ page: (params.page + 1).toString() });
+
+  if (params.emailOrUsername) {
+    queryParams.append('text_search', params.emailOrUsername);
+  }
+
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getApiBaseUrl()}/api/edx_proctoring/v1/user_onboarding/status/course_id/${courseId}?${queryParams.toString()}`
+  );
+  return camelCaseObject(data);
+};
+
+/**
+ * Build the URL for the proctoring provider's review dashboard. The LMS endpoint
+ * redirects to the provider's hosted dashboard and is rendered inside an iframe,
+ * mirroring the legacy instructor dashboard's Review Dashboard section.
+ */
+export const getReviewDashboardUrl = (courseId: string): string => (
+  `${getApiBaseUrl()}/api/edx_proctoring/v1/instructor/${courseId}`
+);

--- a/src/specialExams/data/apiHook.test.tsx
+++ b/src/specialExams/data/apiHook.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
-import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams, useResetAttempt, useResumeAttempt } from '@src/specialExams/data/apiHook';
-import { AttemptsParams, AddAllowanceParams, DeleteAllowanceParams } from '@src/specialExams/types';
+import { getAttempts, getAllowances, addAllowance, deleteAllowance, getSpecialExams, resetAttempt, resumeAttempt, getProctoringSettings, getOnboardingStatuses } from '@src/specialExams/data/api';
+import { useAttempts, useAllowances, useAddAllowance, useDeleteAllowance, useSpecialExams, useResetAttempt, useResumeAttempt, useProctoringSettings, useOnboardingStatuses } from '@src/specialExams/data/apiHook';
+import { AttemptsParams, AddAllowanceParams, DeleteAllowanceParams, OnboardingParams } from '@src/specialExams/types';
 
 jest.mock('@src/specialExams/data/api');
 
@@ -13,6 +13,8 @@ const mockDeleteAllowance = deleteAllowance as jest.MockedFunction<typeof delete
 const mockGetSpecialExams = getSpecialExams as jest.MockedFunction<typeof getSpecialExams>;
 const mockResetAttempt = resetAttempt as jest.MockedFunction<typeof resetAttempt>;
 const mockResumeAttempt = resumeAttempt as jest.MockedFunction<typeof resumeAttempt>;
+const mockGetProctoringSettings = getProctoringSettings as jest.MockedFunction<typeof getProctoringSettings>;
+const mockGetOnboardingStatuses = getOnboardingStatuses as jest.MockedFunction<typeof getOnboardingStatuses>;
 
 const mockAttemptsData = {
   count: 2,
@@ -511,6 +513,93 @@ describe('specialExams api hooks', () => {
       });
 
       expect(mockResumeAttempt).toHaveBeenCalledWith(params);
+    });
+  });
+
+  describe('useProctoringSettings', () => {
+    const courseId = 'course-v1:edX+Test+2023';
+    const mockSettings = {
+      proctoringProvider: 'proctortrack',
+      proctoringEscalationEmail: null,
+      createZendeskTickets: false,
+      enableProctoredExams: true,
+      supportsOnboarding: true,
+      reviewDashboardAvailable: true,
+    };
+
+    it('fetches proctoring settings successfully', async () => {
+      mockGetProctoringSettings.mockResolvedValue(mockSettings);
+
+      const { result } = renderHook(() => useProctoringSettings(courseId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetProctoringSettings).toHaveBeenCalledWith(courseId);
+      expect(result.current.data).toBe(mockSettings);
+    });
+
+    it('does not fetch when courseId is empty', () => {
+      const { result } = renderHook(() => useProctoringSettings(''), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockGetProctoringSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useOnboardingStatuses', () => {
+    const courseId = 'course-v1:edX+Test+2023';
+    const params: OnboardingParams = { page: 0, emailOrUsername: '' };
+    const mockOnboardingData = {
+      count: 1,
+      numPages: 1,
+      results: [
+        { username: 'student1', enrollmentMode: 'verified', status: 'verified', modified: '2023-01-01T10:00:00Z' },
+      ],
+    };
+
+    it('fetches onboarding statuses successfully', async () => {
+      mockGetOnboardingStatuses.mockResolvedValue(mockOnboardingData);
+
+      const { result } = renderHook(() => useOnboardingStatuses(courseId, params), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetOnboardingStatuses).toHaveBeenCalledWith(courseId, params);
+      expect(result.current.data).toBe(mockOnboardingData);
+    });
+
+    it('does not fetch when disabled', () => {
+      const { result } = renderHook(() => useOnboardingStatuses(courseId, params, false), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockGetOnboardingStatuses).not.toHaveBeenCalled();
+    });
+
+    it('handles API error', async () => {
+      const mockError = new Error('Network error');
+      mockGetOnboardingStatuses.mockRejectedValue(mockError);
+
+      const { result } = renderHook(() => useOnboardingStatuses(courseId, params), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBe(mockError);
     });
   });
 });

--- a/src/specialExams/data/apiHook.ts
+++ b/src/specialExams/data/apiHook.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { addAllowance, deleteAllowance, getAllowances, getAttempts, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
+import { addAllowance, deleteAllowance, getAllowances, getAttempts, getOnboardingStatuses, getProctoringSettings, getSpecialExams, resetAttempt, resumeAttempt } from '@src/specialExams/data/api';
 import { specialExamsQueryKeys } from '@src/specialExams/data/queryKeys';
-import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams, ResetAttemptParams, ResumeAttemptParams } from '@src/specialExams/types';
+import { AddAllowanceParams, AttemptsParams, DeleteAllowanceParams, OnboardingParams, ResetAttemptParams, ResumeAttemptParams } from '@src/specialExams/types';
 
 export const useAttempts = (courseId: string, params: AttemptsParams, enabled = true) => (
   useQuery({
@@ -45,6 +45,22 @@ export const useSpecialExams = (courseId: string, examType: string) => (
     queryKey: specialExamsQueryKeys.specialExams(courseId, examType),
     queryFn: () => getSpecialExams(courseId, examType),
     enabled: !!courseId && !!examType,
+  })
+);
+
+export const useProctoringSettings = (courseId: string) => (
+  useQuery({
+    queryKey: specialExamsQueryKeys.proctoringSettings(courseId),
+    queryFn: () => getProctoringSettings(courseId),
+    enabled: !!courseId,
+  })
+);
+
+export const useOnboardingStatuses = (courseId: string, params: OnboardingParams, enabled = true) => (
+  useQuery({
+    queryKey: specialExamsQueryKeys.onboarding(courseId, params),
+    queryFn: () => getOnboardingStatuses(courseId, params),
+    enabled: !!courseId && enabled,
   })
 );
 

--- a/src/specialExams/data/queryKeys.ts
+++ b/src/specialExams/data/queryKeys.ts
@@ -1,5 +1,5 @@
 import { appId } from '@src/constants';
-import { AttemptsParams } from '../types';
+import { AttemptsParams, OnboardingParams } from '../types';
 
 export const specialExamsQueryKeys = {
   all: [appId, 'specialExams'] as const,
@@ -7,4 +7,6 @@ export const specialExamsQueryKeys = {
   attempts: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'attempts', params?.page || 1, params?.emailOrUsername || '', params?.ordering || ''] as const,
   allowances: (courseId: string, params?: AttemptsParams) => [...specialExamsQueryKeys.byCourse(courseId), 'allowances', params?.page || 1, params?.emailOrUsername || '', params?.ordering || ''] as const,
   specialExams: (courseId: string, examType: string) => [...specialExamsQueryKeys.byCourse(courseId), 'specialExams', examType] as const,
+  onboarding: (courseId: string, params?: OnboardingParams) => [...specialExamsQueryKeys.byCourse(courseId), 'onboarding', params?.page || 1, params?.emailOrUsername || ''] as const,
+  proctoringSettings: (courseId: string) => [...specialExamsQueryKeys.byCourse(courseId), 'proctoringSettings'] as const,
 };

--- a/src/specialExams/messages.ts
+++ b/src/specialExams/messages.ts
@@ -285,6 +285,41 @@ const messages = defineMessages({
     id: 'instruct.specialExams.successOnResume',
     defaultMessage: 'Successfully resumed attempt for {student}.',
     description: 'Success message shown after resuming an exam attempt'
+  },
+  onboarding: {
+    id: 'instruct.specialExams.onboarding',
+    defaultMessage: 'Onboarding',
+    description: 'Label for the student onboarding status tab'
+  },
+  reviewDashboard: {
+    id: 'instruct.specialExams.reviewDashboard',
+    defaultMessage: 'Review Dashboard',
+    description: 'Label for the proctoring review dashboard tab'
+  },
+  enrollmentMode: {
+    id: 'instruct.specialExams.enrollmentMode',
+    defaultMessage: 'Enrollment Mode',
+    description: 'Column header for enrollment mode in the onboarding status list'
+  },
+  onboardingStatus: {
+    id: 'instruct.specialExams.onboardingStatus',
+    defaultMessage: 'Onboarding Status',
+    description: 'Column header for onboarding status in the onboarding status list'
+  },
+  lastUpdated: {
+    id: 'instruct.specialExams.lastUpdated',
+    defaultMessage: 'Last Updated',
+    description: 'Column header for the last modified date in the onboarding status list'
+  },
+  noOnboardingStatuses: {
+    id: 'instruct.specialExams.noOnboardingStatuses',
+    defaultMessage: 'No onboarding statuses found',
+    description: 'Message displayed when there are no onboarding statuses to show'
+  },
+  reviewDashboardTitle: {
+    id: 'instruct.specialExams.reviewDashboardTitle',
+    defaultMessage: 'Proctoring Review Dashboard',
+    description: 'Accessible title for the embedded proctoring review dashboard iframe'
   }
 });
 

--- a/src/specialExams/types.ts
+++ b/src/specialExams/types.ts
@@ -84,3 +84,24 @@ export interface DeleteAllowanceParams {
   userIds: number[],
   allowanceType: string,
 }
+
+export interface OnboardingStatus {
+  username: string,
+  enrollmentMode: string | null,
+  status: string | null,
+  modified: string | null,
+}
+
+export interface OnboardingParams {
+  page: number,
+  emailOrUsername: string,
+}
+
+export interface ProctoringSettings {
+  proctoringProvider: string | null,
+  proctoringEscalationEmail: string | null,
+  createZendeskTickets: boolean,
+  enableProctoredExams: boolean,
+  supportsOnboarding: boolean,
+  reviewDashboardAvailable: boolean,
+}


### PR DESCRIPTION
## Description

Restores the two Special Exams sections that exist on the legacy (Django-rendered) instructor
dashboard but were missing from this MFE: **Student Onboarding Status** and **Review Dashboard**.
The Special Exams tab previously shipped only *Exam Attempts* and *Allowances*; this adds the
remaining two as additional tabs.

- **Onboarding** — a `DataTable` (username, enrollment mode, onboarding status, last updated) with
  username search and pagination, backed by the edx-proctoring v1 endpoint
  `GET /api/edx_proctoring/v1/user_onboarding/status/course_id/{courseId}`. This endpoint is called
  directly (the same way the existing "resume attempt" action already calls edx-proctoring v1)
  because the onboarding logic is provider-specific and lives in edx-proctoring rather than in a
  wrappable library function.
- **Review Dashboard** — an `<iframe>` pointed at `GET /api/edx_proctoring/v1/instructor/{courseId}`,
  which the LMS redirects into the proctoring provider's hosted review dashboard. This mirrors the
  legacy dashboard's behavior exactly (same iframe/redirect mechanism the Learning and Authoring
  MFEs use for embedded LMS content).

Both tabs are **provider-gated**: they only render when the course's proctoring backend supports
them. Gating uses two new capability flags (`supportsOnboarding`, `reviewDashboardAvailable`)
returned by the v2 `proctoring_settings` endpoint (see the dependent backend PR). This matches the
legacy dashboard, which showed these sections only for backends that support onboarding / expose a
review dashboard (e.g. Verificient's Proctortrack).

**Impacted user roles:** **Course Team / Instructors (staff)** — they regain the two sections in the
new dashboard. **Operators** — no config change required; behavior is driven entirely by the
course's proctoring provider.

**Screenshots:**
<img width="1510" height="837" alt="Screenshot 2026-07-10 at 3 15 15 PM" src="https://github.com/user-attachments/assets/56cb2b09-1978-4350-aba8-7a8633caad37" />

<img width="1510" height="837" alt="Screenshot 2026-07-10 at 3 15 43 PM" src="https://github.com/user-attachments/assets/fa65837f-91ba-405b-8165-6077de9e609d" />

## Supporting information

- Internal tracking: https://github.com/mitodl/hq/issues/11865
- Depends on the edx-platform PR that adds `supports_onboarding` / `review_dashboard_available` to
  the v2 `proctoring_settings` endpoint (linked below).
- openedx-platform PR: https://github.com/openedx/openedx-platform/pull/38874

## Testing instructions

1. Have a course with proctoring enabled whose backend **supports onboarding and a review
   dashboard** (e.g. Proctortrack). The course needs an onboarding (practice proctored) exam and
   some proctoring-eligible (e.g. `verified`) enrollments, ideally with onboarding attempts in a few
   statuses.
2. As course staff/admin, open the instructor dashboard MFE → **Special Exams**.
3. Confirm four tabs appear: **Exam Attempts, Allowances, Onboarding, Review Dashboard**.
4. **Onboarding:** confirm the table lists learners with username, enrollment mode, onboarding
   status, and last-updated; verify username search and pagination work.
5. **Review Dashboard:** confirm the iframe loads and redirects into the provider's dashboard.
6. Open a course whose backend does **not** support these (e.g. the `null` backend) and confirm the
   two tabs are **hidden** and only *Exam Attempts* / *Allowances* show.

## Other information

- **Depends on** the backend PR adding the two capability flags to the v2 `proctoring_settings`
  endpoint. Without it, `supportsOnboarding` / `reviewDashboardAvailable` are undefined and the two
  tabs stay hidden (graceful degradation).
- **Cross-origin note:** the Review Dashboard iframe loads an LMS URL that redirects to the provider.
  When the MFE and LMS share a parent domain (the standard Open edX cookie-domain setup), the session
  flows through as it does for the Learning MFE's courseware iframe. If the MFE is served from an
  unrelated origin, the provider's own `X-Frame-Options`/CSP `frame-ancestors` governs whether it can
  be embedded.
- This repo's `src/testUtils.tsx` exposes `renderWithIntl` / `renderWithQueryClient` (there is no
  `initializeMocks` helper here yet); the new tests use these, consistent with every existing suite.
- No deprecations, migrations, or new dependencies.

## Best Practices Checklist

- [x] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [x] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [x] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [x] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [x] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [x] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
