### PR TITLE
feat: certificate report behind config flag

### DIFF
--- a/src/dataDownloads/DataDownloadsPage.test.tsx
+++ b/src/dataDownloads/DataDownloadsPage.test.tsx
@@ -21,6 +21,9 @@ jest.mock('@openedx/frontend-base', () => ({
 jest.mock('@src/data/api', () => ({
   getApiBaseUrl: jest.fn(() => 'http://lms.example.com'),
 }));
+jest.mock('@src/data/apiHook', () => ({
+  useCourseInfo: () => ({ data: { certificatesEnabled: false } }),
+}));
 
 const mockUseGeneratedReports = useGeneratedReports as jest.MockedFunction<typeof useGeneratedReports>;
 const mockUseGenerateReportLink = useGenerateReportLink as jest.MockedFunction<typeof useGenerateReportLink>;

--- a/src/dataDownloads/DataDownloadsPage.test.tsx
+++ b/src/dataDownloads/DataDownloadsPage.test.tsx
@@ -9,7 +9,6 @@ import { renderWithQueryClient } from '@src/testUtils';
 import messages from './messages';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-jest.mock('./data/apiHook');
 jest.mock('@src/components/PageNotFound', () => ({
   __esModule: true,
   default: () => <div>Page Not Found</div>,
@@ -21,7 +20,9 @@ jest.mock('@openedx/frontend-base', () => ({
 jest.mock('@src/data/api', () => ({
   getApiBaseUrl: jest.fn(() => 'http://lms.example.com'),
 }));
+jest.mock('./data/apiHook');
 jest.mock('@src/data/apiHook', () => ({
+  ...jest.requireActual('@src/data/apiHook'),
   useCourseInfo: () => ({ data: { certificatesEnabled: false } }),
 }));
 

--- a/src/dataDownloads/DataDownloadsPage.tsx
+++ b/src/dataDownloads/DataDownloadsPage.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import { useGeneratedReports, useGenerateReportLink } from './data/apiHook';
 import { useCallback, useState, useRef, useEffect } from 'react';
 import { getApiBaseUrl } from '@src/data/api';
+import { useCourseInfo } from '@src/data/apiHook';
 import { getReportTypeDisplayName } from './utils';
 import PageNotFound from '@src/components/PageNotFound';
 import { useAlert } from '@src/providers/AlertProvider';
@@ -20,6 +21,7 @@ const DataDownloadsPage = () => {
   const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const initialReportCountRef = useRef<number | null>(null);
 
+  const { data: courseInfo } = useCourseInfo(courseId);
   const { data: reportsData, isLoading, error } = useGeneratedReports(courseId, { enablePolling: isPolling });
   const { mutate: generateReportLinkMutate, isPending: isGenerating } = useGenerateReportLink(courseId);
 
@@ -183,6 +185,7 @@ const DataDownloadsPage = () => {
         onGenerateProblemResponsesReport={handleGenerateProblemResponsesReport}
         isGenerating={isGenerating}
         problemResponsesError={problemResponsesError}
+        certificatesEnabled={courseInfo?.certificatesEnabled}
       />
       <PendingTasks />
     </>

--- a/src/dataDownloads/components/GenerateReports.test.tsx
+++ b/src/dataDownloads/components/GenerateReports.test.tsx
@@ -7,12 +7,17 @@ import messages from '@src/dataDownloads/messages';
 const mockOnGenerateReport = jest.fn();
 const mockOnGenerateProblemResponsesReport = jest.fn();
 
-const renderComponent = (isGenerating = false, problemResponsesError?: string) => renderWithIntl(
+const renderComponent = (
+  isGenerating = false,
+  problemResponsesError?: string,
+  certificatesEnabled = false,
+) => renderWithIntl(
   <GenerateReports
     onGenerateReport={mockOnGenerateReport}
     onGenerateProblemResponsesReport={mockOnGenerateProblemResponsesReport}
     isGenerating={isGenerating}
     problemResponsesError={problemResponsesError}
+    certificatesEnabled={certificatesEnabled}
   />
 );
 
@@ -21,13 +26,24 @@ describe('GenerateReports', () => {
     jest.clearAllMocks();
   });
 
-  it('should render the component with all tabs', () => {
+  it('should render the component with the core report tabs', () => {
     renderComponent();
 
     expect(screen.getByText(messages.generateReportsTitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: messages.enrollmentReportsTabTitle.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: messages.gradingReportsTabTitle.defaultMessage })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: messages.problemResponseReportsTabTitle.defaultMessage })).toBeInTheDocument();
+  });
+
+  it('should not render the Certificate Reports tab when certificates are disabled for the course', () => {
+    renderComponent();
+
+    expect(screen.queryByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage })).not.toBeInTheDocument();
+  });
+
+  it('should render the Certificate Reports tab when certificates are enabled for the course', () => {
+    renderComponent(false, undefined, true);
+
     expect(screen.getByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage })).toBeInTheDocument();
   });
 
@@ -207,7 +223,7 @@ describe('GenerateReports', () => {
   describe('Certificate Reports Tab', () => {
     it('should render certificate report section', async () => {
       const user = userEvent.setup();
-      renderComponent();
+      renderComponent(false, undefined, true);
 
       const tab = screen.getByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage });
       await user.click(tab);
@@ -217,7 +233,7 @@ describe('GenerateReports', () => {
 
     it('should call onGenerateReport with issued_certificates when button is clicked', async () => {
       const user = userEvent.setup();
-      renderComponent();
+      renderComponent(false, undefined, true);
 
       const tab = screen.getByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage });
       await user.click(tab);

--- a/src/dataDownloads/components/GenerateReports.test.tsx
+++ b/src/dataDownloads/components/GenerateReports.test.tsx
@@ -47,6 +47,19 @@ describe('GenerateReports', () => {
     expect(screen.getByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage })).toBeInTheDocument();
   });
 
+  it('should default to hiding the Certificate Reports tab when certificatesEnabled is not provided', () => {
+    // Render without the certificatesEnabled prop so the default value is exercised.
+    renderWithIntl(
+      <GenerateReports
+        onGenerateReport={mockOnGenerateReport}
+        onGenerateProblemResponsesReport={mockOnGenerateProblemResponsesReport}
+        isGenerating={false}
+      />
+    );
+
+    expect(screen.queryByRole('tab', { name: messages.certificateReportsTabTitle.defaultMessage })).not.toBeInTheDocument();
+  });
+
   describe('Enrollment Reports Tab', () => {
     it('should render all enrollment report sections', () => {
       renderComponent();

--- a/src/dataDownloads/components/GenerateReports.tsx
+++ b/src/dataDownloads/components/GenerateReports.tsx
@@ -9,6 +9,7 @@ interface GenerateReportsProps {
   onGenerateProblemResponsesReport: (problemLocation?: string) => void,
   isGenerating: boolean,
   problemResponsesError?: string,
+  certificatesEnabled?: boolean,
 }
 
 interface ReportSectionProps {
@@ -55,6 +56,7 @@ const GenerateReports = ({
   onGenerateProblemResponsesReport,
   isGenerating,
   problemResponsesError,
+  certificatesEnabled = false,
 }: GenerateReportsProps) => {
   const intl = useIntl();
   const [problemLocation, setProblemLocation] = useState('');
@@ -203,19 +205,21 @@ const GenerateReports = ({
             </div>
           </Tab>
 
-          <Tab eventKey="certificates" title={intl.formatMessage(messages.certificateReportsTabTitle)}>
-            <div className="d-flex flex-column px-3.5">
-              <ReportSection
-                titleMessage={messages.issuedCertificatesTitle}
-                descriptionMessage={messages.issuedCertificatesDescription}
-                buttonMessage={messages.generateCertificatesReport}
-                onGenerate={() => onGenerateReport('issued_certificates')}
-                isFirst
-                isLast
-                isGenerating={isGenerating}
-              />
-            </div>
-          </Tab>
+          {certificatesEnabled && (
+            <Tab eventKey="certificates" title={intl.formatMessage(messages.certificateReportsTabTitle)}>
+              <div className="d-flex flex-column px-3.5">
+                <ReportSection
+                  titleMessage={messages.issuedCertificatesTitle}
+                  descriptionMessage={messages.issuedCertificatesDescription}
+                  buttonMessage={messages.generateCertificatesReport}
+                  onGenerate={() => onGenerateReport('issued_certificates')}
+                  isFirst
+                  isLast
+                  isGenerating={isGenerating}
+                />
+              </div>
+            </Tab>
+          )}
         </Tabs>
       </Card>
     </>


### PR DESCRIPTION
## issue
Instructor dashboard > Data Download > **Certificate Report** tab is always showing regardless if the certificates are enabled in the backend.
We already have that information in the `CourseInfo`, this PR uses that to gate the "Certificate Report" tab on frontend.

## Description
This pull request updates the Data Downloads feature to conditionally display the Certificate Reports tab based on whether certificates are enabled for the course. It introduces a new prop to the `GenerateReports` component and updates tests to cover both states.

**Feature: Conditional Certificate Reports Tab**

* The `GenerateReports` component now accepts a new `certificatesEnabled` prop, which determines if the Certificate Reports tab should be shown. The tab and related functionality are only rendered when this prop is true. [[1]](diffhunk://#diff-5db6163a761e4a169c6ffb63e81f2a04c9bd725d726e328594d48a1b9d50db70R12) [[2]](diffhunk://#diff-5db6163a761e4a169c6ffb63e81f2a04c9bd725d726e328594d48a1b9d50db70R59) [[3]](diffhunk://#diff-5db6163a761e4a169c6ffb63e81f2a04c9bd725d726e328594d48a1b9d50db70R208) [[4]](diffhunk://#diff-5db6163a761e4a169c6ffb63e81f2a04c9bd725d726e328594d48a1b9d50db70R222)
* The `DataDownloadsPage` component fetches course info using the `useCourseInfo` hook and passes the `certificatesEnabled` value to `GenerateReports`. [[1]](diffhunk://#diff-c46099a585d813a2aa75e59313da0c8f6b770c7128714bb9837f95f8fc3e778dR9) [[2]](diffhunk://#diff-c46099a585d813a2aa75e59313da0c8f6b770c7128714bb9837f95f8fc3e778dR24) [[3]](diffhunk://#diff-c46099a585d813a2aa75e59313da0c8f6b770c7128714bb9837f95f8fc3e778dR188)
* Mocks for `useCourseInfo` were added to tests to support the new prop.

**Testing Improvements**

* Unit tests for `GenerateReports` were updated to verify that the Certificate Reports tab is only rendered when certificates are enabled, and not otherwise. [[1]](diffhunk://#diff-b1f6fb1e735b36e2c6a6dc3698a8c896fef2d1ba475369b37e5f4acb71080c46L10-R20) [[2]](diffhunk://#diff-b1f6fb1e735b36e2c6a6dc3698a8c896fef2d1ba475369b37e5f4acb71080c46L24-R46) [[3]](diffhunk://#diff-b1f6fb1e735b36e2c6a6dc3698a8c896fef2d1ba475369b37e5f4acb71080c46L210-R226) [[4]](diffhunk://#diff-b1f6fb1e735b36e2c6a6dc3698a8c896fef2d1ba475369b37e5f4acb71080c46L220-R236)
* The `renderComponent` helper in tests was updated to accept the new `certificatesEnabled` prop.

## Supporting information
https://github.com/mitodl/hq/issues/11855

## Testing instructions

1. Go to `instructor dashboard > Data Download` you will see "Certificate Report" tab
2. Checkout to this branch
3. Check the certificate generation config at `/admin/certificates/certificategenerationconfiguration/`
4. If its enabled you should see the tab
5. if its disabled the "Certificate Report" tab shouldn't be there.

## Best Practices Checklist

We're trying to move away from some deprecated patterns in this codebase. Please
check if your PR meets these recommendations before asking for a review:

- [ ] Any _new_ files are using TypeScript (`.ts`, `.tsx`).
- [ ] Deprecated `propTypes`, `defaultProps`, and `injectIntl` patterns are not used in any new or modified code.
- [ ] Tests should use the helpers in `src/testUtils.tsx` (specifically `initializeMocks`)
- [ ] Use React Query to load data from REST APIs. See any `apiHooks.ts` in this repo for examples.
- [ ] All new i18n messages in `messages.ts` files have a `description` for translators to use.
- [ ] Imports avoid using `../`. To import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of `from '../../../../testUtils'`
